### PR TITLE
Fixed issues with mults for WWDIGI

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -500,6 +500,7 @@ begin
 
     tElapsedTimeFromLastQSO := Windows.GetTickCount;
     UpdateWindows;
+    // It is not clear to me why we would call SHowStationInformation again.
     ShowStationInformation(@ReceivedData.Callsign);
     ClearContestExchange(ReceivedData);
     LastTwoLettersCrunchedOn := '';
@@ -527,7 +528,7 @@ begin
     if OpMode = SearchAndPounceOpMode then SendSerialNumberChange(sntReserved);
 
     SendSerialNumberChange(sntFree);
-
+    StationInformationCall := ''; // Moved this to the very end of the process to log a contact. ny4i
   end;
 end;
 
@@ -6334,7 +6335,8 @@ begin
                      if Length(exch.QTHString) = 0 then
                          begin
                          if (ActiveDomesticMult = GridSquares) or
-                            (ActiveExchange = RSTAndOrGridExchange)            then
+                               ((ActiveExchange = RSTAndOrGridExchange) or
+                                (ActiveExchange = Grid2Exchange)         ) then
                             begin
                             exch.QTHString := fieldValue; // GRIDSQUARE
                             end;
@@ -6466,7 +6468,7 @@ begin
       except
          DebugMsg('Exception processign ADIF Record ' + sADIF);
       end;
-      DomQTHTable.GetDomQTH(exch.QTHString, exch.DomMultQTH, exch.DomesticQTH);
+     // ****************************** DomQTHTable.GetDomQTH(exch.QTHString, exch.DomMultQTH, exch.DomesticQTH);
       // fix up operator
       if exch.ceOperator = '' then
          begin

--- a/tr4w/src/trdos/FCONTEST.PAS
+++ b/tr4w/src/trdos/FCONTEST.PAS
@@ -1434,6 +1434,7 @@ begin
       DigitalModeEnable := true;
       QSOByMode := False;
       QSOByBand := True;
+      LiteralDomesticQTH := true;
       end;
 
   end;

--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -2012,9 +2012,10 @@ begin
     on a different band?  I put it back in in 6.72 - and clared
     StationInformationCall when logging a QSO }
 
-  if Call^ = StationInformationCall then
+  if Call^ = StationInformationCall then   // This is a flag to show we have been here before ny4i
     Exit;
 
+  logger.trace('>>> Entering ShowStationInformation with call of %s',[Call^]);
   StationInformationCall := Call^;
 
   //  if Copy(Call, 1, 3) = 'CQ-' then Exit;

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -1284,7 +1284,7 @@ var
   TempMode                              : ModeType;
 begin
   logger.trace('>>>Entering LogContact');
-  StationInformationCall := '';
+ // StationInformationCall := '';    // This might be cleared out too soon - Moved to end of TryLogContact ny4i
   ShowQSOStatusCall := '';
   VisibleDupeSheetChanged := True;
   //if Packet.PacketSerialPort <> NoPort then Packet.DeletePacketEntry(RXData.Callsign, RXData.Band, RXData.Mode);
@@ -1464,6 +1464,8 @@ begin
         SendScoreToUDP;
         end;
      end;
+  //**************************
+  ///StationInformationCall := ''; // ny4i - Moved this to be cleared here.
 end;
 procedure loglastcall;
 

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1910,7 +1910,10 @@ begin
 
          if TempRXData.DomesticMult then           // ny4i Issue 398
             begin
-            WriteADIFFIeld('STATE',TempRXData.QTHString);
+            if not LooksLikeAGrid(TempRXData.QTHString) then
+               begin
+               WriteADIFFIeld('STATE',TempRXData.QTHString);
+               end;
             end;
 
         //if ContestsArray[Contest].DM = DomesticMult
@@ -1962,6 +1965,11 @@ begin
                 nNumberOfBytesToWrite := Format(CABRILLO_BUFFER, '<APP_TR4W_HQ:%u>%-7s ', tCallStringLength, p);
                 sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
               end;
+            WWDIGI, BATAVIA_FT8:
+               begin
+               nNumberOfBytesToWrite := Format(CABRILLO_BUFFER, '<GRIDSQUARE:%u>%s ', tCallStringLength, p);
+               sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
+               end;
           else
             begin
                nNumberOfBytesToWrite := Format(CABRILLO_BUFFER, '<QTH:%u>%s ',tCallStringLength, p);
@@ -4048,7 +4056,7 @@ begin
 
       {Make Exchanges Strings}
       case ActiveExchange of
-         GridExchange:
+         GridExchange, Grid2Exchange:
             begin
             Result := cMyGrid;
             //Format(CABRILLO_MYEX, '%-11s', cMyGrid);

--- a/tr4w/src/uWSJTX.pas
+++ b/tr4w/src/uWSJTX.pas
@@ -466,17 +466,38 @@ begin
                      SetPrefix(TempRXData);
                      end;
 
-                  CalculateQSOPoints(TempRXData);
+                  //CalculateQSOPoints(TempRXData);
                    if logger.IsDebugEnabled then
                    begin
                    logger.debug('TotalContacts right before update of NumberSent in uWSJTX ADIF UDP message = ' + IntToStr(TotalContacts));
                    end;
-                  TempRXData.NumberSent := TotalContacts;
-                  LogContact(TempRXData, true);
-                  tCleareCallWindow;
+                  //TempRXData.NumberSent := TotalContacts;
+                  //LogContact(TempRXData, true);
+                  if ParametersOkay(TempRXData.Callsign, TempRXData.QTHString, ActiveBand, ActiveMode, ActiveRadioPtr.LastDisplayedFreq {LastDisplayedFreq[ActiveRadio]}, TempRXData) then
+                     begin
+                     ReceivedData.ceSearchAndPounce := OpMode = SearchAndPounceOpMode;
+                     ReceivedData.ceComputerID := ComputerID;
+                     LogContact(TempRXData, True);
+                     tElapsedTimeFromLastQSO := Windows.GetTickCount;
+                     UpdateWindows;
+                     //ShowStationInformation(@TempRXData.Callsign);
+                     ClearContestExchange(TempRXData);
+                     LastTwoLettersCrunchedOn := '';
+                     CallAlreadySent := False;
+                     ExchangeHasBeenSent := False;
+                     EditingCallsignSent := False;
+                     SeventyThreeMessageSent := False;
+                     EscapeDeletedCallEntry := CallWindowString;
+                     tCleareCallWindow;
+                     tCleareExchangeWindow;
+                     tCallWindowSetFocus;
+                     CleanUpDisplay;
+                     end;
+
+                  //tCleareCallWindow;
 
                   //ShowStationInformation(@TempRXData.Callsign);
-                  UpdateWindows;
+                  //UpdateWindows;
                   end;
                end;
             else


### PR DESCRIPTION
Also fixed some ADIF issues with WWDIGI and BATAVIA and GRID2Exchange.

The mult status now shows just the two character mult on the main window too.

I changed where StationInformationCall was reset so we did not keep doing ShowStationInfo (Please test this with CW and your standard test cases). I want to make sure moving where StationInformationCall was updated does not affect anything.

You will now notice that the mults in a contest like WWDIGI where we use the 2 letters is what we check in the main window.

I also tested ADIF export and found an issue there which I fixed. I also addressed a related issue exporting the grid versus state (bad assumption on my part).

I tested this with FT8 and FT4 and the modes work ok.
