### PR TITLE
CWBC auto send

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3339,11 +3339,11 @@ begin
        begin
        PutCallToCallWindow(LogSCP.PossibleCallList.List[itempos].Call);
        end;
-    if activeradioptr.CWByCAT_Sending then
+    {if activeradioptr.CWByCAT_Sending then  // ny4i Issue 131. COmmented out because with AutoSend, a CQ would be sent on the other radio when we hit the auto character count
        begin
        Sleep(1500);
        BackToInactiveRadioAfterQSO;
-       end;
+       end;}
   end;
 
 procedure CallWindowKeyUpProc;

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -1113,7 +1113,7 @@ begin
 
  //if activeradioptr^.cwbycat then backtoinactiveradioafterqso; // ny4i Issue130 Moving this to after LogContact
  {TODO } // Uncomment above and comment below to check for CWBC_AutoSend ny4i 9-mar-2016
- if activeradioptr^.cwbycat then backtoinactiveradioafterqso;
+ //if activeradioptr^.cwbycat then backtoinactiveradioafterqso;
 
 end;
 

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -1673,7 +1673,7 @@ var
 begin
   begin
    if InSplit then begin
-     PutRadioOutOfSplit(ActiveRadio);
+     PutRadioOutOfSplit(ActiveRadio);    // n4af 4.47.5
       PutRadioOutOfSplit(InActiveRadio);
       InSplit := False;
      exit;
@@ -2786,25 +2786,20 @@ begin
     menu_ctrl_ct1bohscreen:
 //      tDialogBox(40, @ct1bohDlgProc);
       CreateModalDialog(330 + 10, 68 + 10, tr4whandle, @ct1bohDlgProc, 0);
-
+  
     menu_ctrl_PlaceHolder: AddBandMapPlaceHolder;
 
     menu_mainwindow_setfocus: FrmSetFocus;
 
     menu_insertmode: InvertBooleanCommand(@InsertMode);
 
-    menu_ctrl_SplitOff:
-    begin
-    if not ActiveRadioPtr.CurrentStatus.Split then
-    PutRadioIntoSplit(ActiveRadio)
-    else
-    PutRadioOutOfSplit(ActiveRadio)  // n4af 4.46.13
-    end;
+    menu_ctrl_SplitOff:               // n4af 4.47.5
+     tr4w_alt_n_transmit_frequency ;
     
     menu_escape:
       Escape_proc;
+
     menu_csv:
-    
     ExportToCSV;
 
     menu_inactiveradio_cwspeedup:
@@ -3340,10 +3335,16 @@ begin
   itempos := SendMessage(p, LB_GETCURSEL, 0, 0);
 
   if Key = PossibleCallAcceptKey then
-    if SendMessage(p, LB_GETCOUNT, 0, 0) > 0 then PutCallToCallWindow(LogSCP.PossibleCallList.List[itempos].Call);
-end;
-//-------------------
-
+    if SendMessage(p, LB_GETCOUNT, 0, 0) > 0 then
+       begin
+       PutCallToCallWindow(LogSCP.PossibleCallList.List[itempos].Call);
+       end;
+    if activeradioptr.CWByCAT_Sending then
+       begin
+       Sleep(1500);
+       BackToInactiveRadioAfterQSO;
+       end;
+  end;
 
 procedure CallWindowKeyUpProc;
 begin

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -182,7 +182,7 @@ const
   TR4W_CURRENTVERSION                   = 'TR4W v.' + TR4W_CURRENTVERSION_NUMBER;//{$IF LANG <> 'ENG'} + ' [' + LANG + ']'{$IFEND}{$IF MMTTYMODE} + '_mmtty'{$IFEND};
   TR4W_CURRENTVERSIONDATE               = 'Mar  4, 2016' ;
 
-  TR4WSERVER_CURRENTVERSION             = '1.41';
+  TR4WSERVER_CURRENTVERSION             = '1.41';
 
   LOGVERSION1                           = 'v';
   LOGVERSION2                           = '1';

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -177,8 +177,7 @@ const
 
   OZCR2008                              = False;
 
-
-  TR4W_CURRENTVERSION_NUMBER            = '4.47.4' ;     // GM0GAV
+  TR4W_CURRENTVERSION_NUMBER            = '4.47.5' ;     // N4AF
 
   TR4W_CURRENTVERSION                   = 'TR4W v.' + TR4W_CURRENTVERSION_NUMBER;//{$IF LANG <> 'ENG'} + ' [' + LANG + ']'{$IFEND}{$IF MMTTYMODE} + '_mmtty'{$IFEND};
   TR4W_CURRENTVERSIONDATE               = 'Mar  4, 2016' ;

--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -3176,7 +3176,7 @@ end;
 
 procedure BackToInactiveRadioAfterQSO;
 begin
-  if (ActiveRadioPtr^.tTwoRadioMode = TR3){ or (ActiveRadioPtr^.tTwoRadioMode = TR2)} then
+  if (ActiveRadioPtr^.tTwoRadioMode = TR3) or (activeradioptr.cwbycat) then
   begin
     tClearDupeInfoCall;
     ActiveRadioPtr^.tTwoRadioMode := TR0;

