### PR TITLE
Fixed VFOBumpUp and VFPBumpDown for Flex

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -1139,7 +1139,7 @@ begin
    case IntRadioType of
 
       TS140, TS440, TS450, TS480, TS570, TS590, TS690, TS850, TS870, TS940,
-      TS950, TS990, TS2000, FLEX:
+      TS950, TS990, TS2000:
          begin
          ActiveRadioPtr.AddToOutputBuffer {WriteBufferToCATPort}('UP;', 3);
          end;
@@ -1161,7 +1161,7 @@ begin
             CHR(0) + CHR(0) + CHR(0) + CHR(0) + CHR($02));
          end;
 
-      IC78..IC9700, OMNI6: {KK1L: 6.73 Added OMNI6}
+      IC78..IC9700, OMNI6, FLEX:
          begin
          if ActiveRadioPtr.CurrentStatus.Freq = 0 then
             begin
@@ -1216,7 +1216,7 @@ begin
    case IntRadioType of
 
       TS140, TS440, TS450, TS480, TS570, TS590, TS690, TS850, TS870, TS940,
-      TS950, TS990, TS2000, FLEX:
+      TS950, TS990, TS2000:
          begin
          ActiveRadioPtr.AddToOutputBuffer {WriteBufferToCATPort}('DN;', 3);
          end;
@@ -1238,7 +1238,7 @@ begin
             CHR(0) + CHR(0) + CHR(0) + CHR(0) + CHR($03));
          end;
 
-      IC78..IC9700, OMNI6: {KK1L: 6.73 Added OMNI6}
+      IC78..IC9700, OMNI6, FLEX:
          begin
          if ActiveRadioPtr.CurrentStatus.Freq = 0 then
             begin

--- a/tr4w/target/commands_help_eng.ini
+++ b/tr4w/target/commands_help_eng.ini
@@ -1101,7 +1101,7 @@ DESCRIPTION=Ethernet port number, which will used connection with TR4WSERVER.
 
 [SHIFT KEY ENABLE]
 DEFAULT=TRUE
-DESCRIPTION=The shift keys can be used to adjust the  frequency of Kenwood and some Yaesu rigs. To disable this feature, set this parameter to FALSE.
+DESCRIPTION=The shift keys can be used to adjust the frequency of Kenwood, Flex, Icom and some Yaesu rigs. To disable this feature, set this parameter to FALSE.
 
 [SHORT 0]
 DEFAULT=T


### PR DESCRIPTION
Moved FLEX option to where Icom radios are as they just add or subtract 20 Hz to the Active radio frequency. This is because Flex does not support UP; and DN; command. This closes issue #727