### PR TITLE
Make external logger selectable

### DIFF
--- a/tr4w/src/trdos/LOGDOM.PAS
+++ b/tr4w/src/trdos/LOGDOM.PAS
@@ -36,6 +36,7 @@ utils_text,
 type
 
   RemainingMultDisplayModeType = (NoRemainingMults, Erase, HiLight);
+ // ExternalLogType = (NoExternalLogger, DXKeeper, ACLog, HRD);
 
   PrefixRecPtr = ^PrefixRec;
 
@@ -78,6 +79,7 @@ type
 procedure EnumDOMFILE(FileString: PShortString);
 const
   RemainingMultDisplayModeTypeSA        : array[RemainingMultDisplayModeType] of PChar = ('NONE', 'ERASE', 'HILIGHT');
+//  ExternalLogTypeSA                     : array[ExternalLogType] of PChar( = ('None', 'DXKeeper', 'ACLog', 'HRD');
 
 var
   ActiveDomesticMult                    : DomesticMultType {= NoDomesticMults};

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -1307,7 +1307,10 @@ begin
        end;
     if ExternalLoggerEnabled then
        begin
-       externalLogger.LogQSO(RXData);
+       if Assigned(externalLogger) then
+          begin
+          externalLogger.LogQSO(RXData);
+          end;
        end;
     perfTimeStop := Now;
     logger.Debug('Milliseconds to send UDP and TCP to external logger = %d',[DateUtils.MilliSecondsBetween(perfTimeStop, perfTimeStart)]);

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -61,7 +61,8 @@ uses
    VC,
    idUDPClient,
    idGlobal,
-   Log4D
+   Log4D,
+   uExternalLoggerBase
    ;
 
 type
@@ -234,7 +235,7 @@ const
       );
 
    {List}
