### PR TITLE
Fixed error in format statement

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -2101,7 +2101,7 @@ begin
         // if length(TestString) <> 4 then TestString := '';
         if TestString = '' then
           Exit;
-        logger.debug('[ExchangeWindowChange] Setting TempExchange.QTHString to (%)', [TestString]);
+        logger.debug('[ExchangeWindowChange] Setting TempExchange.QTHString to (%s)', [TestString]);
         TempExchange.QTHString := TestString;
         DQTH := FoundDomesticQTH(TempExchange);
         if not DQTH then


### PR DESCRIPTION
The format statement had just a % instead of %s. I am surprised this didn't catch more issues as it is in ExchangeWindowChange. This fixes #657.

As I said, I am surprised this was not caught. I only saw this on the CW station in Field Day. You may want to compile this into a new version and get to anyone if they are using TR4W in WRTC.