### PR TITLE
Fixed exporting the state

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -136,6 +136,7 @@ procedure CheckForNewContestDate(Date: TQSOTime);
 
 procedure WriteADIFField(sFieldName: string; sFieldValue: string);
 function GetOperatorsFromLog: string;
+function DeleteRepeatedSpaces(const s: string): string;
 
 procedure WriteTitleBlockToSummarySheet;
 
@@ -155,6 +156,7 @@ procedure BandChangeReport;
 procedure MakeReportFileName(ShortFileName: PChar);
 procedure MakeNotesList;
 function GoodLookingQSO: boolean;
+function GetStateFromSection(section: string) : string;
 //function CorrectContestExchange: boolean;
 
 var
@@ -1881,7 +1883,7 @@ begin
 
       WriteADIFField('SRX_STRING',TempRXData.ExchString);
       stxString := GetMyExchangeForExport;
-      WriteADIFField('STX_STRING',Trim(stxString));
+      WriteADIFField('STX_STRING',Trim(DeleteRepeatedSpaces(stxString)));
 
       if TempRXData.Precedence <> #0 then
       begin
@@ -1908,12 +1910,18 @@ begin
          else
             tCallStringLength := length(TempRXData.QTHString);
 
-         if TempRXData.DomesticMult then           // ny4i Issue 398
+         //if TempRXData.DomesticMult then           // ny4i Issue 398       // This was not quite right - NY4I 2020-11-22
+         if ContestsArray[Contest].DF = 'arrlsect' then
             begin
-            if not LooksLikeAGrid(TempRXData.QTHString) then
+            sTemp := GetStateFromSection(TempRXData.QTHString);
+            if length(sTemp) > 0 then
                begin
-               WriteADIFFIeld('STATE',TempRXData.QTHString);
+               WriteADIFField('STATE',sTemp);
                end;
+            end
+         else if LooksLikeAState(TempRXData.QTHString) then
+            begin
+            WriteADIFField('STATE',TempRXData.QTHString);
             end;
 
         //if ContestsArray[Contest].DM = DomesticMult
@@ -1931,8 +1939,8 @@ begin
                 sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
               end;
 
-            ARRLFIELDDAY, ARRLSSCW, ARRLSSSSB, WINTERFIELDDAY:
-              begin
+            ARRLFIELDDAY, WINTERFIELDDAY:
+                begin
                 if TempRXData.QTHString <> 'DX' then     // Change to validate it is a section
                    begin
                    WriteADIFField('ARRL_SECT',TempRXData.QTHString);
@@ -1943,7 +1951,15 @@ begin
                 nLength := length(MyFDClass) + 1 + length(MySection);
                 sBuffer := SysUtils.Format('<STX_STRING:%u>%s %s ',[nLength, MyFDClass, MySection]);
                 sWriteFileFromString(tReportFileWrite, sBuffer);
-
+                end;
+            ARRLSSCW, ARRLSSSSB:
+               begin
+               if TempRXData.QTHString <> 'DX' then     // Change to validate it is a section
+                   begin
+                   WriteADIFField('ARRL_SECT',TempRXData.QTHString);
+                   //nNumberOfBytesToWrite := Format(CABRILLO_BUFFER, '<ARRL_SECT:%u>%s ', tCallStringLength, p);
+                   //sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
+                   end;
 
 
               end;
@@ -4292,5 +4308,65 @@ begin
    end;
 end;
 (*----------------------------------------------------------------------------*)
