### PR TITLE
Issue 678 Yaesu serial CW not working

### DIFF
--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -1328,7 +1328,7 @@ begin
     exit;
   end;
 }
-  logger.debug('[CWThraedProc] AddCharacterToCWBuffer');
+  logger.debug('[CWThreadProc] AddCharacterToCWBuffer');
 {$IF tDebugMode}
   AddStringToTelnetConsole('AddCharacterToCWBuffer',tstReceived);
 {$IFEND}
@@ -1936,7 +1936,7 @@ begin
     dec(CWBufferStart);
     if CWBufferStart = -1 then CWBufferStart := CWBufferSize;
   end;
-  logger.debug('[CWThredProc] CWBufferStart := CWBuferEnd');
+  logger.debug('[CWThreadProc] CWBufferStart := CWBuferEnd');
   {$IF tDebugMode}
   AddStringToTelnetConsole('CWBufferStart := CWBufferEnd', tstReceived);
 {$IFEND}
@@ -2263,7 +2263,7 @@ begin
   begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio1.tKeyerPort {ActiveKeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
-      hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, { 2 } 0, FILE_ATTRIBUTE_NORMAL, #0);
+      hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, Radio1.RadioKeyerStopBits, FILE_ATTRIBUTE_NORMAL, #0);
     if hand <> INVALID_HANDLE_VALUE then
     begin
       if hand <> INVALID_HANDLE_VALUE then
@@ -2290,7 +2290,7 @@ begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio2.tKeyerPort {Radio2.tr4w_KeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
        begin
-       hand := InitializeSerialPort(Radio2.tKeyerPort, Radio2.RadioBaudRate, 8, Tree.tNoParity, 2, FILE_ATTRIBUTE_NORMAL, #0);
+       hand := InitializeSerialPort(Radio2.tKeyerPort, Radio2.RadioBaudRate, 8, Tree.tNoParity, Radio2.RadioKeyerStopBits, FILE_ATTRIBUTE_NORMAL, #0);
        end;
     if hand <> INVALID_HANDLE_VALUE then
     begin
@@ -2480,7 +2480,7 @@ begin
   end;
 
   ExitAndPTTof:
-  logger.debug('[CWThredProc] ExitAndPTTof');
+  logger.debug('[CWThreadProc] ExitAndPTTof');
 {$IF tDebugMode}
   AddStringToTelnetConsole('ExitAndPTTof', tstReceived);
 {$IFEND}
@@ -2524,7 +2524,7 @@ end;
 
 procedure tStartAutoCQ;
 begin
-   logger.debug('[CWThredProc] In tStartAutoCQ');
+   logger.debug('[CWThreadProc] In tStartAutoCQ');
 {$IF tDebugMode}
   AddStringToTelnetConsole('In tStartAutoCQ', tstReceived);
 {$IFEND}

--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -755,7 +755,11 @@ var
   hand                                  : HWND;
   TempByte                              : Byte;
 begin
-  if ActiveRadioPtr.tKeyerPortHandle = INVALID_HANDLE_VALUE then Exit;
+  if ActiveRadioPtr.tKeyerPortHandle = INVALID_HANDLE_VALUE then
+     begin
+     logger.debug('[TurnOnActivePort] Exiting early due to ActiveRadioPtr.tKeyerPortHandle = INVALID_HANDLE_VALUE');
+     Exit;
+     end;
 //  ActivePortOn := True;
 //  CountsSinceLastCW := 0;
 
@@ -1324,7 +1328,7 @@ begin
     exit;
   end;
 }
-
+  logger.debug('[CWThraedProc] AddCharacterToCWBuffer');
 {$IF tDebugMode}
   AddStringToTelnetConsole('AddCharacterToCWBuffer',tstReceived);
 {$IFEND}
@@ -1932,7 +1936,8 @@ begin
     dec(CWBufferStart);
     if CWBufferStart = -1 then CWBufferStart := CWBufferSize;
   end;
-{$IF tDebugMode}
+  logger.debug('[CWThredProc] CWBufferStart := CWBuferEnd');
+  {$IF tDebugMode}
   AddStringToTelnetConsole('CWBufferStart := CWBufferEnd', tstReceived);
 {$IFEND}
 //  tAllowIncrementCWBufferStart := False;
@@ -2258,7 +2263,7 @@ begin
   begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio1.tKeyerPort {ActiveKeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
-      hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, 2, FILE_ATTRIBUTE_NORMAL, #0);
+      hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, { 2 } 0, FILE_ATTRIBUTE_NORMAL, #0);
     if hand <> INVALID_HANDLE_VALUE then
     begin
       if hand <> INVALID_HANDLE_VALUE then
@@ -2284,7 +2289,9 @@ begin
   begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio2.tKeyerPort {Radio2.tr4w_KeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
-      hand := InitializeSerialPort(Radio2.tKeyerPort, Radio2.RadioBaudRate, 8, Tree.tNoParity, 2, FILE_ATTRIBUTE_NORMAL, #0);
+       begin
+       hand := InitializeSerialPort(Radio2.tKeyerPort, Radio2.RadioBaudRate, 8, Tree.tNoParity, 2, FILE_ATTRIBUTE_NORMAL, #0);
+       end;
     if hand <> INVALID_HANDLE_VALUE then
     begin
       if hand <> INVALID_HANDLE_VALUE then
@@ -2473,6 +2480,7 @@ begin
   end;
 
   ExitAndPTTof:
+  logger.debug('[CWThredProc] ExitAndPTTof');
 {$IF tDebugMode}
   AddStringToTelnetConsole('ExitAndPTTof', tstReceived);
 {$IFEND}
@@ -2516,6 +2524,7 @@ end;
 
 procedure tStartAutoCQ;
 begin
+   logger.debug('[CWThredProc] In tStartAutoCQ');
 {$IF tDebugMode}
   AddStringToTelnetConsole('In tStartAutoCQ', tstReceived);
 {$IFEND}

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -229,6 +229,7 @@ type
       RadioBaudRate:   cardinal;
       RadioNumberBits: integer;
       RadioStopBits:   integer;
+      RadioKeyerStopBits: integer;
       RadioParity:     ParityType;
       RadioTCPPort:    integer;
       RadioTimeout:    integer;

--- a/tr4w/src/trdos/LogCW.pas
+++ b/tr4w/src/trdos/LogCW.pas
@@ -197,6 +197,7 @@ begin
 
    //localMsg                                               := Format('Adding %s to CW Buffer', [Msg]);
    //AddStringToTelnetConsole(PChar(localMsg),tstAlert);
+   logger.Debug('[AddStringToBuffer] Adding %s to CW Buffer',[Msg]);
    if ( (Msg = CWByCATBufferTerminator) or
         ((CWEnable and CWEnabled and IsCWByCATActive )) ) then   // ny4i 4.44.5    + Issue 111
       begin

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -156,6 +156,7 @@ const
    DITDAHRATIO_ARRAY: array[0..03] of integer = (3, 4, 5, 6);
    LEADING_ZEROS_ARRAY: array[0..03] of integer = (0, 1, 2, 3);
 
+   // Integer commnand pointers
    ArrayRecordArray: array[1..16] of ArrayRecord =
       (
     {(*}
@@ -330,6 +331,7 @@ const
    + 1 {WSJTXRadioControlEnabled}
    + 2 {UDPLookupInfo} // Issue 612 ny4i
    + 2 {Radio1 & Radio2 UseHamLib} // Issue 676 ny4i
+   + 2 {Radio1 and Radio2 KEYER STOP BITS} // Issue 678 ny4i
    ;
 
    // Note if crAddress says pointer(NN), then it is callign a function at position NN in the an array
@@ -625,9 +627,7 @@ const
  (crCommand: 'QZB RANDOM OFFSET ENABLE';      crAddress: @QZBRandomOffsetEnable;          crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'R150S MODE';                    crAddress: @CTY.ctyR150SMode;               crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckNormal;   cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'RFOBL MODE';                    crAddress: @CTY.ctyRFOBLMode;               crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckNormal;   cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
- // RadioServerTCPPort
  (crCommand: 'RADIO TCP SERVER PORT';         crAddress: @RadioServerTCPPort;             crMin:1;  crMax:65535;   crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 0),   // ny4i
-
  (crCommand: 'RADIO ONE BAND OUTPUT PORT';    crAddress: @Radio1.BandOutputPort;          crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckNormal;  cfFunc: cfRadio1; crType: ctPortLPT; crNetwork: 0),
  (crCommand: 'RADIO ONE BAUD RATE';           crAddress: pointer(11);                     crMin:0;  crMax:57600;   crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckArray; cfFunc: cfRadio1; crType: ctInteger; crNetwork: 0),
  (crCommand: 'RADIO ONE CAT DTR';             crAddress: pointer(29);                     crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckList;   cfFunc: cfRadio1; crType: ctOther; crNetwork: 0),
@@ -643,6 +643,7 @@ const
  (crCommand: 'RADIO ONE IP ADDRESS';          crAddress: @Radio1.IPAddress;               crMin:0;  crMax:50;      crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfRadio1; crType: ctString; crNetwork: 0),
  (crCommand: 'RADIO ONE KEYER DTR';           crAddress: pointer(31);                     crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckList;   cfFunc: cfRadio1; crType: ctOther; crNetwork: 0),
  (crCommand: 'RADIO ONE KEYER RTS';           crAddress: pointer(30);                     crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckList;   cfFunc: cfRadio1; crType: ctOther; crNetwork: 0),
+ (crCommand: 'RADIO ONE KEYER STOP BITS';     crAddress: @Radio1.RadioKeyerStopBits;      crMin:0;  crMax:2;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 0),   // ny4i
  (crCommand: 'RADIO ONE NAME';                crAddress: @Radio1.RadioName;               crMin:0;  crMax:20;      crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctString; crNetwork: 0),
  (crCommand: 'RADIO ONE RECEIVER ADDRESS';    crAddress: @Radio1.ReceiverAddress;         crMin:0;  crMax:MAXWORD; crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfRadio1; crType: ctInteger; crNetwork: 0),
  (crCommand: 'RADIO ONE TRACKING ENABLE';     crAddress: nil;                             crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal; cfFunc: cfRadio1; crType: ctBoolean; crNetwork: 0),
@@ -667,6 +668,7 @@ const
  (crCommand: 'RADIO TWO IP ADDRESS';          crAddress: @Radio2.IPAddress;               crMin:0;  crMax:50;      crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfRadio2; crType: ctString; crNetwork: 0),
  (crCommand: 'RADIO TWO KEYER DTR';           crAddress: pointer(35);                     crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckList;   cfFunc: cfRadio2; crType: ctOther; crNetwork: 0),
  (crCommand: 'RADIO TWO KEYER RTS';           crAddress: pointer(34);                     crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckList;   cfFunc: cfRadio2; crType: ctOther; crNetwork: 0),
+ (crCommand: 'RADIO TWO KEYER STOP BITS';     crAddress: @Radio2.RadioKeyerStopBits;      crMin:0;  crMax:2;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 0),   // ny4i
  (crCommand: 'RADIO TWO NAME';                crAddress: @Radio2.RadioName;               crMin:0;  crMax:20;      crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctString; crNetwork: 0),
  (crCommand: 'RADIO TWO RECEIVER ADDRESS';    crAddress: @Radio2.ReceiverAddress;         crMin:0;  crMax:MAXWORD; crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckNormal;  cfFunc: cfRadio2; crType: ctInteger; crNetwork: 0),
  (crCommand: 'RADIO TWO TRACKING ENABLE';     crAddress: nil;                             crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckNormal; cfFunc: cfAll; crType: ctBoolean; crNetwork: 0),

--- a/tr4w/target/commands_help_cze.ini
+++ b/tr4w/target/commands_help_cze.ini
@@ -1051,6 +1051,10 @@ DEFAULT=PTT
 DESCRIPTION=hodnota: OFF;ON;CW;PTT. Příkazem se nastaví použití pinu DTR portu, určeného příkazem KEYER RADIO ONE OUTPUT PORT (viz).
 ALIAS=RTS AUTOMATICKÉHO KLÍČE RIG1
 
+[RADIO ONE KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO ONE with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
+
 [RADIO ONE NAME]
 DEFAULT=RIG 1
 DESCRIPTION=hodnota: volný text. Program TR4W umožňuje současné použití dvou transceiverů. Každému z nich musí být přiděleno jméno, které se pak zobrazí v levé dolní části obrazovky. Přepínat mezi transceivery lze kombinací ALT-R.
@@ -1124,6 +1128,10 @@ ALIAS=DTR AUTOMATICKÉHO KLÍČE RIG2
 DEFAULT=PTT
 DESCRIPTION=hodnota: OFF;ON;CW;PTT. Příkazem se nastaví použití pinu RTS portu, určeného příkazem KEYER RADIO TWO OUTPUT PORT (viz).
 ALIAS=RTS AUTOMATICKÉHO KLÍČE RIG2
+
+[RADIO ONE KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO TWO with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
 
 [RADIO TWO NAME]
 DEFAULT=RIG 2

--- a/tr4w/target/commands_help_eng.ini
+++ b/tr4w/target/commands_help_eng.ini
@@ -882,11 +882,15 @@ DESCRIPTION=Set width of the rig`s filter. 0 - disable filter width control; 1,2
 
 [RADIO ONE KEYER DTR]
 DEFAULT=CW
-DESCRIPTION=
+DESCRIPTION=When using RADIO ONE with Serial CW (real RS232 or USB), this controls the function of the DTR pin. Note by convention, DTR is typically used for CW.
 
 [RADIO ONE KEYER RTS]
 DEFAULT=PTT
-DESCRIPTION=
+DESCRIPTION=When using RADIO ONE with Serial CW (real RS232 or USB), this controls the function of the RTS pin. Note by convention, RTS is typically used for PTT.
+
+[RADIO ONE KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO ONE with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
 
 [RADIO ONE NAME]
 DEFAULT=Radio 1
@@ -911,8 +915,6 @@ DESCRIPTION=Type of radio one you have connected.
 [RADIO ONE WIDE CW FILTER]
 DEFAULT=FALSE
 DESCRIPTION=Set width of CW filter. Actual for FT747GX, FT840, FT890, FT900, FT990, FT1000 rigs.
-
-
 
 [RADIO TWO BAND OUTPUT PORT]
 DEFAULT=NONE
@@ -956,11 +958,15 @@ DESCRIPTION=Set width of the rig`s filter. 0 - disable filter width control; 1,2
 
 [RADIO TWO KEYER DTR]
 DEFAULT=CW
-DESCRIPTION=
+DESCRIPTION=When using RADIO TWO with Serial CW (real RS232 or USB), this controls the function of the DTR pin. Note by convention, DTR is typically used for CW.
 
 [RADIO TWO KEYER RTS]
 DEFAULT=PTT
-DESCRIPTION=
+DESCRIPTION=When using RADIO TWO with Serial CW (real RS232 or USB), this controls the function of the RTS pin. Note by convention, RTS is typically used for PTT.
+
+[RADIO TWO KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO TWO with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
 
 [RADIO TWO NAME]
 DEFAULT=Radio 2

--- a/tr4w/target/commands_help_rus.ini
+++ b/tr4w/target/commands_help_rus.ini
@@ -1066,6 +1066,10 @@ DEFAULT=PTT
 DESCRIPTION=Команда определяет назначение вывода RTS последовательного порта, указанного в команде KEYER RADIO ONE OUTPUT PORT.
 ALIAS=
 
+[RADIO ONE KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO ONE with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
+
 [RADIO ONE NAME]
 DEFAULT=Радио 1
 DESCRIPTION=Программа позволяет использовать два трансивера. Вы можете переключаться между ними, используя команду Alt-R. Имя для каждого радио показывается в нижнем левом углу экрана.
@@ -1147,6 +1151,10 @@ ALIAS=
 DEFAULT=PTT
 DESCRIPTION=Команда определяет назначение вывода RTS последовательного порта, указанного в команде KEYER RADIO TWO OUTPUT PORT.
 ALIAS=
+
+[RADIO TWO KEYER STOP BITS]
+DEFAULT=0
+DESCRIPTION=When using RADIO TWO with Serial CW (real RS232 or USB), this controls the number of stop bits used when initializing the port. This should not be necessary to set unless you have an issue. If so, try setting it to 2.
 
 [RADIO TWO NAME]
 DEFAULT=Радио 2


### PR DESCRIPTION
This has been tested on a Yaesu FT991A with a serial port via USB. This should be tested by the two people that had an issue with the CW on newer Yaesu radios. 

This should also be tested by everyone else that uses serial port CW (not WinKeyer or CWByCAT).