### PR TITLE
Close Logfile after UDP command

### DIFF
--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -2875,6 +2875,7 @@ end;
          logger.error('[SendFullLogToUDP] Was not valid QSO %s',[TempRXData.Callsign]);
          end;
       end;
+   CloseLogFile;
    Logger.Info('%d records sent to UDP',[nCount]);
    Format(QuickDisplayBuffer, '%d log records sent to UDP', nCount);
    QuickDisplay(QuickDisplayBuffer);


### PR DESCRIPTION
The UDP command to send all the cont5acts to the UDP contact port was not closing the log. This caused a subsequent contact to have an error in save log.