### PR TITLE
Update LOGRADIO.PAS

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -1322,14 +1322,21 @@ begin
       try
       if logger.IsTraceEnabled then
          begin
-         if not (nNumberOfBytesToWrite in [3,6,7]) then
+         if true then //not (nNumberOfBytesToWrite in [3,6,7]) then
             begin
             logger.trace('>>>>Enter WriteToCATPort');
             SetString(debugStr,PChar(@Buffer),nNumberOfBytesToWrite);
             nLen := nNumberOfBytesToWrite; //Ord(Buffer[0]);
-            BinToHex(@Buffer,Buf,nLen);
-            Buf[(nLen*2) - 2] := #0;
-            logger.trace(Format('[%s] Calling WriteFile to write %u bytes <%s>',[RadioName,nNumberOfBytesToWrite,Buf]));
+            if Self.RadioModel in IcomRadios then
+               begin
+               BinToHex(@Buffer,Buf,nLen);
+               Buf[(nLen*2) - 2] := #0;
+               logger.trace(Format('[%s] Calling WriteFile to write %u bytes <%s>',[RadioName,nNumberOfBytesToWrite,Buf]));
+               end
+            else
+               begin
+               logger.trace(Format('[%s] Calling WriteFile to write %u bytes <%s>',[RadioName,nNumberOfBytesToWrite,debugStr]));
+               end;
             end;
          end;
 


### PR DESCRIPTION
The code to trace output was not called if the length was 3, 6 or 7. This may have excluded needed strings for debug.
Note we poll far to often. Consider reducing poll frequency.

Also, only tracing for Icom radios is in hex. Most other radios are in text format (some older radios may not be).