--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -3174,9 +3174,12 @@ begin
     if port in [Parallel1..Parallel3] then Result := ParallelInterface;
 end;
 
+{ NY4I To make this work with CWBYCAT, we have to call this next procedure when
+       CWBYCAT_SENDING is turned off. The check of tTwoRadioMode - TR3 will control it
+}
 procedure BackToInactiveRadioAfterQSO;
 begin
-  if (ActiveRadioPtr^.tTwoRadioMode = TR3) or (activeradioptr.cwbycat) then
+  if (ActiveRadioPtr^.tTwoRadioMode = TR3) {or (activeradioptr.cwbycat)} then   // ny4i Issue 131
   begin
     tClearDupeInfoCall;
     ActiveRadioPtr^.tTwoRadioMode := TR0;

--- a/tr4w/src/trdos/LogCfg.pas
+++ b/tr4w/src/trdos/LogCfg.pas
@@ -250,6 +250,9 @@ procedure SetUpGlobalsAndInitialize;
 
 begin
 
+{$IF NEWER_DEBUG}
+   ShowMessage('Debug mode is enabled - Reset NEWER_DEBUG before production build');
+{$IFEND}
   udp := TIdUDPClient.Create(nil); // ny4i Issue #99
   if QTCsEnabled then New(QTCDataArray); //LoadQTCDataFile;
 

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -2014,6 +2014,7 @@ begin
           begin
           DebugMsg('rig.CWByCAT_Sending set to FALSE - ' + rig.RadioName + ' (' + InterfacedRadioTypeSA[rig.RadioModel] + ')');
           rig.CWByCAT_Sending := false;
+          BackToInactiveRadioAfterQSO; // This just checks to see if it should ny4i Issue 131
           if rig.CheckAutoCallTerminate then
              begin
              DEBUGMsg('rig.CheckAutoCallTerminate is true - Enter ReturnInCQMode');
@@ -2536,6 +2537,7 @@ begin
      if IsCWByCATActive then
         begin
         ActiveRadioPtr.CWByCAT_Sending := false; // If we were sending but the PTT goes off, now reset this.
+        BackToInactiveRadioAfterQSO; // ny4i Just checks to see if it should do this.
         DebugMsg('[Active] CWByCAT_Sending set to FALSE - ' + ActiveRadioPtr.RadioName + ' (' + InterfacedRadioTypeSA[ActiveRadioPtr.RadioModel] + ')');
         tStartAutoCQ; // this is totally bizzare but the way autocqresume works is you call this and it checks.
         end;

--- a/tr4w/tr4w.dof
+++ b/tr4w/tr4w.dof
@@ -130,13 +130,17 @@ OriginalFilename=
 ProductName=
 ProductVersion=1.0.0.0
 Comments=
+[Excluded Packages]
+C:\projects\Indy10_5335\D7\dclIndyCore70.bpl=Indy 10 Core Design Time
+C:\projects\Indy10_5335\D7\dclIndyProtocols70.bpl=Indy 10 Protocols Design Time
 [HistoryLists\hlUnitAliases]
 Count=1
 Item0=WinTypes=Windows;WinProcs=Windows;DbiTypes=BDE;DbiProcs=BDE;DbiErrs=BDE;
 [HistoryLists\hlSearchPath]
-Count=2
+Count=3
 Item0=src\lang;src\trdos;src\utils;src;src\include\D7
-Item1=$(DELPHI)\Lib\Debug;include;src\lang;src\trdos;src\utils;src;include\D7
+Item1=src\lang;src\trdos;src\utils;src;src\include\D7;src\include\log4d
+Item2=$(DELPHI)\Lib\Debug;include;src\lang;src\trdos;src\utils;src;include\D7
 [HistoryLists\hlOutputDirectorry]
 Count=1
 Item0=target

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -726,7 +726,7 @@ begin
             if Msg.wParam = VK_SPACE {32} then if Msg.HWND = wh[mweCall] then
               begin
                 SpaceBarProc2;
-                if ActiveRadioPtr^.CWByCAT then BackToInactiveRadioAfterQSO;
+                //if ActiveRadioPtr^.CWByCAT then BackToInactiveRadioAfterQSO;  // ny4i commented out to debug Issue 131
                 goto NoTransMess;
               end;
 


### PR DESCRIPTION
# This should NOT be merged into master until sufficiently tested
This adds quite a few changes to refine the way CWBC works.

-  I addressed sending to the K3 and Kenwood without choppy CW on the Kenwood. You can now send CW strings longer than 24 bytes and the program will chunk the message into separate sends (with 24 characters in each send).
- CW Speed increased now work on the K3 (and it may work on the 590).
- AUTOSend and CWBC now works.
- AUTOTERMINATE now works with CWBC although I do not like the delay. Note I still recommend that stations running in TWO Radio Mode and using AUTOTERMINATE may want to to stick to the WinKeyer or other methods.


**This has to be tested extensively.** I ran tests with Two radio mode and Alt-D and CQ on Other radio and that all seems to work. But, please consider this beta until sufficient tested.