+function GetStateFromSection(section: string) : string;
+begin
+   logger.debug ('Entering GetStateFromSection with ' + section);
+   Case AnsiIndexText(AnsiUpperCase(section), ['EMA', 'WMA',                     // 0..1
+                                               'ENY', 'NLI', 'NNY', 'WNY',       // 2..5
+                                               'NNJ', 'SNJ',                     // 6..7
+                                               'EPA', 'WPA',                     // 8..9
+                                               'NFL', 'SFL', 'WCF',              // 10..12
+                                               'NTX', 'WTX', 'STX',
+                                               'EB',  'LAX', 'ORG', 'SB', 'SCV', 'SDG', 'SF', 'SJV', 'SV',
+                                               'PAC',
+                                               'EWA', 'WWA',
+                                               'GTA', 'ONE', 'ONN', 'ONS',
+                                               'MAR'
+                                              ]) of
+
+   0..1: Result := 'MA';
+   2..5: Result := 'NY';
+   6..7: Result := 'NJ';
+   8..9: Result := 'PA';
+   10..12: Result := 'FL';
+   13..15: Result := 'TX';
+   16..24: Result := 'CA';
+   25: Result := 'HI';
+   26..27: Result := 'WA';
+   28..31: Result := 'ON';
+   32: Result := 'NS';
+   else
+      Result := Tree.GetStateFromSection(section); // This is to not return VE providences that do map directly from sections.
+   end;
+
+   logger.debug('Leaving GetSectionFromState with ' + Result);
+end;
+
+function DeleteRepeatedSpaces(const s: string): string;
+  var
+    i, j, State: Integer;
+  begin
+    SetLength(Result, Length(s));
+    j := 0;
+    State := 0;
+
+    for i := 1 to Length(s) do begin
+
+      if s[i] = ' ' then
+        Inc(State)
+      else
+        State := 0;
+
+      if State < 2 then
+        Result[i - j] := s[i]
+      else
+        Inc(j);
+
+    end;
+
+    if j > 0 then
+        SetLength(Result, Length(s) - j);
+  end;
+
 end.
 

--- a/tr4w/src/trdos/tree.pas
+++ b/tr4w/src/trdos/tree.pas
@@ -858,6 +858,7 @@ function LineInput(Prompt: Str160;
 
 function LowerCase(const s: string): string;
 function LooksLikeAGrid(var GridString: ShortString): boolean;
+function LooksLikeAState(state: string): boolean; // NY4I
 function Lpt1BaseAddress: Word;
 function Lpt2BaseAddress: Word;
 function Lpt3BaseAddress: Word;
@@ -4801,6 +4802,36 @@ begin
   end;
 
   GetStateFromSection := '';
+end;
+
+function LooksLikeAState(state: string): boolean;
+
+begin
+  if (state = 'CA') or (state = 'TX') or (state = 'NY') or (state = 'FL') or
+     (state = 'TX') or (state = 'PA') or (state = 'MA') or (state = 'NJ') or
+     (state = 'WA') or (state = 'MD') or (state = 'DC') or
+     (state = 'AK') or (state = 'AL') or (state = 'AR') or
+     (state = 'AZ') or (state = 'CO') or (state = 'CT') or
+     (state = 'DE') or (state = 'GA') or (state = 'IA') or
+     (state = 'ID') or (state = 'IN') or (state = 'IL') or
+     (state = 'KS') or (state = 'KY') or (state = 'LA') or
+     (state = 'ME') or (state = 'MI') or (state = 'MN') or
+     (state = 'MO') or (state = 'MS') or (state = 'MT') or
+     (state = 'NC') or (state = 'ND') or (state = 'NE') or
+     (state = 'NH') or (state = 'NM') or (state = 'NV') or
+     (state = 'OH') or (state = 'OK') or (state = 'OR') or
+     (state = 'RI') or (state = 'SD') or (state = 'TN') or
+     (state = 'UT') or (state = 'VA') or (state = 'VT') or
+     (state = 'WI') or (state = 'WV') or (state = 'WY') or
+     (state = 'SC') or (state = 'HI') or
+     (state = 'NS') or (state = 'QC') or (state = 'ON') or (state = 'MB') or
+     (state = 'SK') or (state = 'AB') or (state = 'BC') or (state = 'NT') or
+     (state = 'NB') or (state = 'NL') or (state = 'YT') or (state = 'PE') or (state = 'NU') then
+     begin
+     Result := true;
+     end;
+
+
 end;
 {
 function ReadFromSerialPort(port: HWND; BytesToRead: Cardinal; WriteDebug: boolean): boolean ;


### PR DESCRIPTION
I fixed exporting the state bu adding more intelligence to the process. The code was looking at DomesticMults but that was wrong. I changed this to look at the contestsArray[contest].DF field to see if it was arrlsect and also to only emit the STATE ADIF field if we can really calculate a valid state.