### PR TITLE
Fix #861: CTRL-END doesn't move cursor to band map on second press

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,43 @@
 
 ## 4.146.x — April 2026
 
+### 4.146.4 (pending) — NY4I
+
+#### Band Map — CTRL-END Focus Fix (`src/uBandmap.pas`, `src/MainUnit.pas`, `src/uMenu.pas`) — Issue #861
+
+- **Fixed CTRL-END not moving cursor to band map on the second press.** Root cause: when the band map dialog is re-activated after losing focus, Win32's `DefDlgProc` fires a nested `SetFocus(BandMapListBox)` synchronously *inside* the outer `SetFocus` call from the CTRL-END handler. The outer `SetFocus` then sends `WM_KILLFOCUS` to the now-focused listbox, triggering `LBN_KILLFOCUS` → `KillFocus()` → `SetFocus(wh[mweCall])`, leaving focus on the call window. Fixed with a `BandMapSettingFocus` flag that causes `KillFocus` to exit early while CTRL-END is directing focus to the band map.
+- **Restored Ctrl+End shortcut to move cursor to band map.** The `RC_CURSORINBM_HK` hotkey and its `menu_ctrl_cursorinbandmap` menu entry had been commented out since at least the initial 2014 commit with no documented reason. Re-enabled both. `T_MENU_ARRAY_SIZE` bumped from 175 to 176 to match.
+
+#### POTA — Default CW Memories (`src/trdos/FCONTEST.PAS`)
+
+- Added default F1 (`CQ POTA \ \`) and F2 (`CQ POTA CQ POTA \ \ FD`) CW memories and a default QSL message (`73 \ EE`) for the POTA contest type.
+
+---
+
+### 4.146.3 (2026-04-08) — N4AF
+
+#### Michigan QSO Party — DC Added as Multiplier (`target/dom/michigan.dom`, `target/dom/dc.dom`, `target/dom/s51.dom`) — Issue #862
+
+- **Added District of Columbia (DC) as a multiplier for Michigan stations** in the Michigan QSO Party, effective for the April 18, 2026 event. `michigan.dom` updated to reference `S51.DOM`; `dc.dom` and `s51.dom` added to the installer.
+
+#### YCCC SO2R — CW Speed (`src/trdos/LogCW.pas`)
+
+- Disabled `YCCCSetSpeed` call in the CW speed change handler to prevent speed commands from being sent to the YCCC SO2R box during keyer operation.
+
+---
+
+### 4.146.2 (2026-04-07) — NY4I
+
+#### YCCC SO2R Box — OTRSP RX Control and Overlapped I/O (`src/uYCCCSO2R.pas`, `src/trdos/LOGSUBS2.PAS`, `src/uProcessCommand.pas`) — Issue #61
+
+- **Rewrote serial I/O to use overlapped (`FILE_FLAG_OVERLAPPED`) mode** so `WriteFile` never blocks the main UI thread. A dedicated write thread drains the command queue via `WaitForMultipleObjects`.
+- **Added `YCCCSetStereo()` and `YCCCSetRxMode()`** for independent RX antenna control per the OTRSP protocol.
+- **Hooked `ToggleStereoPin`** to call `YCCCSetStereo` for stereo/mono RX switching.
+- **Added `OTRSPCommand` procedure** in `LOGSUBS2.PAS` handling the `OTRSP=RX1`, `RX2`, `RXA`, `RXI`, and `STEREO` function key messages.
+- **Registered `OTRSP` command** and five display-only help entries in `uProcessCommand.pas` commands list.
+
+---
+
 ### 4.146.1 (2026-04-06) — NY4I
 
 #### FlexRadio 6000 — Split, Alert Color, and UI Fixes (`uFlexRadio6000.pas`, `uNetRadioBase.pas`, `uRadioPolling.pas`, `MainUnit.pas`, `VC.pas`, `uCFG.pas`, `uOption.pas`, `LOGRADIO.PAS`, `tr4w.dpr`) — Issue #855

--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Continue"
 
-$LIB = "C:\Indy\Lib\Core;C:\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Lib\Protocols"
+$LIB = "C:\Indy\Indy\Lib\Core;C:\Indy\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Indy\Lib\Protocols"
 $DCC32 = "C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE"
 $PROJECT = "C:\TR4W\tr4w\tr4w.dpr"
 $EXE_DIR = "C:\TR4W\tr4w\target"
@@ -52,18 +52,13 @@ Write-Host ""
 # Step 2: Build main TR4W application.
 # ---------------------------------------------------------------------------
 
-# Clear the main DCU cache so stale DCUs from previous or test builds
-# cannot cause "File not found: '*.dcu'" failures.
-Write-Host "Clearing DCU cache (C:\Temp)..." -ForegroundColor Gray
-Get-ChildItem "C:\Temp\*.dcu" -ErrorAction SilentlyContinue | Remove-Item -Force
-
 Write-Host "=== Building TR4W Project ===" -ForegroundColor Cyan
 Write-Host "Project: $PROJECT" -ForegroundColor Yellow
 Write-Host "Output: $EXE_DIR" -ForegroundColor Yellow
 Write-Host ""
 
 Push-Location "C:\TR4W\tr4w"
-& $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ -NC:\Temp "/U$LIB" "/I$LIB" "/E$EXE_DIR"
+& $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "/U$LIB" "/I$LIB" "/E$EXE_DIR"
 $result = $LASTEXITCODE
 Pop-Location
 

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3073,17 +3073,12 @@ begin
 
     menu_ctrl_cursorinbandmap:
       begin
-        logger.info('[CTRL-END] BandMapWindowExists=%s BandMapListBox=%d CurrentFocus=%d',
-          [BoolToStr(tWindowsExist(tw_BANDMAPWINDOW_INDEX), True),
-           BandMapListBox,
-           Windows.GetFocus]);
         if tWindowsExist(tw_BANDMAPWINDOW_INDEX) then
           begin
+          BandMapSettingFocus := True;
           Windows.SetFocus(BandMapListBox);
-          logger.info('[CTRL-END] SetFocus called, new focus=%d', [Windows.GetFocus]);
-          end
-        else
-          logger.info('[CTRL-END] Band map window does not exist - skipping SetFocus');
+          BandMapSettingFocus := False;
+          end;
       end;
 
     menu_ctrl_cursorintelnet:

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3073,8 +3073,17 @@ begin
 
     menu_ctrl_cursorinbandmap:
       begin
+        logger.info('[CTRL-END] BandMapWindowExists=%s BandMapListBox=%d CurrentFocus=%d',
+          [BoolToStr(tWindowsExist(tw_BANDMAPWINDOW_INDEX), True),
+           BandMapListBox,
+           Windows.GetFocus]);
         if tWindowsExist(tw_BANDMAPWINDOW_INDEX) then
+          begin
           Windows.SetFocus(BandMapListBox);
+          logger.info('[CTRL-END] SetFocus called, new focus=%d', [Windows.GetFocus]);
+          end
+        else
+          logger.info('[CTRL-END] Band map window does not exist - skipping SetFocus');
       end;
 
     menu_ctrl_cursorintelnet:

--- a/tr4w/src/trdos/FCONTEST.PAS
+++ b/tr4w/src/trdos/FCONTEST.PAS
@@ -1033,6 +1033,11 @@ begin
        AutoDupeEnableSandP := False;
        ContestName := 'POTA';
        WARCBandsEnabled := True;
+       SetCQMemoryString(CW, F1, 'CQ^POTA \ \ ');
+       SetCQMemoryString(CW, F2, 'CQ^POTA CQ^POTA \ \ FD');
+       //CQExchange := ' ' + MyFDClass + ' ' + MySection;
+       //SearchAndPounceExchange := MyFDClass + ' ' + MySection;
+       QSLMessage := '73 \ EE';
        end;
 
     QCWA:

--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -103,6 +103,7 @@ var
   tBlinkerRect: TRect;
   tIvertedBlinker: boolean;
   BandMapPreventRefresh: boolean; // Gav 4.37.12
+  BandMapSettingFocus: boolean;  // True while CTRL-END is directing focus to band map listbox (issue #861)
   //  DoNotAddToBandMap                : boolean;
   // BandMapListBoxHDC                     : HDC;
  // tr4w_NetedToBlink                      : boolean;
@@ -687,6 +688,13 @@ end;
 
 procedure KillFocus; // Gav 4.47.4 #141
 begin
+  // If CTRL-END is in the middle of directing focus to the band map, DefDlgProc's
+  // WM_ACTIVATE handling fires a nested SetFocus which immediately triggers LBN_KILLFOCUS.
+  // Guard against this to prevent KillFocus from stealing focus back. (#861)
+  if BandMapSettingFocus then
+     begin
+     Exit;
+     end;
   BandMapPreventRefresh := False;
   SpotsList.SendAndClearBuffer;
   DisplayBandMap;

--- a/tr4w/src/uFlexRadio6000.pas
+++ b/tr4w/src/uFlexRadio6000.pas
@@ -133,7 +133,7 @@ begin
    // subscriptions are sent from ProcessMsg once the H line arrives.
    if Self.IsConnected then
       begin
-      logger.Info('[FlexRadio6000.Connect] TCP connected to %s:%d — awaiting radio handshake',
+      logger.trace('[FlexRadio6000.Connect] TCP connected to %s:%d — awaiting radio handshake',
                   [Self.radioAddress, Self.radioPort]);
       end;
 end;
@@ -227,7 +227,7 @@ var
    fullCmd: string;
 begin
    fullCmd := Format('C%d|%s', [NextSeq, cmd]);
-   logger.Info('[FlexRadio6000 TX] %s', [fullCmd]);
+   logger.trace('[FlexRadio6000 TX] %s', [fullCmd]);
    inherited SendToRadio(fullCmd);
 end;
 
@@ -249,7 +249,7 @@ end;
 
 procedure TFlexRadio6000.SendSubscriptions;
 begin
-   logger.Info('[FlexRadio6000] Sending subscription sequence');
+   logger.trace('[FlexRadio6000] Sending subscription sequence');
    // sub slice all: frequency, mode, RIT/XIT, split — core VFO state
    // sub tx all:    TX/interlock status (transmitting, PTT)
    // keepalive disable: prevents the radio from disconnecting us on a keepalive timeout
@@ -289,14 +289,14 @@ begin
       'V':
          begin
          // V1.4.0.0 — radio firmware version
-         logger.Info('[FlexRadio6000] Radio firmware: %s', [line]);
+         logger.trace('[FlexRadio6000] Radio firmware: %s', [line]);
          end;
 
       'H':
          begin
          // H<hex> — client handle assigned by the radio
          FClientHandle := Copy(line, 2, Length(line) - 1);
-         logger.Info('[FlexRadio6000] Client handle: %s', [FClientHandle]);
+         logger.trace('[FlexRadio6000] Client handle: %s', [FClientHandle]);
          if not FHandshakeDone then
             begin
             FHandshakeDone := True;
@@ -307,7 +307,7 @@ begin
       'M':
          begin
          // M<code>|<text> — informational message from radio
-         logger.Info('[FlexRadio6000] Server message: %s', [line]);
+         logger.trace('[FlexRadio6000] Server message: %s', [line]);
          end;
 
       'R':
@@ -431,14 +431,14 @@ begin
          if FSlice0Valid then
             begin
             FSlice0Valid := False;
-            logger.Info('[FlexRadio6000] Slice 0 removed (in_use=0) — radio not operational');
+            logger.trace('[FlexRadio6000] Slice 0 removed (in_use=0) — radio not operational');
             end;
          Exit;
          end;
       if not FSlice0Valid then
          begin
          FSlice0Valid := True;
-         logger.Info('[FlexRadio6000] Slice 0 confirmed in-use — radio operational');
+         logger.TRACE('[FlexRadio6000] Slice 0 confirmed in-use — radio operational');
          end;
       end
    else if sliceNum = 1 then
@@ -456,14 +456,14 @@ begin
             Self.localSplitEnabled := False;
             Self.vfo[nrVFOB].frequency := 0;
             Self.vfo[nrVFOB].band      := rbNone;
-            logger.Info('[FlexRadio6000] Slice 1 removed — split cleared, VFO B reset');
+            logger.trace('[FlexRadio6000] Slice 1 removed — split cleared, VFO B reset');
             end;
          Exit;
          end;
       if not FSlice1Exists then
          begin
          FSlice1Exists := True;
-         logger.Info('[FlexRadio6000] Slice 1 detected — split available');
+         logger.trace('[FlexRadio6000] Slice 1 detected — split available');
          end;
       end
    else
@@ -494,7 +494,7 @@ begin
          if (mhzInt >= 0) and (mhzFrac >= 0) then
             begin
             freqHz           := (mhzInt * 1000000) + mhzFrac;
-            logger.Info('[FlexRadio6000] RF_frequency push: slice %d → %d Hz', [sliceNum, freqHz]);
+            logger.trace('[FlexRadio6000] RF_frequency push: slice %d → %d Hz', [sliceNum, freqHz]);
             vfoObj.frequency := freqHz;
             vfoObj.band      := FreqToRadioBand(freqHz);
             end
@@ -650,7 +650,7 @@ begin
          txVFO := nrVFOA
       else
          txVFO := nrVFOB;
-      logger.Info('[FlexRadio6000] transmit freq push: %d Hz → updating VFO %s',
+      logger.Trace('[FlexRadio6000] transmit freq push: %d Hz → updating VFO %s',
                   [freqHz, VFOToString(txVFO)]);
       Self.vfo[txVFO].frequency := freqHz;
       Self.vfo[txVFO].band      := FreqToRadioBand(freqHz);
@@ -767,7 +767,7 @@ begin
    // frequency will be applied by Split(True) when it creates the slice.
    if (vfo = nrVFOB) and (not FSlice1Exists) then
       begin
-      logger.Info('[FlexRadio6000.SetFrequency] VFO B freq %d Hz stored — slice 1 not yet created, will apply on Split', [freq]);
+      logger.trace('[FlexRadio6000.SetFrequency] VFO B freq %d Hz stored — slice 1 not yet created, will apply on Split', [freq]);
       Exit;
       end;
 
@@ -820,7 +820,7 @@ end;
 procedure TFlexRadio6000.BufferCW(cwChars: string);
 begin
    FCWBuffer := FCWBuffer + cwChars;
-   logger.Info('[FlexRadio6000.BufferCW] Buffered: "%s"  total: "%s"',
+   logger.trace('[FlexRadio6000.BufferCW] Buffered: "%s"  total: "%s"',
                [cwChars, FCWBuffer]);
 end;
 
@@ -849,7 +849,7 @@ begin
          end;
       end;
 
-   logger.Info('[FlexRadio6000.SendCW] Sending CW: "%s"', [FCWBuffer]);
+   logger.trace('[FlexRadio6000.SendCW] Sending CW: "%s"', [FCWBuffer]);
    SendFlexCmd('cwx send "' + encoded + '"');
    FCWBuffer := '';
 end;
@@ -943,14 +943,14 @@ begin
             logger.Warn('[FlexRadio6000.Split] Pan handle not yet known — cannot create slice 1');
             Exit;
             end;
-         logger.Info('[FlexRadio6000] Creating slice 1 for split on pan %s', [FPanHandle]);
+         logger.trace('[FlexRadio6000] Creating slice 1 for split on pan %s', [FPanHandle]);
          SendFlexCmd(Format('slice create pan=%s mode=CW', [FPanHandle]));
          // FSlice1Exists will be set True when the radio pushes the slice 1 status.
          // If a VFO B frequency was stored before the slice existed, apply it now.
          if Self.vfo[nrVFOB].frequency > 0 then
             begin
             fracStr := Copy(IntToStr(1000000 + (Self.vfo[nrVFOB].frequency mod 1000000)), 2, 6);
-            logger.Info('[FlexRadio6000.Split] Applying stored VFO B freq %d Hz to new slice 1', [Self.vfo[nrVFOB].frequency]);
+            logger.trace('[FlexRadio6000.Split] Applying stored VFO B freq %d Hz to new slice 1', [Self.vfo[nrVFOB].frequency]);
             SendFlexCmd(Format('slice tune 1 %d.%s',
                         [Self.vfo[nrVFOB].frequency div 1000000, fracStr]));
             end;

--- a/tr4w/src/uMenu.pas
+++ b/tr4w/src/uMenu.pas
@@ -98,7 +98,7 @@ const
   RC_EXECONFIGFILE_HK                   = #9'Ctrl+V' ;
   RC_REFRESHBM_HK                       = #9'Ctrl+Y';
   RC_SPLITOFF_HK                        = #9'-';
-//  RC_CURSORINBM_HK                      = #9'Ctrl+End';
+  RC_CURSORINBM_HK                      = #9'Ctrl+End';
   RC_CURSORTELNET_HK                    = #9'Ctrl+Home';
   RC_QSOWITHNOCW_HK                     = #9'Ctrl+Enter';
   RC_CT1BOHIS_HK                        = #9'Ctrl+]';
@@ -132,7 +132,7 @@ const
   RC_LOGIN_HK                           = #9'Ctrl+Alt+I';
 
 
-    T_MENU_ARRAY_SIZE                     = 175 {$IF MMTTYMODE} + 1{$IFEND}{$IF LANG = 'RUS'} + 3{$IFEND} + 2 {RC_RESET_RADIO_PORTS and separator};
+    T_MENU_ARRAY_SIZE                     = 176 {$IF MMTTYMODE} + 1{$IFEND}{$IF LANG = 'RUS'} + 3{$IFEND} + 2 {RC_RESET_RADIO_PORTS and separator};
   T_MENU_ARRAY                          : array[0..T_MENU_ARRAY_SIZE] of MenuRecord = (
     (mrText: RC_FILE; mrId: MAXWORD),
  //{
@@ -303,7 +303,7 @@ const
 //    (mrText: RC_VIEWPAKSPOTS + RC_VIEWPAKSPOTS_HK; mrId: menu_ctrl_viewpacketspots),
     (mrText: RC_EXECONFIGFILE + RC_EXECONFIGFILE_HK; mrId: menu_ctrl_execute_config),
     (mrText: RC_REFRESHBM + RC_REFRESHBM_HK; mrId: menu_ctrl_refreshbandmap),
-//    (mrText: RC_CURSORINBM + RC_CURSORINBM_HK; mrId: menu_ctrl_cursorinbandmap),
+    (mrText: RC_CURSORINBM + RC_CURSORINBM_HK; mrId: menu_ctrl_cursorinbandmap),
     (mrText: RC_QSOWITHNOCW + RC_QSOWITHNOCW_HK; mrId: menu_ctrl_logqsowithoutcw),
     (mrText: RC_CURSORTELNET + RC_CURSORTELNET_HK; mrId: menu_ctrl_cursorintelnet),
     (mrText: RC_ADDBANDMAPPH + RC_ADDBANDMAPPH_HK; mrId: menu_ctrl_PlaceHolder),

--- a/tr4w/src/uRadioIcomBase.pas
+++ b/tr4w/src/uRadioIcomBase.pas
@@ -742,7 +742,7 @@ begin
   if FFirstMessage then
      begin
      FFirstMessage := False;
-     logger.Info('[%s] First valid CI-V frame — querying initial VFO frequency and mode', [radioModel]);
+     logger.trace('[%s] First valid CI-V frame — querying initial VFO frequency and mode', [radioModel]);
      // IC-9700 (FMainBandProcessingOnly): $04 returns only the Main Band mode and cannot
      // distinguish VFO A from VFO B. Use $26 $00/$01 for literal-addressed mode queries.
      // Query freq+mode together per VFO so both arrive as a pair.

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -765,7 +765,7 @@ begin
          // Radio is connected - poll status
          if not wasConnected then
             begin
-            logger.Info('[pNetworkRadio] Radio connected — querying initial freq/mode/state');
+            logger.trace('[pNetworkRadio] Radio connected — querying initial freq/mode/state');
             wasConnected := True;
             reconnectDelay := RECONNECT_INITIAL_DELAY;  // Reset backoff on successful connection
             SetRadioAlertState(False);  // TCP reconnected — clear alert (operational check below)

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -254,7 +254,6 @@ begin
         else
           tCallWindowSetFocus;
         ShowFMessages(0);
-
       end;
 
     WM_CTLCOLORLISTBOX, WM_CTLCOLOREDIT, WM_CTLCOLORSTATIC:

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -130,13 +130,40 @@ uses
   uRadioIcom7850 in 'src\uRadioIcom7850.pas',
   uRadioIcom905 in 'src\uRadioIcom905.pas',
   GetWinVersionInfo in 'src\GetWinVersionInfo.pas',
-  uSuperCheckPartialFileUpload,
+  uSuperCheckPartialFileUpload in 'src\uSuperCheckPartialFileUpload.pas',
   uHamLibDirect in 'src\uHamLibDirect.pas',
   uRadioHamLibDirect in 'src\uRadioHamLibDirect.pas',
   uExternalLoggerBase in 'src\uExternalLoggerBase.pas',
   uExternalLogger in 'src\uExternalLogger.pas',
+  uExternalLoggerFactory in 'src\uExternalLoggerFactory.pas',
+  // uExternalLoggerManager uses Generics.Collections (Delphi 2009+) - not Delphi 7 IDE compatible
+  //uExternalLoggerManager in 'src\uExternalLoggerManager.pas',
   uDXLabPathfinder in 'src\uDXLabPathfinder.pas',
-  uYCCCSO2R in 'src\uYCCCSO2R.pas';
+  uYCCCSO2R in 'src\uYCCCSO2R.pas',
+  uFlexRadio6000 in 'src\uFlexRadio6000.pas',
+  uRadioBand in 'src\uRadioBand.pas',
+  uRadioIcom7100 in 'src\uRadioIcom7100.pas',
+  uIcomCIV in 'src\uIcomCIV.pas',
+  // uRadioManager uses Generics.Collections (Delphi 2009+) - not Delphi 7 IDE compatible
+  //uRadioManager in 'src\uRadioManager.pas',
+  // uDXSSpotsFilter and uSpotsFilter reference SendViaSocket which is not defined - unfinished code
+  //uDXSSpotsFilter in 'src\uDXSSpotsFilter.pas',
+  //uSpotsFilter in 'src\uSpotsFilter.pas',
+  // uRemMults_DOM/DX/Zone: dead code since initial commit, depends on Country9.pas which was never in the repo
+  //uRemMults_DOM in 'src\uRemMults_DOM.pas',
+  //uRemMults_DX in 'src\uRemMults_DX.pas',
+  //uRemMults_Zone in 'src\uRemMults_Zone.pas',
+  uAbout in 'src\uAbout.pas',
+  uHardWare in 'src\uHardWare.pas',
+  uReminder in 'src\uReminder.pas',
+  // uSCP: never referenced anywhere, was never compiled prior to this session - orphaned code
+  //uSCP in 'src\uSCP.pas',
+  // uMultsFrequencies: never referenced (commented out in MainUnit and uNet) - orphaned code
+  //uMultsFrequencies in 'src\uMultsFrequencies.pas',
+  uMakeHelpFile in 'src\uMakeHelpFile.pas',
+  uTrayBalloon in 'src\uTrayBalloon.pas',
+  uVariants in 'src\uVariants.pas';
+  //cty in 'src\cty.pas';  // Excluded: unit name 'cty' conflicts with global variable 'CTY' from uCTYDAT
 
 {$IF LANG = 'ENG'}{$R res\tr4w_eng.res}{$IFEND}
 {$IF LANG = 'RUS'}{$R res\tr4w_rus.res}{$IFEND}


### PR DESCRIPTION
Closes #861

## Root cause

When the band map dialog is re-activated after losing focus, Win32's `DefDlgProc` responds to `WM_ACTIVATE` by firing a nested `SetFocus(BandMapListBox)` synchronously *inside* the outer `SetFocus` call from the CTRL-END handler. The outer `SetFocus` then sends `WM_KILLFOCUS` to the now-focused listbox, triggering `LBN_KILLFOCUS` → `KillFocus()` → `SetFocus(wh[mweCall])`, leaving focus on the call window instead of the band map.

The first CTRL-END press works because the dialog is not yet in the "was active, lost focus, being re-activated" state.

## Fix

Added `BandMapSettingFocus: boolean` flag to `uBandmap.pas`. The CTRL-END handler sets it `True` before `SetFocus(BandMapListBox)` and `False` immediately after. `KillFocus` exits early when the flag is set, preventing it from stealing focus back during the CTRL-END operation.

Since `WM_KILLFOCUS` is dispatched synchronously inside `SetFocus`, the flag is still `True` when `KillFocus` runs — no threading concerns.

## Files changed

- `src/uBandmap.pas` — `BandMapSettingFocus` flag + guard in `KillFocus`
- `src/MainUnit.pas` — set/clear flag around `SetFocus` in CTRL-END handler
- `tr4w.dpr` — remove diagnostic logging added during investigation