-   ListParamArray: array[0..52] of ListParamRecord =
+   ListParamArray: array[0..53] of ListParamRecord =
       (
     {(*}
     (lpArray: @RateDisplayTypeStringArray;        lpLength: Byte(High(RateDisplayType));        lpVar: @RateDisplay; ),
@@ -247,7 +248,7 @@ const
     (lpArray: @InitialExchangeTypeStringArray;    lpLength: Byte(High(InitialExchangeType));    lpVar: @ActiveInitialExchange; ),
     (lpArray: @HourDisplayTypeSA;                 lpLength: Byte(High(HourDisplayType));        lpVar: @HourDisplay; ),
     (lpArray: @FootSwitchModeTypeStringArray;     lpLength: Byte(High(FootSwitchModeType));     lpVar: @FootSwitchMode; ),
-    (lpArray: @ActiveExchangeArray;               lpLength: Byte(High(ExchangeType));           lpVar: @ActiveExchange; ),
+{10}(lpArray: @ActiveExchangeArray;               lpLength: Byte(High(ExchangeType));           lpVar: @ActiveExchange; ),
     (lpArray: @DXMultTypenameArray;               lpLength: Byte(High(DXMultType));             lpVar: @ActiveDXMult; ),
     (lpArray: @DupeCheckSoundTypeSA;              lpLength: Byte(High(DupeCheckSoundType));     lpVar: @DupeCheckSound; ),
     (lpArray: @DomesticMultStringArray;           lpLength: Byte(High(DomesticMultType));       lpVar: @ActiveDomesticMult; ),
@@ -257,7 +258,7 @@ const
     (lpArray: @RotatorTypeSA;                     lpLength: Byte(High(RotatorType));            lpVar: @ActiveRotatorType; ),
     (lpArray: @TenMinuteRuleTypeSA;               lpLength: Byte(High(TenMinuteRuleType));      lpVar: @TenMinuteRule; ),
     (lpArray: @UserInfoTypeSA;                    lpLength: Byte(High(UserInfoType));           lpVar: @UserInfoShown; ),
-    (lpArray: @DistanceDisplayTypeSA;             lpLength: Byte(High(DistanceDisplayType));    lpVar: @DistanceMode; ),
+{20}(lpArray: @DistanceDisplayTypeSA;             lpLength: Byte(High(DistanceDisplayType));    lpVar: @DistanceMode; ),
     (lpArray: @ContinentTypeSA;                   lpLength: Byte(High(ContinentType));          lpVar: @MyContinent; ),
     (lpArray: @ContestTypeSA;                     lpLength: Byte(High(ContestType));            lpVar: @Contest; ),
     (lpArray: @ZoneMultTypeSA;                    lpLength: Byte(High(ZoneMultType));           lpVar: @ActiveZoneMult; ),
@@ -268,7 +269,7 @@ const
 
     (lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio1.tr4w_cat_rts_state; ),
     (lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio1.tr4w_cat_dtr_state; ),
-    (lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio1.tr4w_keyer_rts_state; ),
+{30}(lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio1.tr4w_keyer_rts_state; ),
     (lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio1.tr4w_keyer_DTR_state; ),
 
     (lpArray: @tr4w_RTSDTRTypeSA;                 lpLength: Byte(High(tr4w_RTSDTRType));        lpVar: @Radio2.tr4w_cat_rts_state; ),
@@ -282,7 +283,7 @@ const
     (lpArray: @PortTypeSA;                        lpLength: Byte(High(PortType));               lpVar: @Radio1.tKeyerPort; ),
     (lpArray: @PortTypeSA;                        lpLength: Byte(High(PortType));               lpVar: @Radio2.tKeyerPort; ),
 
-    (lpArray: @PortTypeSA;                        lpLength: Byte(High(PortType));               lpVar: @ActiveRotatorPort; ),
+{40}(lpArray: @PortTypeSA;                        lpLength: Byte(High(PortType));               lpVar: @ActiveRotatorPort; ),
     (lpArray: @MP3RecorderDurationSA;             lpLength: Byte(High(TMP3RecorderDuration));   lpVar: @RecorderDuration; ),
 
     (lpArray: @tCategoryBandSA;                   lpLength: Byte(High(tCategoryBand));          lpVar: @CategoryBand; ),
@@ -295,9 +296,10 @@ const
     (lpArray: @SidetoneFrequencySA;               lpLength: Byte(High(TWKSidetoneFrequency));   lpVar: @WinKeySettings.wksValueList.vlSidetoneFrequency; ),
 
     (lpArray: @tCategoryTransmitterSA;            lpLength: Byte(High(tCategoryTransmitter));   lpVar: @CategoryTransmitter;),
-    (lpArray: @tCategoryAssistedSA;               lpLength: Byte(High(tCategoryAssisted));      lpVar: @CategoryAssisted;),
+{50}(lpArray: @tCategoryAssistedSA;               lpLength: Byte(High(tCategoryAssisted));      lpVar: @CategoryAssisted;),
     (lpArray: @tCertificateSA;                    lpLength: Byte(High(tCertificate));           lpVar: @Certificate;),
-    (lpArray: @tLogLevelsSA;                         lpLength: Byte(High(tLogLevels));           lpVar: @logLevels;)
+    (lpArray: @tLogLevelsSA;                      lpLength: Byte(High(tLogLevels));             lpVar: @logLevels;),
+    (lpArray: @ExternalLoggerTypeSA;              lplength: Byte(High(ExternalLoggerType));     lpVar: @elLogType;)
     {*)}
       );
 
@@ -336,6 +338,7 @@ const
    + 2 {Radio1 and Radio2 KEYER STOP BITS} // Issue 678 ny4i
    + 6 {HAMLIBPATH, Radio ONE HAMLIB ID, Radio 2 HAMLIB ID, HAMLIB RIGCTLD IP ADDRESS, HAMLIB RIGCTLD PORT, HAMLIB RIGCTLD RUN AT STARTUP}
    + 3 {ExternalLoggerAddress & ExernalLoggerPort & ExternalLoggerEnabled}
+   + 1 {ExternalLogger}
    ;
 
    // Note if crAddress says pointer(NN), then it is calling a function at position NN in the an array
@@ -457,6 +460,10 @@ const
  (crCommand: 'EXCHANGE MEMORY ENABLE';        crAddress: @ExchangeMemoryEnable;           crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'EXCHANGE RECEIVED';             crAddress: pointer(10);                     crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 2; crKind: ckList; cfFunc: cfAll; crType: ctOther; crNetwork: 1),
  (crCommand: 'EXCHANGE WINDOW S&P BACKGROUND';crAddress: pointer(48);                     crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:10; crJ: 0; crKind: ckList;    cfFunc: cfAll; crType: ctOther; crNetwork: 1),
