### PR TITLE
Fixed WFD Import and SRS commands for Net

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -6761,7 +6761,7 @@ var
 begin
   sModeUpper := ANSIUPPERCASE(sMode);
   case AnsiIndexText(AnsiUpperCase(sMode), ['CW', 'SSB', 'AM', 'FM', 'FT8',
-    'RTTY', 'MFSK']) of
+    'RTTY', 'MFSK', 'PSK31', 'PSK']) of
     0: // CW
       begin
         Result.msmMode := CW;
@@ -6798,6 +6798,11 @@ begin
         Result.msmMode := Digital;
         Result.msmExtendedMode := eMFSK;
       end;
+    7, 8:
+      begin
+        Result.msmMode := Digital;
+        Result.msmExtendedMode := ePSK31;
+      end;
     -1:
       Result.msmMode := NoMode;
   else
@@ -6811,8 +6816,8 @@ var
   sModeUpper: string;
 begin
   sModeUpper := ANSIUPPERCASE(sSubMode);
-  case AnsiIndexText(AnsiUpperCase(sSubMode), ['FT4', 'JS8', 'USB', 'LSB']) of
-    0: // CW
+  case AnsiIndexText(AnsiUpperCase(sSubMode), ['FT4', 'JS8', 'USB', 'LSB', 'PSK31']) of
+    0:
       begin
         Result.msmMode := Digital;
         Result.msmExtendedMode := eFT4;
@@ -6831,6 +6836,11 @@ begin
       begin
         Result.msmMode := Phone;
         Result.msmExtendedMode := eLSB;
+      end;
+     4:
+      begin
+        Result.msmMode := Digital;
+        Result.msmExtendedMode := ePSK31;
       end;
     -1:
       Result.msmMode := NoMode;
@@ -7184,8 +7194,11 @@ begin
         end;
         exch.ExchString := exch.QTHString;
       end;
-    ARRLSSCW, ARRLSSSSB: // 4.105.2
-      exch.DomesticQTH := tempARRL_Sect;
+    ARRLSSCW, ARRLSSSSB, WINTERFIELDDAY, ARRLFIELDDAY: // 4.105.2
+       begin
+       exch.DomesticQTH := tempARRL_Sect;
+       exch.QTHString := tempARRL_SECT;
+       end;
     CWOPS:
       exch.Age := StrToIntDef(exch.QTHString, 0);
     CQWWCW, CQWWSSB: // 4.105.16

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1820,14 +1820,14 @@ begin
       tBandStringLength := Windows.lstrlen(tBandString);
     //   if contest =  RADIOVHFFD  then       // added 4.61.1
         begin                              // 4.61.1
-        if tBandString = '432' then
+        if tBandString = '432' then        // NY4I made CM to cm per ADIF spec
          begin
-           tBandString := '70CM';
+           tBandString := '70cm';
            tBandStringLength := 4;
          end;
         if tBandString = '1GH' then
          begin
-           tBandString := '23CM';
+           tBandString := '23cm';
            tBandStringLength := 4;
          end;
         end;
@@ -2132,6 +2132,12 @@ begin
         end;
         Windows.lstrlen(TempRXData.ceOperator);
         asm push eax end;
+        if TempRXData.ceOperator <> MyCall then
+           begin           // Add STATION_CALLSIGN because operator is different
+           nLength := length(MyCall);
+           sBuffer := SysUtils.Format('<STATION_CALLSIGN:%u>%s ',[nLength, MyCall]);
+           sWriteFileFromString(tReportFileWrite, sBuffer);
+           end;
       end
 
       else
@@ -2146,6 +2152,7 @@ begin
       nNumberOfBytesToWrite := wsprintf(CABRILLO_BUFFER, '<OPERATOR:%u>%s ');
       asm add esp,16 end;
       sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
