### PR TITLE
Fixes #141 and #105

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -131,6 +131,7 @@ uses
   ;
 
   var
+  InSplit                               : boolean = False;
   Switch                                : boolean = False;
   FirstQSO                              : Cardinal;
   T1                                    : Cardinal;
@@ -1660,6 +1661,12 @@ var
   RadioToSet                            : RadioPtr {RadioType};
 begin
   begin
+  if InSplit then begin
+  PutRadioOutOfSplit(ActiveRadio);
+  PutRadioOutOfSplit(InActiveRadio);
+  InSplit := False;
+  exit;
+  end;
   Freq := 0;
     Freq := QuickEditFreq(TC_TRANSMITFREQUENCYKILOHERTZ, 10);
 
@@ -1672,7 +1679,7 @@ begin
     end;
 
     if (Freq = 0) then PutRadioOutOfSplit(ActiveRadio);
-    
+    if (Freq = -0) then PutRadioOutOfSplit(InactiveRadio);
     if (Freq > 1000) and (Freq < 1000000) then
       case RadioToSet.BandMemory {BandMemory[RadioToSet]} of
         Band80: Freq := Freq + 3000000;
@@ -1690,6 +1697,7 @@ begin
 //      PutRadioIntoSplit(RadioToSet); {KK1L: 6.73}
       RadioToSet.PutRadioIntoSplit;
       SplitFreq := Freq;
+      InSplit := True;
     end;
     BandMapCursorFrequency := Freq; {KK1L: 6.68 Band map tracks transmit freq}
     DisplayBandMap;
@@ -2778,17 +2786,8 @@ begin
     menu_insertmode: InvertBooleanCommand(@InsertMode);
 
     menu_ctrl_SplitOff:
-    begin
-   { QuickDisplay('Enter frequency in khz: ');
-    if not ActiveRadioPtr.CurrentStatus.Split then
-    PutRadioIntoSplit(ActiveRadio)
-    else
-    PutRadioOutOfSplit(ActiveRadio)  // n4af 4.46.13
-   }
-
     tr4w_alt_n_transmit_frequency ;
-    end;
-    
+
     menu_escape:
       Escape_proc;
     menu_csv:

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -1972,7 +1972,7 @@ const
   menu_alt_multbell                     = 10307;
   menu_alt_killcw                       = 10308;
   menu_alt_searchlog                    = 10309;
-//  menu_alt_transfreq                    = 10310;
+  menu_alt_transfreq                    = 10310;     //  4.47.3 restore menuid
   menu_alt_reminder                     = 10311;
   menu_alt_autocq                       = 10312;
   menu_alt_tooglerigs                   = 10313;
@@ -2053,7 +2053,7 @@ const
   menu_inactiveradio_cwspeedup          = 10513;
   menu_inactiveradio_cwspeeddown        = 10514;
   //  menu_dupecheck_or_sp                  = 10507;
-  menu_alt_transfreq                    = 10311;
+ // menu_alt_transfreq                    = 10311;   // 4.47.3 remove
   menu_home_page                        = 10606;
 //  menu_send_bug                         = 10605;
   menu_wiki_rus                         = 10604;

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -177,7 +177,7 @@ const
 
   OZCR2008                              = False;
 
-  TR4W_CURRENTVERSION_NUMBER            = '4.47.0' ;     // NY4I
+  TR4W_CURRENTVERSION_NUMBER            = '4.47.1' ;     // NY4I
 
   TR4W_CURRENTVERSION                   = 'TR4W v.' + TR4W_CURRENTVERSION_NUMBER;//{$IF LANG <> 'ENG'} + ' [' + LANG + ']'{$IFEND}{$IF MMTTYMODE} + '_mmtty'{$IFEND};
   TR4W_CURRENTVERSIONDATE               = 'Mar  4, 2016' ;

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -32,7 +32,7 @@ uses
 
 const
   tDebugMode                            = False;
-  NEWER_DEBUG                           = true; // ny4i added this as tDebugMode changes too much.
+  NEWER_DEBUG                           = False; // ny4i added this as tDebugMode changes too much.
   MMTTYMODE                             = False;
 
 type
@@ -177,7 +177,7 @@ const
 
   OZCR2008                              = False;
 
-  TR4W_CURRENTVERSION_NUMBER            = '4.47.1' ;     // NY4I
+  TR4W_CURRENTVERSION_NUMBER            = '4.47.3' ;     // NY4I
 
   TR4W_CURRENTVERSION                   = 'TR4W v.' + TR4W_CURRENTVERSION_NUMBER;//{$IF LANG <> 'ENG'} + ' [' + LANG + ']'{$IFEND}{$IF MMTTYMODE} + '_mmtty'{$IFEND};
   TR4W_CURRENTVERSIONDATE               = 'Mar  4, 2016' ;

