### PR TITLE
Fixed up UDP band issue

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -6867,6 +6867,7 @@ var
   tempState: string;
   tempVE_Prov: string;
   tempARRL_Sect: string;
+  saveDecimalSeparator: char;
 
 begin
   lookingForFieldName := false;
@@ -6944,11 +6945,16 @@ begin
                 end;
               tAdifFREQ:
                 begin
-                  DecimalSeparator := '.';
-                  neFreq := StrToFloat(fieldValue);
-                  neFreq := neFreq * 1000000;
-                  exch.Frequency := Trunc(neFreq);
-                  logger.Trace('[ParseADIFRecord] FREQ = %s', [fieldValue]);
+                  saveDecimalSeparator := DecimalSeparator;
+                  try
+                     DecimalSeparator := '.';
+                     neFreq := StrToFloat(fieldValue);
+                     neFreq := neFreq * 1000000;
+                     exch.Frequency := Trunc(neFreq);
+                     logger.Trace('[ParseADIFRecord] FREQ = %s', [fieldValue]);
+                  finally
+                     DecimalSeparator :=  saveDecimalSeparator;
+                  end;
                 end;
               tAdifITUZ: exch.Zone := StrToInt(fieldValue);
               tAdifMODE:

--- a/tr4w/src/TF.pas
+++ b/tr4w/src/TF.pas
@@ -132,6 +132,7 @@ function BooleanToStr(b: boolean): string;
 //function CenterString(s: string; count: byte): string;
 procedure strU(Str: ShortString) assembler;
 procedure SetMainWindowText(Window: TMainWindowElement; Text: PChar);
+function IntegerBetween(v: integer; i: integer; k: integer): boolean;
 
 function ValExt(Source: PChar; var code: integer): extended;
 
@@ -1894,6 +1895,11 @@ end;
 function SendDlgItemMessage(hDlg: HWND; nIDDlgItem: integer; Msg: UINT): LONGINT; stdcall;
 begin
   Result := Windows.SendDlgItemMessage(hDlg, nIDDlgItem, Msg, 0, 0);
+end;
+
+function IntegerBetween(v: integer; i: integer; k: integer): boolean;
+begin
+   Result := (v >= i) and (v <= k);
 end;
 
 procedure GetTime(var Hour, Minute, Second, Sec100: Word);

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -95,11 +95,11 @@ uses
     (
     '1.8',
     '3.5',
-    '5.4',
     '7',
     '14',
     '21',
     '28',
+    '5.4',
     '30',
     '17',
     '12',
@@ -142,6 +142,7 @@ procedure GoToNextMultBandMapFrequency;
 procedure GoToNextDisplayedBandMapFrequency;
 procedure GoToNextMultDisplayedBandMapFrequency;
 function tAddQSOToLog(RXData: ContestExchange): boolean;
+function ConvertBandTypeToUDPContactBand(band: BandType): string;
 implementation
 uses
   uProcessCommand,
@@ -2745,7 +2746,11 @@ begin
             CW: sMode := 'CW';
             Phone:
                begin
-               if freq < 8000000 then
+               if IntegerBetween(freq,5300000,5500000) then
+                  begin
+                  sMode := 'USB'; // 60m band is USB
+                  end
+               else if freq < 8000000 then
                   begin
                   sMode := 'LSB';
                   end
@@ -2792,9 +2797,7 @@ begin
                              RxData.tSysTime.qtSecond]) +
                  '</timestamp>' + sLineBreak +
             #9 + '<mycall>' + MyCall + '</mycall>' + sLineBreak +
