### PR TITLE
Band map debug

### DIFF
--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -393,13 +393,19 @@ begin
           LBN_DBLCLK:
             begin
               TempInt := GetBMSelItemData;
-              if TempInt = LB_ERR then Exit;
+              if TempInt = LB_ERR then
+                 begin
+                 logger.Trace('In BandMap::BandmapDlgProc, GetBMSelItemData = LB_ERR so exiting without changing radio');
+                 Exit;
+                 end;
               if  QSYInactiveRadio and  TwoRadioMode then          // 4.92.1                         //Gav 4.37.12
                 begin
+                logger.trace('[BandMap::BandmapDlgProc] Calling TuneRadioToSpot for Inactive Radio');
                 TuneRadioToSpot(SpotsList.Get(TempInt), InActiveRadio);
                end
               else
               begin
+                logger.trace('[BandMap::BandmapDlgProc] Calling TuneRadioToSpot for active Radio');
                 TuneRadioToSpot(SpotsList.Get(TempInt), ActiveRadio);
               end;
               KillFocus;                                  // Gav 4.47.4 #141
@@ -472,9 +478,13 @@ begin
 //?
   EntryBand := NoBand;
   EntryMode := NoMode;
-
+  logger.Trace('Entering TuneRadioToSpot %s - %d',[Spot.FCall,Spot.FFrequency]);
   GetBandMapBandModeFromFrequency(Spot.FFrequency, EntryBand, EntryMode);
-  if (EntryBand = NoBand) then exit;
+  if (EntryBand = NoBand) then
+     begin
+     logger.trace('Exiting TuneRadioToSpot due to NoBand');
+     exit;
+     end;
   if ((radio1.filteredstatus.freq=0) or (radio2.filteredstatus.freq=0)) then
    begin
     QSYInActiveRadio := False;
@@ -499,6 +509,7 @@ begin
     end;
 
   // Sleep(100);  4.92.4
+  logger.trace('[TuneRadioToSpot] Calling SetRadioFreq %d',[(Spot.FFrequency + QZBOffset)]);
   SetRadioFreq(Radio, Spot.FFrequency + QZBOffset, EntryMode, 'A');
   PutRadioOutOfSplit(Radio);
   if (QZBRandomOffsetEnable and (EntryMode = CW)) then

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -62,6 +62,7 @@ procedure pFT736R(rig: RadioPtr);
 procedure pFT817_FT847_FT857_FT897(rig: RadioPtr);
 procedure pFT1000MP(rig: RadioPtr);
 procedure pFT100(rig: RadioPtr);
+function ArrayToString(const a: array of Char): string;
 
 procedure pIcom(rig: RadioPtr);
 procedure pIcomNew(rig: RadioPtr);
@@ -2338,6 +2339,7 @@ end;
 function ReadFromSerialPort(BytesToRead: Cardinal; rig: RadioPtr): boolean;
 var
    BytesRead: Cardinal;
+   s: string;
 begin
    Result := False;
    if BytesToRead > SizeOf(rig^.tBuf) then
@@ -2347,6 +2349,8 @@ begin
       {rig^.pOver}) then
       if BytesToRead = BytesRead then
          Result := True;
+   logger.trace('[ReadFromSerialPort] Read %s from serial port',[ArrayToString(rig^.tBuf)]);
+
 end;
 
 procedure ClearRadioStatus(rig: RadioPtr);
@@ -3309,6 +3313,14 @@ begin
          DEBUGMSG('In SetVFOModeExtendedMode, which is not valid ' +
             IntToStr(which));
       end;
+end;
+
+function ArrayToString(const a: array of Char): string;
+begin
+  if Length(a)>0 then
+    SetString(Result, PChar(@a[0]), Length(a))
+  else
+    Result := '';
 end;
 
 end.


### PR DESCRIPTION
Added more BandMap debug messages as well as a trace to see the data coming back from the radio. This way when the user clicks on a spot, we can see if the radio is responding properly to the command. This will show for example, if the radio command is not implemented as is the case if an IC7600 or IC7700 does not have the Version 2 and 2.1 firmware respectively.