+
+ (crCommand: 'EXTERNAL LOGGER';               crAddress: pointer(53);                     crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:2; crJ: 0; crKind: ckList; cfFunc: cfAll; crType: ctOther; crNetwork: 0),
+
+
  (crCommand: 'EXTERNAL LOGGER ADDRESS';       crAddress: @ExternalLoggerAddress;          crMin:0;  crMax:255;     crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal;  cfFunc: cfAll; crType: ctString; crNetwork: 0),
  (crCommand: 'EXTERNAL LOGGER ENABLED';       crAddress: @ExternalLoggerEnabled;          crMin:0;  crMax:0;         crS: csNew; crA: 23; crC:0; crP:0; crJ: 1; crKind: ckNormal; cfFunc: cfAll; crType: ctBoolean; crNetwork: 0),
  (crCommand: 'EXTERNAL LOGGER PORT';          crAddress: @ExternalLoggerPort;             crMin:1;  crMax:65535;   crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 0),

--- a/tr4w/src/uExternalLoggerBase.pas
+++ b/tr4w/src/uExternalLoggerBase.pas
@@ -27,6 +27,10 @@ function BoolToString(b: boolean): string;
 // Add property for IP address, port, type (tcp or udp but just implement tcp right now).
 // Add a connect and disconnect method
 
+Type ExternalLoggerType = (lt_NoExternalLogger, lt_DXKeeper, lt_ACLog, lt_HRD);
+
+const ExternalLoggerTypeSA                     : array[ExternalLoggerType] of PChar = ('NONE', 'DXKEEPER', 'ACLOG', 'HRD');
+
 Type TExternalLoggerBase = class(TObject)
    private
       //socket: TIdTCPClient;
@@ -43,7 +47,7 @@ Type TExternalLoggerBase = class(TObject)
       procedure SetLoggerID (Value: string);
       function GetLoggerAddress: string;
       procedure SetLoggerAddress(Value: string);
-      function GetISConnected: boolean;
+      function GetIsConnected: boolean;
       procedure OnLoggerConnected(Sender:TObject);
       procedure OnLoggerDisconnected(Sender: TObject);
       procedure OnLoggerStatus(Sender: TObject; const Status: TIdStatus; const AStatusText: string);
@@ -52,6 +56,8 @@ Type TExternalLoggerBase = class(TObject)
       readTerminator: string;
       socket: TIdTCPClient;
       procRef: TProcessMsgRef;
+      logTypeSet: boolean;
+      logType: ExternalLoggerType;
 
    public
       constructor Create(ProcRef: TProcessMsgRef); overload;
@@ -75,10 +81,11 @@ Type TExternalLoggerBase = class(TObject)
 
 end;
 
-
+var elLogType: ExternalLoggerType;
 implementation
 
 Uses MainUnit;
+
 
 Constructor TExternalLoggerBase.Create(ProcRef: TProcessMsgRef);
 begin

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -363,7 +363,7 @@ begin
      begin
      wsjtx := TWSJTXServer.Create;
      end;   }               // Moved after we read the config file
-  externalLogger := TExternalLogger.Create('DXKEEPER');
+  //externalLogger := TExternalLogger.Create('DXKEEPER');
   TR4W_PATH_NAME[Windows.GetCurrentDirectory(SizeOf(TR4W_PATH_NAME), @TR4W_PATH_NAME)] := '\';
 
  Format(TR4W_INI_FILENAME, '%ssettings\tr4w.ini', TR4W_PATH_NAME);
@@ -449,8 +449,12 @@ begin
      begin
      wsjtx := TWSJTXServer.Create;
      end;
-  externalLogger.loggerPort := externalLoggerPort;
-  externalLOgger.loggerAddress := externalLoggerAddress;
+  if elLogType <> lt_NoExternalLogger then
+     begin
+     externalLogger := TExternalLogger.Create(elLogType);
+     externalLogger.loggerPort := externalLoggerPort;
+     externalLogger.loggerAddress := externalLoggerAddress;
+     end;
   UpdateDebugLogLevel;
   logger.debug('**************** Program Startup ************************');
   logger.info('DecimalSeparator = ' + DecimalSeparator);


### PR DESCRIPTION
Adds more framework code to support logging to external loggers. This only works with DXKeeper for now, but the shell function is there for ACLog and HRD. Perhaps someone that wants that option will write the code to implement those options. If someone asks for the other loggers, then we can look more into doing it.