### PR TITLE
Misc after FD Fixes

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -1724,8 +1724,24 @@ begin
          begin
          if IntegerBetween(mem,0,4) then
             begin
-            logger.debug('[K3-MemoryKeyer] Playing memory %d',[mem]);
-            localMsg := 'SWT0' + IntToStr(mem) + ';';
+            if logger.IsDebugEnabled then
+               begin
+               if mem = 0 then
+                  begin
+                  logger.debug('[K3-MemoryKeyer] Stopping playback of DVK message');
+                  end
+               else
+                  begin
+                  logger.debug('[K3-MemoryKeyer] Playing memory %d',[mem]);
+                  end;
+               end;
+            case mem of
+            0: localMsg := 'SWT37;'; // RECD button to cancel playback
+            1: localMsg := 'SWT21;';
+            2: localMsg := 'SWT31;';
+            3: localMsg := 'SWT35;';
+            4: localMsg := 'SWT39;';
+            end;
             AddToOutputBuffer(addr(localMsg[1]),length(localMsg));
             Result := false;
             end

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -633,6 +633,8 @@ function GetSentRSTFromExchangeString(var ExchangeString: ShortString {Str40}):
 procedure IncrementQTCCount(Call: CallString);
 function IsValidPOTAPark(const park: string): boolean;
 function IsValidCallsign(const callsign: string): boolean;
+function IsValidUSCallsign(const callsign: string): boolean;
+function IsValidUSPrefix(const callsign: string): boolean;
 
 function KeyRecentlyPressed(Key: Char; MaxElaspedSec100: LONGINT): boolean;
 procedure KeyStamp(Key: Char);
@@ -9329,6 +9331,57 @@ begin
     Result := true;
   end;
   // Result := (StrToInt(sXmit) in [1..99]) and (length(sCategory) = 1);
+end;
+
+
+// ^[AaWaKkNn][a-zA-Z]?[0-9][a-zA-Z]{1,3}$/
+
+function IsValidUSPrefix(const callsign: string): boolean;
+var
+  regex: TPerlRegEx;
+begin
+  // create our regex instance, and we want to do a case insensitive search, in multiline mode
+  Result := false;
+  regex := TPerlRegEx.Create;
+  try
+    logger.debug('Checking if %s is a valid US prefix', [callsign]);
+    regex.RegEx := '^[AaWaKkNn][a-zA-Z]?';
+      // Valid against all of LOTW file
+
+    regex.Subject := callsign;
+
+    Result := regex.MatchAgain;
+  finally
+    regex.Free;
+  end;
+  if Result then
+     begin
+     logger.debug('%s is a valid US prefix', [callsign]);
+     end;
+end;
+
+function IsValidUSCallsign(const callsign: string): boolean;
+var
+  regex: TPerlRegEx;
+begin
+  // create our regex instance, and we want to do a case insensitive search, in multiline mode
+  Result := false;
+  regex := TPerlRegEx.Create;
+  try
+    logger.debug('Checking if %s is a valid US call', [callsign]);
+    regex.RegEx := '^[AaWaKkNn][a-zA-Z]?[0-9][a-zA-Z]{1,3}$';
+      // Valid against all of LOTW file
+
+    regex.Subject := callsign;
+
+    Result := regex.MatchAgain;
+  finally
+    regex.Free;
+  end;
+  if Result then
+  begin
+    logger.debug('%s is a valid US call', [callsign]);
+  end;
 end;
 
 // Add Uses PerlRegEx to unit and code from https://regular-expressions.mobi/delphi.html?wlr=1

