### PR TITLE
Fixed issue where Alt-D S&P did not resume CW on Active radio

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -1108,18 +1108,35 @@ begin
 //  if TwoRadioState = StationCalled then CheckTwoRadioState(ReturnPressed)
 //  else
   if MessageEnable and (not ExchangeHasBeenSent) and (not BeSilent) and MessageEnable then
-  begin
-    if ActiveMode = Digital then SendMessageToMixW('<TX>');
-    if ActiveMode in [CW, Digital] then if not SendCrypticMessage(SearchAndPounceExchange) then Exit;
-    if ActiveMode = Digital then SendMessageToMixW('<RXANDCLEAR>');
-    if ActiveMode in [Phone, FM] then SendCrypticMessage(SearchAndPouncePhoneExchange);
+    begin
+    if ActiveMode = Digital then         // ny4i Issue153 Just reformatted these few 'IFs' for readability
+       begin
+       SendMessageToMixW('<TX>');
+       end;
+
+    if ActiveMode in [CW, Digital] then
+       if not SendCrypticMessage(SearchAndPounceExchange) then
+          begin
+          Exit;
+          end;
+
+    if ActiveMode = Digital then
+       begin
+       SendMessageToMixW('<RXANDCLEAR>');
+       end;
+
+    if ActiveMode in [Phone, FM] then
+       begin
+       SendCrypticMessage(SearchAndPouncePhoneExchange);
+       end;
+
     ExchangeHasBeenSent := True;
 
  //if activeradioptr^.cwbycat then backtoinactiveradioafterqso; // ny4i Issue130 Moving this to after LogContact
  {TODO } // Uncomment above and comment below to check for CWBC_AutoSend ny4i 9-mar-2016
- if activeradioptr^.cwbycat then backtoinactiveradioafterqso;
+ //if activeradioptr^.cwbycat then backtoinactiveradioafterqso; // ny4i Issue153 commented out
 
-end;
+    end;
 
   if TryLogContact then
   begin
@@ -1135,10 +1152,11 @@ end;
     end;
   end;
 
-  if IsCWByCATActive then
+ { if IsCWByCATActive then
      begin
- //    BackToInactiveRadioAfterQSO;
+     BackToInactiveRadioAfterQSO;  // ny4i Issue153 Commented all
      end;
+     }
   DebugMsg('>>>>Exiting   ReturnInSAPOpMode');
 end;
 

--- a/tr4w/src/trdos/LOGSUBS1.PAS
+++ b/tr4w/src/trdos/LOGSUBS1.PAS
@@ -520,7 +520,7 @@ var
   TimeOut                               : integer;
 
 begin
-
+  DebugMsg('>>>>Entering SWAPRADIOS');
   if SingleRadioMode then
   begin
     QuickDisplay(TC_ALTRCOMMANDDISABLED);
@@ -636,6 +636,7 @@ begin
   ShowInformation; // n4af 4.40.2
   ActiveRadioPtr.active := true;
   InactiveRadioPtr.active := false;
+  DebugMsg('<<<<Exiting  SWAPRADIOS');
 end;
 
 procedure ExchangeRadios; {KK1L: 6.71}

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -2013,6 +2013,7 @@ begin
        if not rig.FilteredStatus.TXOn then
           begin
           DebugMsg('rig.CWByCAT_Sending set to FALSE - ' + rig.RadioName + ' (' + InterfacedRadioTypeSA[rig.RadioModel] + ')');
+          BackToInactiveRadioAfterQSO; // ny4i Ussue 153 We have to try here as WK and Serial do it in their threads when not busy
           rig.CWByCAT_Sending := false;
           if rig.CheckAutoCallTerminate then
              begin
@@ -2536,6 +2537,7 @@ begin
      if IsCWByCATActive then
         begin
         ActiveRadioPtr.CWByCAT_Sending := false; // If we were sending but the PTT goes off, now reset this.
+        BackToInactiveRadioAfterQSO; // ny4i Issue 153 We have to try here as WK and Serial do it in their threads when not busy
         DebugMsg('[Active] CWByCAT_Sending set to FALSE - ' + ActiveRadioPtr.RadioName + ' (' + InterfacedRadioTypeSA[ActiveRadioPtr.RadioModel] + ')');
         tStartAutoCQ; // this is totally bizzare but the way autocqresume works is you call this and it checks.
         end;


### PR DESCRIPTION
Release Note: Previously, when using CWByCAT, if Alt-D was used to work the a station, the CQ was not resumed on the Active radio. This has been fixed and closes #153.