--- a/tr4w/src/lang/tr4w_consts_mng.pas
+++ b/tr4w/src/lang/tr4w_consts_mng.pas
@@ -205,9 +205,6 @@ const
   TC_SAVINGTO                           = '%s-ийг %s руу хуулж байна';
   TC_FILESAVEDTOFLOPPYSUCCESSFULLY      = 'Файлыг флоппи руу амжилттай бичлээ';
   TC_FILESAVEDTOSUCCESSFULLY            = '%s руу файлыг амжилттай бичлээ';
-  TC_IMPROPERTRANSMITTERCOUNT           = 'FD transmitters must be between 1 and 99.';
-  TC_IMPROPERARRLFIELDDAYCLASS          = 'Field Day class must be A, B, C, D, E or F.';
-  TC_ARRLFIELDDAYIMPROPERDXEXCHANGE     = 'DX Station exchange must be "DX".';
   {LOGSEND}
   TC_WAITINGFORYOUENTERSTRENGTHOFRST    = 'RST-ийн сигналын (S) хэмжээг оруулна уу (Нэг оронтой шvv)!!';
   {COUNTRY9}
@@ -567,7 +564,7 @@ const
   RC_SAVEINFOLDER  			 			= 'Хавтас нээж хадгалах уу  (огноо,тэмцээн, дуудлага)';
   RC_CONFFILE                           = 'Тохируулгын файл';
   RC_EDITQSO                            = 'Холбоогоо засварлах';
-  RC_DELETED                            = '&Устгасан';
+  RC_DELETED                            = '&Устгах';
   RC_DUPE                               = 'Давтагдсан ХОЛБОО!!!';
   RC_LOGSEARCH                          = 'Дуудлага хайх';
   RC_SEARCH                             = '&Хайх';
@@ -603,8 +600,8 @@ const
   RC_FIRSTGRID                          = 'Эхний гридлокатор';
   RC_EURVHFDIST                         = 'Хоёр VHF станцын зай:';
   RC_GRIDOFAGLL                         = 'Координатыг Гридлокатор болгох';
-  RC_LONGMIE                            = 'Уртраг (- тэмдэгтэй бол зvvн)';
-  RC_LATMIS                             = 'Оргорог (- тэмдэгтэй бол омнод)';
+  RC_LONGMIE                            = 'Уртраг (- тэмдэгтэй бол ЗYYH)';
+  RC_LATMIS                             = 'Оргорог (- тэмдэгтэй бол OMHOД)';
   RC_CALCOFCORI                         = 'Багтаамж, индукцийг тооцоолох';
   RC_INDUCANCE                          = 'Индукц, uH';
   RC_CAPACITANCE                        = 'Багтаамж, pf';
@@ -696,5 +693,10 @@ const
   RC_ALTP                               = 'Функцийн товчнуудыг програмчлах';
   RC_ALTX                               = 'Програмаас гарах';
   TC_IRELAND                            = 'Ирланд';
-TC_SPLIT_WARN                       = 'Warning: You are in SPLIT MODE !!!';
- RC_SPLITOFF                       = 'Toggle Split ON/OFF';
+  TC_SPLIT_WARN                         = 'Анхаар!: Та SPLIT MODE дээр байна ш??!';
+{FD Additions NY4I}
+ 
+  TC_IMPROPERTRANSMITTERCOUNT           = 'FD нэвтрvvлэгчvvд 1-ээс 99-ийн хооронд байна';
+  TC_IMPROPERARRLFIELDDAYCLASS          = 'Field Day-ын ангилал A, B, C, D, E, F байна';
+  TC_ARRLFIELDDAYIMPROPERDXEXCHANGE     = 'DX станц "DX" гэж нэвтрvvлнэ';
+  RC_SPLITOFF                           = 'SPLIT-ийг залгах ба салгах ON/OFF';

--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -3176,7 +3176,7 @@ end;
 
 procedure BackToInactiveRadioAfterQSO;
 begin
-  if (ActiveRadioPtr^.tTwoRadioMode = TR3){ or (ActiveRadioPtr^.tTwoRadioMode = TR2)} then
+  if (ActiveRadioPtr^.tTwoRadioMode = TR3) or (ActiveRadioPtr^.tTwoRadioMode = TR2) then
   begin
     tClearDupeInfoCall;
     ActiveRadioPtr^.tTwoRadioMode := TR0;

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -1715,8 +1715,8 @@ begin
                         begin
 
                         repeat
