### PR TITLE
Fixed error ALT-M

### DIFF
--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -2263,7 +2263,16 @@ begin
   begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio1.tKeyerPort {ActiveKeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
-      hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, Radio1.RadioKeyerStopBits, FILE_ATTRIBUTE_NORMAL, #0);
+       begin
+       if logger.IsErrorEnabled then
+          begin
+          if (radio1.RadioModel in YaesuRadios) and (radio1.RadioKeyerStopBits <> 0) then
+             begin
+             logger.Error('***** Keyer stop bits not set to 0 for a Yaesu radio');
+             end;
+          end;
+       hand := InitializeSerialPort(Radio1.tKeyerPort, Radio1.RadioBaudRate, 8, Tree.tNoParity, Radio1.RadioKeyerStopBits, FILE_ATTRIBUTE_NORMAL, #0);
+       end;
     if hand <> INVALID_HANDLE_VALUE then
     begin
       if hand <> INVALID_HANDLE_VALUE then
@@ -2290,6 +2299,13 @@ begin
     hand := CPUKeyer.SerialPortConfigured_Handle[Radio2.tKeyerPort {Radio2.tr4w_KeyerPort}];
     if hand = INVALID_HANDLE_VALUE then
        begin
+       if logger.IsErrorEnabled then
+          begin
+          if (radio2.RadioModel in YaesuRadios) and (radio2.RadioKeyerStopBits <> 0) then
+             begin
+             logger.Error('***** Keyer stop bits not set to 0 for a Yaesu radio');
+             end;
+          end;
        hand := InitializeSerialPort(Radio2.tKeyerPort, Radio2.RadioBaudRate, 8, Tree.tNoParity, Radio2.RadioKeyerStopBits, FILE_ATTRIBUTE_NORMAL, #0);
        end;
     if hand <> INVALID_HANDLE_VALUE then

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -3150,21 +3150,18 @@ begin
                   TempChar := '4';
                   end;
                end;
-            if Mode = Digital then
+            if (Mode = Digital) and (ActiveRadioPtr.CurrentStatus.Mode = Digital) then  // Issue 681 ny4i Used code from Kenwood branch below.
                begin
-               if ActiveRadioPtr.CurrentStatus.Mode <> Digital then
-                  begin
-                  tKenwood14Bytes[0] := 'M';
-                  tKenwood14Bytes[1] := 'D';
-                  tKenwood14Bytes[2] := '0'; //Ord(VFO) - 17;
-                  tKenwood14Bytes[3] := TempChar;
-                  tKenwood14Bytes[4] := ';';
-                  WriteToCATPort(tKenwood14Bytes, 5);
-                  end
-               else
-                  begin
-                  logger.Debug('Skipping Yaesu mode change since mode was already DIGITAL');
-                  end;
+               logger.debug('Skipping Yaesu mode change because MODE was already DIGITAL');
+               end
+            else
+               begin
+               tKenwood14Bytes[0] := 'M';
+               tKenwood14Bytes[1] := 'D';
+               tKenwood14Bytes[2] := '0'; //Ord(VFO) - 17;
+               tKenwood14Bytes[3] := TempChar;
+               tKenwood14Bytes[4] := ';';
+               WriteToCATPort(tKenwood14Bytes, 5);
                end;
             end;
 


### PR DESCRIPTION
Fixed the error in ALT-M on Yaesu radios. Also added some code to display a LOG ERROR message if the KEYER STOP BITS are anything but 0 for a Yaesu radio. This closes issue #681.