### PR TITLE
[Issue#813] Ensure at least one space after MyCall

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -2738,7 +2738,7 @@ if TempRXData.DomMultQTH = '' then
             push ModeString
             push Freq
       end;
-      wsprintf(CABRILLO_FIRST_PART, 'QSO: %5s %s %d-%02d-%02d %02d%02d %-8s');
+      wsprintf(CABRILLO_FIRST_PART, 'QSO: %5s %s %d-%02d-%02d %02d%02d %-7s ');
       asm add esp,40
       end;
 {


### PR DESCRIPTION
This makes identical output for MyCall shorter than 8 chars. And there will be additional space for longer MyCall.

However, the field should be 15 chracters long.