### PR TITLE
Update uRadioPolling.pas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # TR4W
 TRLOG 4 Windows free amateur radio logging application
+The Fork is just for debugging of K3 polling issues.

--- a/tr4w/build/make_setup_file.bat
+++ b/tr4w/build/make_setup_file.bat
@@ -1,4 +1,4 @@
 rem UpResource.exe
 upx.exe ..\target\tr4w.exe --lzma
-"D:\Program Files\NSIS\makensisw.exe" full.nsi
+"C:\Program Files (x86)\NSIS\makensisw.exe" full.nsi
 pause

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -163,7 +163,7 @@ begin
             BufferNotChanged := 0;
 
             NextWait:
-            Sleep(80); // 4.73.5 was set to 40  Revert to 80 to fix K3/Microham (K0TI)
+            Sleep(80);  // 4.73.5 was set to 40  Revert to 80 to fix K3/Microham (K0TI)
             ClearCommError(rig^.tCATPortHandle, Errs, @stat);
             if stat.cbInQue > BytesInBuffer then
                begin

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -163,7 +163,7 @@ begin
             BufferNotChanged := 0;
 
             NextWait:
-            Sleep(10); // 4.73.5 was set to 40
+            Sleep(80); // 4.73.5 was set to 40  Revert to 80 to fix K3/Microham (K0TI)
             ClearCommError(rig^.tCATPortHandle, Errs, @stat);
             if stat.cbInQue > BytesInBuffer then
                begin


### PR DESCRIPTION
Revert delay in polling code to pre 4.73.5 number to fix issue with K3/MicroHam MK2R. This is a tested fix at the W0ZT station. 
I'm not sure it needs to go as high as 80, something shorter might work, as I'm don't have easy access to the station (with covid and all) I am unable to easily test other values.