### PR TITLE
FT4 and FT8 mode fixed and CAB in RTTY contest

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1848,7 +1848,14 @@ begin
 
       if TempRXData.ExtMode = eNoMode then
          begin
-         sMode := ADIFModeString[TempRXData.mode];
+         if TempRXData.Mode = Digital then
+            begin
+            sMode := 'RTTY';  // Issue 457 Revisited.
+            end
+         else
+            begin
+            sMode := ADIFModeString[TempRXData.mode];
+            end;
          end
       else if TempRXData.ExtMode = eFT4 then    // ??? In MFSKModes[TempRXData.ExtMode]?
          begin
@@ -2513,7 +2520,11 @@ begin
     // This was just assuming any digital contact was RY which is obviously not true.
     if TempRXData.Mode = Digital then
        begin
-       if TempRXData.ExtMode = eRTTY then
+       if TempRXData.ExtMode = eNoMode then
+          begin
+          ModeString := 'RY';
+          end
+       else if TempRXData.ExtMode = eRTTY then
           begin
           ModeString := 'RY';
           end

--- a/tr4w/tr4w.cfg
+++ b/tr4w/tr4w.cfg
@@ -34,10 +34,10 @@
 -E"target"
 -LE"c:\program files (x86)\borland\delphi7\Projects\Bpl"
 -LN"c:\program files (x86)\borland\delphi7\Projects\Bpl"
--U"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include"
--O"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include"
--I"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include"
--R"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include"
+-U"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7"
+-O"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7"
+-I"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7"
+-R"src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7"
 -w-UNSAFE_TYPE
 -w-UNSAFE_CODE
 -w-UNSAFE_CAST

--- a/tr4w/tr4w.dof
+++ b/tr4w/tr4w.dof
@@ -94,7 +94,7 @@ OutputDir=target
 UnitOutputDir=
 PackageDLLOutputDir=
 PackageDCPOutputDir=
-SearchPath=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include
+SearchPath=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7
 Packages=vcl;rtl;vclx;VclSmp;vclshlctrls
 Conditionals=
 DebugSourceDirs=
@@ -130,3 +130,15 @@ OriginalFilename=
 ProductName=
 ProductVersion=1.0.0.0
 Comments=
+[HistoryLists\hlUnitAliases]
+Count=1
+Item0=WinTypes=Windows;WinProcs=Windows;DbiTypes=BDE;DbiProcs=BDE;DbiErrs=BDE;
+[HistoryLists\hlSearchPath]
+Count=4
+Item0=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\d7
+Item1=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core;c:\Indy\lib\d7
+Item2=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy;c:\Indy\lib\core
+Item3=src\lang;src\trdos;src\utils;src;D:\newsrc\tr4w\src\include\Indy;src\include\Indy;D:\newsrc\tr4w\src\include\Indy\Lib\Core;D:\newsrc\tr4w\src\include\Indy\D7;D:\newsrc\tr4w\include;c:\Indy
+[HistoryLists\hlOutputDirectorry]
+Count=1
+Item0=target


### PR DESCRIPTION
This closes issue #457 and closes #466 . The fix to make the mode show up properly in the CAB and ADIF file was handled in PostUnit. The real issue here is that we we Digital for too much. I have a branch I have to finish testing that makes Digital and RTTY seperate Modes. So until that is all done, doing the fixup in Post makes the most sense.