-            #9 + '<band>' + BandTypeToUDPContactBand[RXData.Band] + '</band>' + sLineBreak +
-           // #9 + '<band>' + Format('%d',[freq div 1000000]) + '</band>' + sLineBreak +     // Not 20M but 14 -- Odd.
-         // #9 +   '<band>' + BandStringsArrayWithOutSpaces[RxData.Band] + '</band>' + sLineBreak +
+            #9 + '<band>' + ConvertBandTypeToUDPContactBand(RXData.Band) + '</band>' + sLineBreak +
             #9 + '<rxfreq>' + Format('%d',[freq div 10]) + '</rxfreq>' + sLineBreak + // 1420100
             #9 + '<txfreq>' + Format('%d',[txFreq div 10]) + '</txfreq>' + sLineBreak +
             #9 + '<operator>' + RXData.ceOperator + '</operator>' + sLineBreak +
@@ -2850,6 +2853,7 @@ end;
 procedure LookupInfoToUDP(RXData: ContestExchange);
 var
    sBuf: AnsiString;
+   saveDecimalSeparator: char;
 begin
 
    udp.BroadcastEnabled := true;
@@ -2861,6 +2865,7 @@ end;
 
 procedure SendFullLogToUDP;
 var nCount: integer;
+   saveDecimalSeparator: char;
 begin
    nCount := 0;
    if not OpenLogFile then
@@ -2870,27 +2875,47 @@ end;
       Exit;
       end;
 
-   DecimalSeparator := '.'; // Set this so we use . as reqired by ADIF and not localized separator ny4i
-  
-   ReadVersionBlock;
-   while ReadLogFile do  // This reads the log into TempRXData global (bad design)
-      begin
-      if GoodLookingQSO then
+   saveDecimalSeparator := DecimalSeparator;
+   try
+      //DecimalSeparator := '.'; // Set this so we use . as reqired by ADIF and not localized separator ny4i
+
+      ReadVersionBlock;
+      while ReadLogFile do  // This reads the log into TempRXData global (bad design)
          begin
-         inc(nCount);
-         logger.Debug('[SendFullLogToUDP] (%d) Read contact for callsign %s',[nCount,TempRXData.Callsign]);
-         //SendDeletedContactToUDP(TempRXData);
-         LogContactToUDP(TempRXData);
-         end
-      else
-         begin
-         logger.error('[SendFullLogToUDP] Was not valid QSO %s',[TempRXData.Callsign]);
+         if GoodLookingQSO then
+            begin
+            inc(nCount);
+            logger.Debug('[SendFullLogToUDP] (%d) Read contact for callsign %s',[nCount,TempRXData.Callsign]);
+            //SendDeletedContactToUDP(TempRXData);
+            LogContactToUDP(TempRXData);
+            end
+         else
+            begin
+            logger.error('[SendFullLogToUDP] Was not valid QSO %s',[TempRXData.Callsign]);
+            end;
          end;
-      end;
-   CloseLogFile;
-   Logger.Info('%d records sent to UDP',[nCount]);
-   Format(QuickDisplayBuffer, '%d log records sent to UDP', nCount);
-   QuickDisplay(QuickDisplayBuffer);
+      CloseLogFile;
+      Logger.Info('%d records sent to UDP',[nCount]);
+      Format(QuickDisplayBuffer, '%d log records sent to UDP', nCount);
+      QuickDisplay(QuickDisplayBuffer);
+   finally
+      DecimalSeparator := SaveDecimalSeparator;
+   end;
 end;
+
+function ConvertBandTypeToUDPContactBand(band: BandType): string;
+begin
+   if DecimalSeparator <> '.' then
+      begin
+      // Convert the . in BandTypeToUDPContactBand to the DecimalSeperator
+      result := StringReplace(BandTypeToUDPContactBand[band],'.',DecimalSeparator,[rfReplaceAll]);
+      end
+   else
+      begin
+      result := BandTypeToUDPContactBand[band];
+      end;
+
+end;
+
 
 end.

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -345,6 +345,7 @@ const
     'YES',
     'NO');
 
