### PR TITLE
Polling update to Kenwood/K3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # TR4W
 TRLOG 4 Windows free amateur radio logging application
+The Fork is just for debugging of K3 polling issues.

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -202,24 +202,6 @@ begin
                 logger.warn('Buffer Bytes -' + inttostr(BytesInBuffer));
               end;
 
-{
-            NextWait:
-            Sleep(80);  // 4.73.5 was set to 40  Revert to 80 to fix K3/Microham (K0TI)
-            ClearCommError(rig^.tCATPortHandle, Errs, @stat);
-            if stat.cbInQue > BytesInBuffer then
-               begin
-                  BytesInBuffer := stat.cbInQue;
-                  goto NextWait;
-               end
-            else
-               begin
-                  inc(BufferNotChanged);
-                  if BufferNotChanged < 3 then
-                     goto NextWait;
-               end;
-}
-
-
             if BytesInBuffer > 0 then
                begin
                   inc(NumberOfSucceffulPolls);

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -121,6 +121,9 @@ var
    Errs: DWORD;
    BytesInBuffer: integer;
    BufferNotChanged: integer;
+   RadioWaitTime: integer;
+   RadioTimeoutTime: integer;
+   RadioWaitLoops: integer;
    NumberOfSucceffulPolls: integer;
    i: integer;
    TempCommand: tKenwoodCommands;
@@ -134,6 +137,11 @@ begin
       begin
          SetK3ExtendedCommandMode;
       end;
+
+    // set up the parmeaters for how long we wait for the radio
+   RadioWaitTime := 10; // How often we check for bytes Set to 10
+   RadioTimeoutTime := 1000; // sets the max timeout time for radio
+   RadioWaitLoops := RadioTimeoutTime Div RadioWaitTime; // how may loops to make
 
    repeat
       inc(rig^.tPollCount);
@@ -162,6 +170,39 @@ begin
             BytesInBuffer := 0;
             BufferNotChanged := 0;
 
+            // Take in bytes from the radio until either we get the number of
+            // bytes expected or until we time out.
+            // Normally check for new bytes every 10 ms and timeout in 1000 ms.
+            // refactored 12/11/2020 Dan-K0TI
+
+            while BufferNotChanged < RadioWaitLoops do
+              begin
+                Sleep(RadioWaitTime);  // wait a little for some bytes
+                ClearCommError(rig^.tCATPortHandle, Errs, @stat);
+                if stat.cbInQue > BytesInBuffer then
+                  begin
+                    BytesInBuffer := stat.cbInQue;
+                    if BytesInBuffer = KenwoodPollRequestsAnswerLength[PollNumber] then
+                      begin
+                         // log the time it took to get here
+                         logger.trace('Max wait time (ms) -' + inttostr(BufferNotChanged * RadioWaitTime));
+                         // found the correct byte count, go process
+                         break;
+                      end;
+                  end
+                else
+                  begin
+                    // still not enough bytes, try again
+                    inc(BufferNotChanged);
+                  end;
+              end;
+            if BufferNotChanged >= RadioWaitLoops then // we timed out, log it
+              begin
+                logger.warn('Radio Timeout 1000ms');
+                logger.warn('Buffer Bytes -' + inttostr(BytesInBuffer));
+              end;
+
+{
             NextWait:
             Sleep(80);  // 4.73.5 was set to 40  Revert to 80 to fix K3/Microham (K0TI)
             ClearCommError(rig^.tCATPortHandle, Errs, @stat);
@@ -176,6 +217,8 @@ begin
                   if BufferNotChanged < 3 then
                      goto NextWait;
                end;
+}
+
 
             if BytesInBuffer > 0 then
                begin

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -110,8 +110,8 @@ const
 implementation
 
 procedure pKenwood2(rig: RadioPtr);
-label
-   NextWait;
+//label
+//   NextWait;
 
 type
    tKenwoodCommands = (kcIF, kcFA, kcFB);


### PR DESCRIPTION
This changes the K3 polling code so that a long wait time is not required. This code checks for new data every 10 ms and if it gets the number of bytes expected it moves on without any further waiting, otherwise it will wait for as long as 1000ms for response from the radio. This should give the best of both worlds. This has been tested extensively on the KX3 here at baud rates from 4800 up to 38400. It has not been tested on K3, so that needs to be tested. 
I found on the KX3 that the normal time for a radio response to be 30-40 ms, but if your tuning the radio it's about 100-150, and a band change can take 600 or more.

The same code structure is in the Orion polling section but as I don't have a radio to test I didn't update that. 

This also fixes that Readme.md that I broke before. My son was teaching me git workflows so he generated that change.