--- a/tr4w/src/trdos/tree.pas
+++ b/tr4w/src/trdos/tree.pas
@@ -861,6 +861,7 @@ function LineInput(Prompt: Str160;
 
 function LowerCase(const s: string): string;
 function LooksLikeAGrid(var GridString: ShortString): boolean;
+function LooksLikeAGridIgnoreAE(var GridString: ShortString): boolean;
 function LooksLikeAState(state: string): boolean; // NY4I
 function Lpt1BaseAddress: Word;
 function Lpt2BaseAddress: Word;
@@ -3299,35 +3300,102 @@ begin
   LooksLikeAGrid := False;
 
   TestString := UpperCase(GridString);
-    if          ((ActiveExchange = RSTAndOrGridExchange) or        // 4.118.1
-                (ActiveExchange = Grid2Exchange) or
-                (ActiveExchange = RSTAndGrid3Exchange) or
-                (ActiveExchange = GridExchange) or
-                (ActiveExchange = RSTQSONumberAndGridSquareExchange) or
-                (ActiveExchange = GridExchange)  or
-                (ActiveExchange = RSTAndGridExchange)) then
+  if ((ActiveExchange = RSTAndOrGridExchange) or        // 4.118.1
+      (ActiveExchange = Grid2Exchange) or
+      (ActiveExchange = RSTAndGrid3Exchange) or
+      (ActiveExchange = GridExchange) or
+      (ActiveExchange = RSTQSONumberAndGridSquareExchange) or
+      (ActiveExchange = GridExchange)  or
+      (ActiveExchange = RSTAndGridExchange)) then
 
-  begin
-  if (length(TestString) <> 4) and (length(TestString) <> 6) then Exit;
-
+     begin
+     if (length(TestString) <> 4) and (length(TestString) <> 6) then
+        begin
+        Exit;
+        end;
   //   if (TestString[1] < 'A') or (TestString[1] > 'R') then Exit;
   //   if (TestString[2] < 'A') or (TestString[2] > 'R') then Exit;
-  for i := 1 to 2 do
-    if (TestString[i] < 'A') or (TestString[i] > 'R') then Exit;
-
+     for i := 1 to 2 do
+        begin
+        if (TestString[i] < 'A') or (TestString[i] > 'R') then
+           begin
+           Exit;
+           end;
+        end;
   //if (TestString[3] < '0') or (TestString[3] > '9') then Exit;
   //if (TestString[4] < '0') or (TestString[4] > '9') then Exit;
-  for i := 3 to 4 do
-    if (TestString[i] < '0') or (TestString[i] > '9') then Exit;
-
+     for i := 3 to 4 do
+        begin
+        if (TestString[i] < '0') or (TestString[i] > '9') then
+           begin
+           Exit;
+           end;
+        end;
   //   if GridString[1] > 'Z' then GridString[1] := CHR(Ord(GridString[1]) - Ord('a') + Ord('A'));
   //   if GridString[2] > 'Z' then GridString[2] := CHR(Ord(GridString[2]) - Ord('a') + Ord('A'));
-  for i := 1 to 2 do
-    if GridString[i] > 'Z' then GridString[i] := CHR(Ord(GridString[i]) - Ord('a') + Ord('A'));
-
-  LooksLikeAGrid := True;
-  end;
+     for i := 1 to 2 do
+        begin
+        if GridString[i] > 'Z' then
+           begin
+           GridString[i] := CHR(Ord(GridString[i]) - Ord('a') + Ord('A'));
+           end;
+        end;
+     LooksLikeAGrid := True;
+     end
+  else
+     begin
+     logger.debug('Exiting LooksLikeAGrid because ActiveExchange not related to a grid');
+     end;
 end;
+
+
+function LooksLikeAGridIgnoreAE(var GridString: ShortString): boolean;
+
+{ If it does look like a grid, it will make the first two letters lower
+  case so it looks like a domestic QTH. }
+
+var
+  TestString                            : Str20;
+  i                                     : integer;
+  p                                  : pchar;
+begin
+
+  LooksLikeAGridIgnoreAE := False;
+
+  TestString := UpperCase(GridString);
+  if (length(TestString) <> 4) and (length(TestString) <> 6) then
+     begin
+     Exit;
+     end;
+
+  for i := 1 to 2 do
+     begin
+     if (TestString[i] < 'A') or (TestString[i] > 'R') then
+        begin
+        Exit;
+        end;
+     end;
+
+  for i := 3 to 4 do
+     begin
+     if (TestString[i] < '0') or (TestString[i] > '9') then
+        begin
+        Exit;
+        end;
+     end;
+
+  for i := 1 to 2 do
+     begin
+     if GridString[i] > 'Z' then
+        begin
+        GridString[i] := CHR(Ord(GridString[i]) - Ord('a') + Ord('A'));
+        end;
+     end;
+
+  LooksLikeAGridIgnoreAE := True;
+
+end;
+
 
 function LowerCase(const s: string): string;
 var


### PR DESCRIPTION
This closes #658.
This closes #659.
This closes #661.
This closes #667.
This closes #660.

Fixes bug where the WSJT-X mode was logged as Data/RTTY instead of FT8 or FT4. (658)
Fixed the PlayMessage_Active macro for the Elecraft K3. (659)
If the program aborts before a QSO is made, the new login operator call was not saved to the restart file. (661)
When using login, validates the callsign entered look like a valid callsign. (667)
Improved the update colorization in WSJT-X for dupes or mults. (660)