+
 
       sWriteFile(tReportFileWrite, '<EOR>'#13#10, 7);
     end;

--- a/tr4w/src/uProcessCommand.pas
+++ b/tr4w/src/uProcessCommand.pas
@@ -495,27 +495,35 @@ end;
 
 procedure scSRS;
 begin
-  if ActiveRadioPtr.RadioModel in [IC78..IC9700, OMNI6] then
-  begin
+   if ActiveRadioPtr.tNetObject <> nil then
+      begin
+      ActiveRadioPtr.tNetObject.SendToRadio(scFileName);
+      end
+   else if ActiveRadioPtr.RadioModel in [IC78..IC9700, OMNI6] then
+      begin
 //    ActiveRadioPtr.ICOM_COMMAND_CUSTOM := scFileName;
 //    ActiveRadioPtr.CommandsTempBuffer
-    Windows.CopyMemory(@ActiveRadioPtr.CommandsTempBuffer[1], @scFileName[1], length(scFileName));
-    ActiveRadioPtr.CommandsTempBuffer[0] := CHR(length(scFileName));
-    ActiveRadioPtr.AddCommandToBuffer;
-  end
-  else
+      Windows.CopyMemory(@ActiveRadioPtr.CommandsTempBuffer[1], @scFileName[1], length(scFileName));
+      ActiveRadioPtr.CommandsTempBuffer[0] := CHR(length(scFileName));
+      ActiveRadioPtr.AddCommandToBuffer;
+      end
+   else
 //    WriteToSerialCATPort(scFileName, ActiveRadioPtr.tCATPortHandle);
-    ActiveRadioPtr.WriteToCATPort(scFileName[1], length(scFileName));
+      ActiveRadioPtr.WriteToCATPort(scFileName[1], length(scFileName));
 end;
 
 procedure scSRSI;
 begin
-  if InActiveRadioPtr.RadioModel in [IC78..IC9700, OMNI6] then
-  begin
+  if InActiveRadioPtr.tNetObject <> nil then
+    begin
+    InActiveRadioPtr.tNetObject.SendToRadio(scFileName);
+    end
+  else if InActiveRadioPtr.RadioModel in [IC78..IC9700, OMNI6] then
+    begin
     Windows.CopyMemory(@InActiveRadioPtr.CommandsTempBuffer[1], @scFileName[1], length(scFileName));
     InActiveRadioPtr.CommandsTempBuffer[0] := CHR(length(scFileName));
     InActiveRadioPtr.AddCommandToBuffer;
-  end
+    end
 //    InActiveRadioPtr.ICOM_COMMAND_CUSTOM := scFileName
   else
 //    WriteToSerialCATPort(scFileName, InActiveRadioPtr.tCATPortHandle);
@@ -524,7 +532,11 @@ end;
 
 procedure scSRS1;
 begin
-  if Radio1.RadioModel in [IC78..IC9700, OMNI6] then
+  if Radio1.tNetObject <> nil then
+    begin
+    Radio1.tNetObject.SendToRadio(scFileName);
+    end
+  else if Radio1.RadioModel in [IC78..IC9700, OMNI6] then
   begin
     Windows.CopyMemory(@Radio1.CommandsTempBuffer[1], @scFileName[1], length(scFileName));
     Radio1.CommandsTempBuffer[0] := CHR(length(scFileName));
@@ -538,7 +550,11 @@ end;
 
 procedure scSRS2;
 begin
-  if Radio2.RadioModel in [IC78..IC9700, OMNI6] then
+  if Radio2.tNetObject <> nil then
+    begin
+    Radio2.tNetObject.SendToRadio(scFileName);
+    end
+  else if Radio2.RadioModel in [IC78..IC9700, OMNI6] then
   begin
     Windows.CopyMemory(@Radio2.CommandsTempBuffer[1], @scFileName[1], length(scFileName));
     Radio2.CommandsTempBuffer[0] := CHR(length(scFileName));


### PR DESCRIPTION
Added code to call the NetObject.SendRadio command if the SRS commands are used. Also added code to fix the importing of WinterFieldDay files. This closes #635 and closes #637 as well as the WFD Import which did not have an issue.