+    // NOTE - The following array is used by LOGContactToUDP so the BandType enumeration on ContestExchange and this array need to be aligned.
   tCabrilloFreqString                   : array[Band160..BandLight] of PChar =
     (
     '1800',
@@ -353,7 +354,7 @@ const
     '14000',
     '21000',
     '28000',
-    '05220',
+    '5220',
     '10100',
     '18100',
     '24900',
@@ -1762,6 +1763,7 @@ var
   stxString                             : string;
   sMode                                 : string;
   sSubMode                              : string;
+  saveDecimalSeparator                  : char;
 //  IOTAstring                            : Str10;
 begin
   dtReportTime := Now;
@@ -1769,15 +1771,19 @@ begin
   tReportsFilename[Windows.lstrlen(tReportsFilename) - 3] := #0;
   lstrcat(tReportsFilename, 'ADI');
   if not tOpenFileForWrite(tReportFileWrite, tReportsFilename) then Exit;
-
+  //saveDecimalSeperator := DecimalSeperator;
   if not OpenLogFile then
   begin
     CloseHandle(tReportFileWrite);
     Exit;
   end;
 
+  {
+  saveDecimalSeparator := DecimalSeparator;
   DecimalSeparator := '.'; // Set this so we use . as reqired by ADIF and not localized separator ny4i
-  
+  } // This code wasd commented so the specific functions that use StrFloat do this work to ensure the window is very small where we change the DecimalSeparator.
+  // Otherwise an exception in this procedure could cause DecimalSeparator to be set incorrectly.
+
   // Issue 405 to fix up the header - ny4i
   sWriteFileFromString(tReportFileWrite,'ADIF File'#13#10);
 
@@ -1900,10 +1906,15 @@ begin
       if TempRXData.Frequency <> 0 then //14149280  or 7025000
          begin
          // Making this simpler...
-         DecimalSeparator := '.';
-         sTemp := FloatToStr((TempRXData.Frequency/1000000));
-         sBuffer := SysUtils.Format('<FREQ:%u>%s',[length(sTemp),sTemp]);
-         sWriteFileFromString(tReportFileWrite, sBuffer);
+         saveDecimalSeparator := DecimalSeparator;
+         try
+            DecimalSeparator := '.';
+            sTemp := FloatToStr((TempRXData.Frequency/1000000));
+            sBuffer := SysUtils.Format('<FREQ:%u>%s',[length(sTemp),sTemp]);
+            sWriteFileFromString(tReportFileWrite, sBuffer);
+         finally
+            DecimalSeparator := saveDecimalSeparator;
+         end;
 
 
       end;
@@ -2177,6 +2188,7 @@ begin
   CloseLogFile;
   PreviewFileNameAddress := tReportsFilename;
   FilePreview;
+  //DecimalSeparator :=  saveDecimalSeparator;
 end;
 
 

--- a/tr4w/src/uNetRadioBase.pas
+++ b/tr4w/src/uNetRadioBase.pas
@@ -68,7 +68,6 @@ const
 }
 
 function BoolToString(b: boolean): string;
-function IntegerBetween(v: integer; i: integer; k: integer): boolean;
 
 // Add telnet client to this base class
 // Add property for IP address, port, type (tcp or udp but just implement tcp right now).
@@ -569,12 +568,12 @@ begin
       end;
   // logger.trace('In ModeToString, %d converted to %s',[Ord(mode), Result]);
 end;
-
+{ Moved to TF
 function IntegerBetween(v: integer; i: integer; k: integer): boolean;
 begin
    Result := (v >= i) and (v <= k);
 end;
-
+ }
 constructor TReadingThread.Create(AConn: TIdTCPConnection; proc: TProcessMsgRef);
 begin
   logger.debug('************* DEBUG: TReadingThread.Create');

--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -1,7 +1,7 @@
 unit uRadioElecraftK4;
 
 interface
-uses uNetRadioBase, StrUtils, SysUtils, Math;
+uses uNetRadioBase, StrUtils, SysUtils, Math, TF;
 
 
 Type TK4Radio = class(TNetRadioBase)

--- a/tr4w/src/uWSJTX.pas
+++ b/tr4w/src/uWSJTX.pas
@@ -954,16 +954,21 @@ begin
         else
         begin
           // Commander interface forces . as decimal for Get
-          DecimalSeparator := '.';
-          ThousandSeparator := ',';
-          sFreq := SysUtils.FormatFloat(',0.000',
-            radio1.CurrentStatus.VFO[VFOA].Frequency / 1000);
-          logger.Trace('[uWSJTX] Sending VFOA frequency: ' +
-            SysUtils.Format('<CmdFreq:%u>%s', [length(sFreq), sFreq]));
-          AContext.Connection.IOHandler.Write(SysUtils.Format('<CmdFreq:%u>%s',
-            [length(sFreq), sFreq]));
-          DecimalSeparator := SaveDecimalSeparator;
-          ThousandSeparator := saveThousandSeparator;
+          saveDecimalSeparator := DecimalSeparator;
+          saveThousandSeparator := ThousandSeparator;
+          try
+             DecimalSeparator := '.';
+             ThousandSeparator := ',';
+             sFreq := SysUtils.FormatFloat(',0.000',
+             radio1.CurrentStatus.VFO[VFOA].Frequency / 1000);
+             logger.Trace('[uWSJTX] Sending VFOA frequency: ' +
+                          SysUtils.Format('<CmdFreq:%u>%s', [length(sFreq), sFreq]));
+             AContext.Connection.IOHandler.Write(SysUtils.Format('<CmdFreq:%u>%s',
+                                                 [length(sFreq), sFreq]));
+          finally
+             DecimalSeparator := SaveDecimalSeparator;
+             ThousandSeparator := saveThousandSeparator;
+          end;
         end;
       end
       else if fieldValue = 'CmdSetFreq' then

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -6,6 +6,7 @@ uses
   MMSystem,
   Windows,
   iniFiles,
+  SysUtils,
   MainUnit in 'src\MainUnit.pas',
   BeepUnit in 'src\trdos\BeepUnit.pas',
   CFGCMD in 'src\trdos\CfgCmd.pas',
@@ -339,7 +340,7 @@ begin
 
    logger.info('******************** PROGRAM STARTUP ************************');
    logger.Trace('trace output');
-
+   logger.Info('DecimalSeparator = ' + DecimalSeparator);
   tMutex := CreateMutex(nil, False, tr4w_ClassName);
   if tMutex = 0 then
   begin
@@ -364,7 +365,6 @@ begin
   LuconSZLoadded := AddFontResource(TR4W_LC_FILENAME) <> 0;
   MainFixedFont := tCreateFont(15, FW_BOLD * Ord(BoldFont), @MainFontName[1]);
   MSSansSerifFont := tCreateFont(15, FW_DONTCARE, 'MS Sans Serif');
-
   CreateDirectoryIfNotExist;
 
 {$IF tDebugMode}
@@ -441,6 +441,7 @@ begin
 
   UpdateDebugLogLevel;
   logger.debug('**************** Program Startup ************************');
+  logger.info('DecimalSeparator = ' + DecimalSeparator);
   logger.debug('Current program version = %s',[TR4W_CURRENTVERSION]);
   logger.debug('Current TR4W Server version = %s',[TR4WSERVER_CURRENTVERSION]);
   logger.debug('Current log version = %s',[LOGVERSION]);


### PR DESCRIPTION
Fixed an issue where the band being sent in the UDP Contact record was shifted due to an array ordering issue.

Also fixed an issue where and if the band had a decimal (1.8, 3.5, 5.4), it was not localized as per the N1MM UDP documentation.

Also fixed a related issue where the DecimnalSeparator was set to . incorrectly when sending the whole log to UDP.

Added Try..Finally code around the kludge to reset the DecimalSeparator to ensure it is set back to the proper value for the locale.