### PR TITLE
Fix to Winter Field Day scoring and Cab generation

### DIFF
--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -2852,6 +2852,16 @@ begin
       end;
     end;
     TotalScore := TotalMults * QPoints;
+    if tCategoryPowerSA[Categorypower] = 'LOW' then
+       begin
+       Result := Result * 2;
+       end
+    else if tCategoryPowerSA[Categorypower] = 'QRP' then
+       begin
+       Result := Result * 5;
+       end;
+
+
     Exit;
   end;
 

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -5742,7 +5742,7 @@ begin
             else
       }
       begin
-      if RXData.Mode = Phone then
+      if RXData.Mode in [Phone,FM] then
         RXData.QSOPoints := 1
       else
         RXData.QSOPoints := 2;

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -2342,7 +2342,14 @@ begin
       begin
       Continue;
       end;
-
+    if Contest = WINTERFIELDDAY then
+       begin
+       if TempTag = ctLocation then
+          begin
+          sWriteFileFromString(tReportFileWrite,'ARRL-SECTION: ' + TempBuffer2 + #13#10);
+          sWriteFileFromString(tReportFileWrite,'CATEGORY: ' + MyFDClass + #13#10);
+          end;
+       end;
     TempPchar := @CabrilloTagsArray[TempTag].ctrTag[1];
     if TempTag = ctOperators then
        begin
@@ -2536,21 +2543,36 @@ begin
     // This was just assuming any digital contact was RY which is obviously not true.
     if TempRXData.Mode = Digital then
        begin
-       if TempRXData.ExtMode = eNoMode then
+       case TempRXData.ExtMode of
+          eNoMode, eRTTY:
+             if Contest = WINTERFIELDDAY then
+                begin
+                ModeString := 'DI'; // Error in WFD's parser they refuse to fix. de NY4I
+                end
+             else
+                begin
+                ModeString := 'RY';
+                end;
+          else
+             if Contest = WINTERFIELDDAY then
+                begin
+                ModeString := 'DI'; // Error in WFD's parser they refuse to fix. de NY4I
+                end
+             else
+                begin
+                ModeString := 'DG';
+                end;
+          end; // case
+       end
+    else if TempRXData.Mode = FM then
+       begin
+       if Contest = WINTERFIELDDAY then
           begin
-          ModeString := 'RY';
-          end
-       else if TempRXData.ExtMode = eRTTY then
-          begin
-          ModeString := 'RY';
+          ModeString := 'PH';
           end
        else
           begin
-          ModeString := 'DG';
-          if Contest = WINTERFIELDDAY then
-             begin
-             ModeString := 'DI'; // Error in WFD's parser they refuse to fix. de NY4I
-             end;
+          ModeString := tCabrilloModeString[TempRXData.Mode];
           end;
        end
     else


### PR DESCRIPTION
I use the power version to calculate the score so the user only needs to add in their bonus points. I also updated the QSOPoint calculation to include Phone and FM as modes that are one point. Previously it was just phone so FM ended up with 2 points. Field Day had the same bug.