-                             Msg := msg + ' '; // ny4i put back to test
-                          // Msg := ' ' + msg;  // n4af change buffer order on spaces
+                          //   Msg := msg + ' '; // ny4i put back to test
+                           Msg := ' ' + msg;  // n4af change buffer order on spaces
                         until length(Msg) = 24;
                         localMsg := Format('KY %s;', [Msg]);
                         end;

--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -76,6 +76,7 @@ procedure TuneRadioToSpot(Spot: TSpotRecord; Radio: RadioType);
 procedure DeleteSpotFromBandmap;
 procedure ShowSpotInfo;
 procedure ClearSpotInfo;
+procedure KillFocus;                                         // Gav 4.47.4 #141
 procedure SetTextInBMSB(Index: integer; Text: PChar);
 function GetBMSelItemData: integer;
 function NEWBMLBPROC(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): integer; stdcall;
@@ -414,6 +415,7 @@ begin
           204:
             begin
               SpotsList.Clear;
+              KillFocus;                                         // Gav 4.47.4 #141
             end;
           205: If TwoRadioMode then InvertBooleanCommand(@QSYInactiveRadio);   // Gav     4.37.12
 
@@ -428,9 +430,7 @@ begin
             end;
           LBN_KILLFOCUS:
             begin
-              BandMapPreventRefresh := False;         // Gav     4.37.12
-              SpotsList.SendAndClearBuffer;
-              DisplayBandMap;
+              KillFocus;                                         // Gav 4.47.4 #141
             end;
           LBN_SELCHANGE:
             begin
@@ -450,13 +450,8 @@ begin
               begin
                 TuneRadioToSpot(SpotsList.Get(TempInt), ActiveRadio);
               end;
-              BandMapPreventRefresh := False;          //Gav 4.45.6
-              SpotsList.SendAndClearBuffer;             //Gav 4.45.6
-              DisplayBandMap;                       //Gav 4.45.6
-              Windows.SetFocus(wh[mweCall]);    // n4af 4.38.2
+              KillFocus;                                  // Gav 4.47.4 #141
             end;
-          //            TuneOnSpotFromBandmap;
-
         end;
       end;
     WM_CLOSE: 1: CloseTR4WWindow(tw_BANDMAPWINDOW_INDEX);
@@ -641,7 +636,6 @@ begin
   i := SendMessage(BandMapListBox, LB_GETCURSEL, 0, 0);
   if i = LB_ERR then Exit;
   SpotsList.Delete(SendMessage(BandMapListBox, LB_GETITEMDATA, i, 0));
-  DisplayBandMap;                       //Gav 4.44.6
   if tLB_SETCURSEL(BandMapListBox, i) = LB_ERR then tLB_SETCURSEL(BandMapListBox, i - 1);
   ShowSpotInfo;
 end;
@@ -687,6 +681,15 @@ var
   i                                     : integer;
 begin
   for i := 0 to 4 do SetTextInBMSB(i, nil);
+end;
+
+
+procedure KillFocus;                                         // Gav 4.47.4 #141
+begin
+  BandMapPreventRefresh := False;
+  SpotsList.SendAndClearBuffer;
+  DisplayBandMap;
+  Windows.SetFocus(wh[mweCall]);
 end;
 
 

--- a/tr4w/src/uMenu.pas
+++ b/tr4w/src/uMenu.pas
@@ -96,7 +96,7 @@ const
   RC_VIEWPAKSPOTS_HK                    = #9'Ctrl+U';
   RC_EXECONFIGFILE_HK                   = #9'Ctrl+V' ;
   RC_REFRESHBM_HK                       = #9'Ctrl+Y';
-  RC_SPLITOFF_HK                        = #9'Ctrl+-';
+  RC_SPLITOFF_HK                        = #9'-';
   RC_CURSORINBM_HK                      = #9'Ctrl+End';
   RC_CURSORTELNET_HK                    = #9'Ctrl+Home';
   RC_QSOWITHNOCW_HK                     = #9'Ctrl+Enter';
@@ -280,7 +280,7 @@ const
 
 
 
- //}
+ //
 
     (mrText: 'Ctrl-'; mrId: MAXWORD),
  //{
@@ -304,7 +304,7 @@ const
     (mrText: RC_QSOWITHNOCW + RC_QSOWITHNOCW_HK; mrId: menu_ctrl_logqsowithoutcw),
     (mrText: RC_CURSORTELNET + RC_CURSORTELNET_HK; mrId: menu_ctrl_cursorintelnet),
     (mrText: RC_ADDBANDMAPPH + RC_ADDBANDMAPPH_HK; mrId: menu_ctrl_PlaceHolder),
