### PR TITLE
Fixed in contest scoring for Winter Field Day rules

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -3050,7 +3050,7 @@ QSOPartiesCount = 13;
  ({Name: 'CQIR';                    }   Email: nil;                      DF: 'ireland';           WA7BNM:  434;                         QRZRUID:   0 ; Pxm: NoPrefixMults; ZnM: NoZoneMults;  DM: DomesticFile; P: 0; AE: QSONumberAndPossibleDomesticQTHExchange;           XM:NoDXMults; QP:TwoPhoneThreeCW),
  ({Name: 'WWIH';                    }   Email: nil;                      DF: nil;                 WA7BNM:  552;                         QRZRUID:   0 ; Pxm: NoPrefixMults; ZnM: CQZones;  AIE:ZoneInitialExchange;DM: NoDomesticMults; P: 0; AE: RSTZoneExchange;           XM:CQDXCC; QP:CQWWRTTYQSOPointMethod),
  ({Name: 'ALRS_UA1DZ_CUP';          }   Email: nil;                      DF: 'russian';           WA7BNM: 0000;                         QRZRUID: 543 ; Pxm: NoPrefixMults; ZnM: NoZoneMults;  AIE:NoInitialExchange; DM: WYSIWYGDomestic; P: 0; AE: RSTDomesticQTHExchange;           XM:CQDXCC; QP:ALRSUA1DZCupQSOPointMethod),
- ({Name: 'WINTER FIELD DAY';        }   Email: nil;                      DF: 'arrlsect';          WA7BNM:   421; {SK3BG: nil;          } QRZRUID: 0   ; Pxm: NoPrefixMults; ZnM: NoZoneMults; AIE: NoInitialExchange; DM: DomesticFile;    P: 0; AE: ClassDomesticOrDXQTHExchange;                XM:ARRLDXCC; QP:ARRLFieldDayQSOPointMethod)
+ ({Name: 'WINTER FIELD DAY';        }   Email: 'wfda@winterfieldday.com';DF: 'arrlsect';          WA7BNM:   421; {SK3BG: nil;          } QRZRUID: 0   ; Pxm: NoPrefixMults; ZnM: NoZoneMults; AIE: NoInitialExchange; DM: DomesticFile;    P: 0; AE: ClassDomesticOrDXQTHExchange;                XM:ARRLDXCC; QP:ARRLFieldDayQSOPointMethod)
  
  {*)}
       );

--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -3088,6 +3088,7 @@ function TotalScore: LONGINT;
 var
   QPoints, TotalMults                   : LONGINT;
   m                                     : RemainingMultiplierType;
+  b                                     : BandType;
 begin
   QPoints := TotalQSOPoints;
 
@@ -3110,6 +3111,28 @@ begin
     TotalScore := QPoints;
     Exit;
   end;
+
+  if Contest = WINTERFIELDDAY then           // Issue 301 NY4I
+     begin
+     TotalMults := 0;
+     for b := Low(BandType) to Band1296 do
+        begin
+        if QTotals[b,Digital] > 0 then
+           begin
+           inc(TotalMults);
+           end;
+        if QTotals[b,CW] > 0 then
+           begin
+           inc(TotalMults);
+           end;
+        if QTotals[b,Phone] > 0 then
+           begin
+           inc(TotalMults);
+           end;
+        end;
+     TotalScore := TotalMults * QPoints;
+     Exit;
+     end;
 
 //  Sheet.MultSheetTotals(MTotals);
   //  VisibleLog.IncrementMultTotalsWithContentsOfEditableWindow(MTotals);


### PR DESCRIPTION
This fixed #301 to calculate the score according to the Winter Field Day rules. It does not however add their custom Cabrillo fields as they are non-standard. The user can add those fields on their own prior to submission.