### PR TITLE
Fixed so we do not get port binding conflicts

### DIFF
--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -280,13 +280,13 @@ begin
 
   if QSONumberByBand then
      begin
-     logger.debug('In TotalContacts, (QSONumberByBand is true) returning ' + IntToStr(Result));
      Result := QSOTotals[ActiveBand, Both];
+     logger.debug('In TotalContacts, (QSONumberByBand is true) returning ' + IntToStr(Result));
      end
   else
      begin
-     logger.debug('In TotalContacts, (QSONumberByBand is false so AllBands) returning ' + IntToStr(Result));
      Result := QSOTotals[AllBands, Both];
+     logger.debug('In TotalContacts, (QSONumberByBand is false so AllBands) returning ' + IntToStr(Result));
      end;
 
 end;

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -469,7 +469,8 @@ implementation
 
 uses
   uCbrSum,
-  MainUnit;
+  MainUnit,
+  uCFG;
 
 procedure WriteADIFField(sFieldName: string; sFieldValue: string);
 var sBuffer: string;
@@ -2577,7 +2578,15 @@ begin
 
     if TempRXData.RSTSent < 25 then
        begin
-       RSTSent := PChar(SysUtils.Format('%d', [wsjtx.ConvertSNRToRST(TempRXData.RSTSent)]));
+       if WSJTXEnabled then
+          begin
+          RSTSent := PChar(SysUtils.Format('%d', [wsjtx.ConvertSNRToRST(TempRXData.RSTSent)]));
+          end
+       else
+          begin
+          RSTSent := PChar(SysUtils.Format('%d',[599]));
+          logger.info('RSTSent was less than 25 but WSJTXEnabled is FALSE');
+          end;
        end
     else
        begin
@@ -2587,7 +2596,14 @@ begin
     if (TempRXData.ExtMode in [eFT8, eMFSK, eJT65]) and
        (TempRXData.RSTReceived < 25)                then
        begin
-       RSTReceived := PChar(SysUtils.Format('%d', [wsjtx.ConvertSNRToRST(TempRXData.RSTReceived)]));
+       if WSJTXEnabled then
+          begin
+          RSTReceived := PChar(SysUtils.Format('%d', [wsjtx.ConvertSNRToRST(TempRXData.RSTReceived)]));
+          end
+       else
+          begin
+          RSTReceived := '599';
+          end;
        end
     else
        begin

--- a/tr4w/src/uOption.pas
+++ b/tr4w/src/uOption.pas
@@ -437,17 +437,23 @@ begin
        logger.Debug('Change of Foreground QSOB4 color');
        // Send colors for Dupes (QSOB4)
        //rgb := ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweBackG]);
-       wsjtx.SetDupeBackgroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweBackG]));
+       if assigned(wsjtx) then
+          begin
+          wsjtx.SetDupeBackgroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweBackG]));
        //rgb := ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweColor]);
-       wsjtx.SetDupeForegroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweColor]));
+          wsjtx.SetDupeForegroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweColor]));
+          end;
        end
     else if TWindows[TMainWindowElement(TempInteger)].mweName = 'MULT' then
        begin
        // Send colors for multipliers
        //rgb := ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweBackG]);
-       wsjtx.SetMultBackgroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweBackG]));
+       if assigned(wsjtx) then
+          begin
+          wsjtx.SetMultBackgroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweBackG]));
        //rgb := ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweColor]);
-       wsjtx.SetMultForegroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweColor]));
+          wsjtx.SetMultForegroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweNewMultStatus].mweColor]));
+          end;
        end;
 
 

--- a/tr4w/src/uWSJTX.pas
+++ b/tr4w/src/uWSJTX.pas
@@ -172,10 +172,11 @@ begin
   colorsMultFore.R := $00;
   colorsMultFore.G := $00;
   colorsMultFore.B := $00;
-  logger.Debug('[WSJT-X]Creating tcpServ on port %d',[FTCPPort]);
+
 
   if WSJTXRadioControlEnabled then
      begin
+     logger.Debug('[WSJT-X]Creating tcpServ on port %d',[FTCPPort]);
      tcpServ := TIdTCPServer.Create(nil);
      logger.Debug('[WSJT-X] Created tcpServ on port %d',[FTCPPort]);
      tcpServ.OnExecute := Self.IdTCPServer1Execute;

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -359,7 +359,10 @@ begin
 //  if TryToCheckTheLatestVersion then Exit;
 //{$IFEND}
 
-  wsjtx := TWSJTXServer.Create;
+  {if WSJTXEnabled then
+     begin
+     wsjtx := TWSJTXServer.Create;
+     end;   }               // Moved after we read the config file
   externalLogger := TExternalLogger.Create('DXKEEPER');
   TR4W_PATH_NAME[Windows.GetCurrentDirectory(SizeOf(TR4W_PATH_NAME), @TR4W_PATH_NAME)] := '\';
 
@@ -442,6 +445,10 @@ begin
   ReadInConfigFile(cfgCFG);          //n4af 4.31.5
   ReadInConfigFile(cfgCommMes);      //common messages gets precedence - n4af
 
+  if WSJTXEnabled then
+     begin
+     wsjtx := TWSJTXServer.Create;
+     end;
   externalLogger.loggerPort := externalLoggerPort;
   externalLOgger.loggerAddress := externalLoggerAddress;
   UpdateDebugLogLevel;
@@ -620,7 +627,8 @@ begin
 {$IFEND}
 
 
-
+   if WSJTXEnabled then
+      begin
    // Send colors for Dupes (QSOB4)
 
    wsjtx.SetDupeBackgroundColor(ColorToRGB(tr4wColorsArray[TWindows[mweQSOB4Status].mweBackG]));
@@ -635,6 +643,7 @@ begin
       begin
       wsjtx.Start;
       end;
+   end;
     {****************************  Main CallBack  ****************************}
 
   while (GetMessage(Msg, 0, 0, 0)) do


### PR DESCRIPTION
Even when the option WSJTXEnabled was false, the UDP port was still being bound. This caused a conflict when running with JTAlert.