-    (mrText: RC_SPLITOFF + RC_SPLITOFF_HK; mrId: menu_ctrl_SplitOff),      // n4af 4.46.8
+ //   (mrText: RC_SPLITOFF + RC_SPLITOFF_HK; mrId: menu_ctrl_SplitOff),      // n4af 4.46.8
     (mrText: RC_CT1BOHIS + RC_CT1BOHIS_HK; mrId: menu_ctrl_ct1bohscreen),
     (mrText: RC_ADDINFO; mrId: MAXWORD - 1),
   //{
@@ -318,6 +318,7 @@ const
 
     (mrText: RC_COMMANDS; mrId: MAXWORD),
  //{
+    (mrText: RC_SPLITOFF + RC_SPLITOFF_HK; mrId: menu_Ctrl_Splitoff),      // n4af 4.46.8
     (mrText: RC_FOCUSINMW + RC_FOCUSINMW_HK; mrId: menu_mainwindow_setfocus),
     (mrText: RC_TOGGLEINSERT + RC_TOGGLEINSERT_HK; mrId: menu_insertmode),
     (mrText: RC_ESCAPE + RC_ESCAPE_HK; mrId: menu_escape),

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -2154,16 +2154,15 @@ begin
       ShowFMessages(0);
     end;
 
-    if ((rig.FilteredStatus.Freq <> BandMapCursorFrequency) or
-      (BandMapMode <> ActiveMode)) and (rig.FilteredStatus.Freq <> 0) then
-    begin
-      SpotsList.DisplayCallsignOnThisFreq(rig.FilteredStatus.Freq);             
-      BandMapCursorFrequency := rig.FilteredStatus.Freq;
-      BandMapBand := ActiveBand;
-      BandMapMode := ActiveMode;
-      DisplayBandMap;
-    end;
-  end
+    if ((dif > 0)  and ((rig.FilteredStatus.Freq <> BandMapCursorFrequency) or (BandMapMode <> ActiveMode)) and (rig.FilteredStatus.Freq <> 0)) then              // Gav 4.47.4 #015
+          begin
+             SpotsList.DisplayCallsignOnThisFreq(rig.FilteredStatus.Freq);
+             BandMapCursorFrequency := rig.FilteredStatus.Freq;
+             BandMapBand := ActiveBand;
+             BandMapMode := ActiveMode;
+             DisplayBandMap;
+          end;
+    end
   else
   begin   // Inactive Radio Processing
 
@@ -2188,8 +2187,7 @@ begin
 
 //GAV added this section. Changes BandmapBand & Bandmap Mode to follow inactive radio when inactive radio is tuned
 
-    if ((rig.FilteredStatus.Freq <> BandMapCursorFrequency) or
-      (BandMapMode <> ActiveMode)) and (rig.FilteredStatus.Freq <> 0) then
+    if ((dif > 0)  and ((rig.FilteredStatus.Freq <> BandMapCursorFrequency) or (BandMapMode <> ActiveMode)) and (rig.FilteredStatus.Freq <> 0)) then       // Gav 4.47.4 #015
     begin
       BandmapBand := rig.FilteredStatus.Band;
       BandMapMode := rig.FilteredStatus.Mode;

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -2077,7 +2077,7 @@ var
 begin
   StatusChanged := False;
 //  CompareString(LOCALE_SYSTEM_DEFAULT, 0, @rig.CurrentStatus, SizeOf(RadioStatusRecord), @rig.PreviousStatus, SizeOf(RadioStatusRecord)) <> 2;
-  for TempInteger := 0 to SizeOf(RadioStatusRecord) - 1 do
+  for TempInteger := 0 to SizeOf(RadioStatusRecord) - 2 do                                              // Gav issue #105  changed -1 to -2 to mask off TXOn 
   begin
     if PChar(@rig.CurrentStatus)[TempInteger] <> PChar(@rig.PreviousStatus)[TempInteger] then
     begin

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -2077,7 +2077,7 @@ var
 begin
   StatusChanged := False;
 //  CompareString(LOCALE_SYSTEM_DEFAULT, 0, @rig.CurrentStatus, SizeOf(RadioStatusRecord), @rig.PreviousStatus, SizeOf(RadioStatusRecord)) <> 2;
-  for TempInteger := 0 to SizeOf(RadioStatusRecord) - 2 do                                              // Gav issue #105  changed -1 to -2 to mask off TXOn 
+  for TempInteger := 0 to SizeOf(RadioStatusRecord) - 1 do
   begin
     if PChar(@rig.CurrentStatus)[TempInteger] <> PChar(@rig.PreviousStatus)[TempInteger] then
     begin


### PR DESCRIPTION
#141 Added Kllfocus procedure to cleanly move focus from Bandmap,
resolves issue of rubbish left in bandmap after clear all spots.

#105 Resolved issue of bandmap flipping band on every ptt event. Now
only changes the bandmap band when the frequency changes.