### PR TITLE
Band map flicker reduction, spot deletion fix, radio logging cleanup

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -263,6 +263,8 @@ procedure PTTOffWhenStopWAV(uTimerID, uMessage: UINT; dwUser, dw1, dw2: DWORD)
   stdcall;
 procedure OneSecTimerProc(uTimerID, uMessage: UINT; dwUser, dw1, dw2: DWORD)
   stdcall;
+procedure BandMapRefreshTimerProc(uTimerID, uMessage: UINT; dwUser, dw1, dw2: DWORD)
+  stdcall;
 
 procedure SaveTR4WPOSFILE;
 procedure LoadTR4WPOSFILE;
@@ -1570,6 +1572,16 @@ begin
   // Windows.SetWindowText(tr4whandle, inttopchar({GetHeapStatus.TotalFree}AllocMemSize));
  // Windows.SetWindowText(InsertWindowHandle, inttopchar(FreeMemCount));
 {$IFEND}
+end;
+
+procedure BandMapRefreshTimerProc(uTimerID, uMessage: UINT; dwUser, dw1, dw2: DWORD)
+  stdcall;
+begin
+  if BandMapNeedsRefresh then
+     begin
+     BandMapNeedsRefresh := False;
+     DisplayBandMap;
+     end;
 end;
 
 procedure PTTOffWhenStopWAV(uTimerID, uMessage: UINT; dwUser, dw1, dw2: DWORD)

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -2108,6 +2108,7 @@ const
   ALARM_WAKEUP_TIMER_HANDLE             = 9;
   CLOSE_ALARM_WAKEUP_HANDLE             = 10;
   UPDATE_NET_CW_MESSAGE                 = 11;
+  BANDMAP_REFRESH_TIMER_HANDLE          = 12;
 
   {menu items & accelerators}
 

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -590,10 +590,12 @@ begin
       WaitResult := MsgWaitForMultipleObjects(1, H, False, Remaining, QS_SENDMESSAGE);
       if WaitResult = WAIT_OBJECT_0 then
          begin
+         logger.Info('[WaitForPollingThread] Thread exited cleanly');
          Break;  // thread exited
          end;
       if WaitResult = WAIT_TIMEOUT then
          begin
+         logger.Info('[WaitForPollingThread] TIMED OUT after %dms', [TimeoutMs]);
          Break;  // timed out
          end;
       // WAIT_OBJECT_0 + 1 = message available — pump it so SendMessage unblocks
@@ -606,6 +608,7 @@ begin
 {$IF not tDebugMode }
   if Ask then
     if YesOrNo(tr4whandle, TC_DOYOUREALLYWANTTOEXITTHEPROGRAM) = IDno then Exit;
+  logger.Info('Starting ExitProgram');
 {$IFEND}
 //  GetLogColumnsWidth;
 //  timeEndPeriod(1);
@@ -616,7 +619,9 @@ begin
 //  if (OCXHandle <> 0) then FreeLibrary(OCXHandle);
 {$IFEND}
   logger.Info('[ExitProgram] Step 1: SaveTelnetWindowSpots');
+  logger.debug('Calling SaveTelnetWindowSpots');
   SaveTelnetWindowSpots;
+  logger.debug('Back from SaveTelnetWindowSpots');
 
   // Stop polling threads FIRST so they don't recreate transports or call
   // SendMessage (SetDlgItemText) while we're tearing down on the main thread.
@@ -627,9 +632,9 @@ begin
   logger.Info('[ExitProgram] Step 2: Stopping polling threads');
   Radio1.PollingStopRequested := True;
   Radio2.PollingStopRequested := True;
-  logger.Info('[ExitProgram] Step 2a: Waiting for Radio1 polling thread');
+  logger.Info('[ExitProgram] Step 2a: Waiting for Radio1 (handle=%d)', [Radio1.tRadioInterfaceThreadHandle]);
   WaitForPollingThreadWithMessages(Radio1.tRadioInterfaceThreadHandle, 3000);
-  logger.Info('[ExitProgram] Step 2b: Waiting for Radio2 polling thread');
+  logger.Info('[ExitProgram] Step 2b: Waiting for Radio2 (handle=%d)', [Radio2.tRadioInterfaceThreadHandle]);
   WaitForPollingThreadWithMessages(Radio2.tRadioInterfaceThreadHandle, 3000);
   logger.Info('[ExitProgram] Step 2c: Polling threads done');
 
@@ -637,29 +642,53 @@ begin
   // Without this, the radio never receives disconnect packets and keeps
   // the session alive, blocking reconnection on next program start.
   logger.Info('[ExitProgram] Step 3: Disconnecting Radio1');
-  if Radio1.tNetObject <> nil then Radio1.tNetObject.Disconnect;
+  if Radio1.tNetObject <> nil then
+     begin
+     Radio1.tNetObject.Disconnect;
+     end;
   logger.Info('[ExitProgram] Step 4: Disconnecting Radio2');
-  if Radio2.tNetObject <> nil then Radio2.tNetObject.Disconnect;
+  if Radio2.tNetObject <> nil then
+     begin
+     Radio2.tNetObject.Disconnect;
+     end;
   logger.Info('[ExitProgram] Step 5: WSACleanup');
 
-  if WindowsSocketsInitialised then WSACleanup;
+  if WindowsSocketsInitialised then
+     begin
+     WSACleanup;
+     end;
+
   ntBeepClose;
+
+  logger.Info('[ExitProgram] SaveTR4WPOSFILE');
   SaveTR4WPOSFILE;
-  if BackCopyEnable then StopBackCopy;
+
+  if BackCopyEnable then
+     begin
+     StopBackCopy;
+     end;
+
   if NetDebug then
-  begin
-    Close(NetDebugBinaryOutput);
-    Close(NetDebugBinaryInput);
-  end;
+     begin
+     Close(NetDebugBinaryOutput);
+     Close(NetDebugBinaryInput);
+     end;
   if UDPBroadcastScore then
      begin
      SendScoreToUDP;
      end;
-  if DVKEnable then DVPUnInit;
+  if DVKEnable then
+     begin
+     DVPUnInit;
+     end;
+
   {if BandMapEnable then }SaveBandMap;
   wkClose;
   DriverDestroy;
+
+  logger.Info('[ExitProgram] Step SaveRestartFile');
   Sheet.SaveRestartFile;
+
   UnInitializeKeyer;
   NoSound;
   CD.SCPDisableAndDeAllocateFileBuffer;
@@ -668,15 +697,21 @@ begin
 //  SpotsList.Destroy;
   if LuconSZLoadded then RemoveFontResource(TR4W_LC_FILENAME);
 {$IF SCPDEBUG}
-  if scpLoaded then scpClose;
+  if scpLoaded then
+     begin
+     scpClose;
+     end;
 {$IFEND}
 //  if TrayBallonDisplayed then Balloon_DeleteTrayIcon;
   FreeAndNil(udp); // ny4i 4.44.9 Destroy the udp object
   FreeAndNil(slElements);
   // Restore StickyKeys settings // ny4i Issue 126
   SystemParametersInfo( SPI_SETSTICKYKEYS, SizeOf(StickyKeysAtStartup), @StickyKeysAtStartup, 0 );
-  tr4w_ShutDown;
+ logger.Info('[ExitProgram] Calling tr4w_Shutdown');
+ tr4w_ShutDown;
+ logger.Info('[ExitProgram] Exiting');
 end;
+
 procedure TalkToRTTYPort;
 
 

--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -533,6 +533,7 @@ var
   BandMapDecayMultiplier                : integer = 1; {KK1L: 6.65}
   BandMapDupeDisplay                    : boolean = True;
   BandMapEnable                         : boolean;
+  BandMapNeedsRefresh                   : boolean = False;
   BandMapEntryInCallWindow              : boolean;
   BandMapFileVersion                    : Char = '1';
   {KK1L: 6.65 Expanded array to cover all cases to keep BM from going whacko when tuning out of band}

--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -370,13 +370,23 @@ begin
         tLB_SETCOLUMNWIDTH(hwnddlg, BandMapItemWidth); // 4.98.9
 
         BandMapEnable := True;
+        // WS_EX_COMPOSITED causes Windows to paint all children via a back
+        // buffer and blit atomically, eliminating the visible top-to-bottom
+        // sweep when the owner-draw list box repaints its ~164 items.
+        Windows.SetWindowLong(hwnddlg, GWL_EXSTYLE,
+          Windows.GetWindowLong(hwnddlg, GWL_EXSTYLE) or WS_EX_COMPOSITED);
         SendMessage(BandMapStatusBar, SB_SETPARTS, 6, integer(@BMPanelWidth));
         //      SetTimer(hwnddlg, BANDMAP_BLINK_TIMER_HANDLE, 600, nil);     //n4af
         tr4w_WindowsArray[tw_BANDMAPWINDOW_INDEX].WndHandle := hwnddlg;
         //      BandMapListBoxHDC := Windows.GetDC(BandMapListBox);
           //           DoNotAddToBandMap := False;
 
-        DisplayBandMap;
+        // DisplayBandMap is intentionally omitted here.
+        // OpenTR4WWindow calls SetWindowPos(SWP_SHOWWINDOW) immediately after
+        // CreateDialogIndirectParam, which fires WM_SIZE → DisplayBandMap.
+        // Calling DisplayBandMap in both WM_INITDIALOG and WM_SIZE causes two
+        // WM_SETREDRAW off/on cycles in rapid succession, producing a visible
+        // flash on startup with many spots loaded from BandMap.bin.
       end;
 
     WM_COMMAND:
@@ -636,6 +646,7 @@ begin
   if tLB_SETCURSEL(BandMapListBox, i) = LB_ERR then
     tLB_SETCURSEL(BandMapListBox, i - 1);
   ShowSpotInfo;
+  DisplayBandMap;
 end;
 
 procedure SetTextInBMSB(Index: integer; Text: PChar);

--- a/tr4w/src/uIcomNetworkTransport.pas
+++ b/tr4w/src/uIcomNetworkTransport.pas
@@ -374,7 +374,7 @@ end;
 
 procedure TIcomNetworkTransport.Disconnect;
 begin
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect called from state %s',
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect called from state %s',
               [IcomStateToString(FState)]);
 
   if FState = icsDisconnected then
@@ -383,14 +383,14 @@ begin
      end;
 
   // Stop all timers first
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: StopTimers');
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: StopTimers');
   StopTimers;
 
   // Send CI-V Close if stream was open
   if FCivStreamOpen and (FCivSocket <> nil) and (FCivRemoteId <> 0) then
      begin
      try
-        logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: SendCivClose');
+        logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: SendCivClose');
         SendCivClose;
         SendControlPacket(ICOM_PKT_DISCONNECT, FCivSocket,
            FCivRemoteId, FRadioAddress, FCivPort, FCivSeq);
@@ -406,7 +406,7 @@ begin
   if (FControlSocket <> nil) and (FRemoteId <> 0) then
      begin
      try
-        logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: SendControlDisconnect');
+        logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: SendControlDisconnect');
         SendControlPacket(ICOM_PKT_DISCONNECT, FControlSocket,
            FRemoteId, FRadioAddress, FControlPort, FSendSeq);
      except
@@ -417,17 +417,17 @@ begin
      end;
      end;
 
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: Sleep(100)');
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: Sleep(100)');
   Sleep(100);
 
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: DestroySockets');
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: DestroySockets');
   DestroySockets;
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: DestroySockets done');
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: DestroySockets done');
   ClearAllBuffers;
 
   if FTimerWnd <> 0 then
      begin
-     logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: DestroyWindow');
+     logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: DestroyWindow');
      SetWindowLong(FTimerWnd, GWL_USERDATA, 0);
      DestroyWindow(FTimerWnd);
      FTimerWnd := 0;
@@ -435,7 +435,7 @@ begin
 
   FCivStreamOpen := False;
   SetState(icsDisconnected);
-  logger.Info('[IcomTransport:' + FRadioName + '] Disconnect: complete');
+  logger.Debug('[IcomTransport:' + FRadioName + '] Disconnect: complete');
 end;
 
 procedure TIcomNetworkTransport.SendCivData(const CivFrame: string);
@@ -537,9 +537,9 @@ procedure TIcomNetworkTransport.DestroySockets;
 
       // Step 1: Deactivate (stops listener thread, closes socket)
       try
-         logger.Info('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' Active:=False');
+         logger.Debug('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' Active:=False');
          Socket.Active := False;
-         logger.Info('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' Active:=False done');
+         logger.Debug('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' Active:=False done');
       except
          on E: Exception do
             begin
@@ -549,7 +549,7 @@ procedure TIcomNetworkTransport.DestroySockets;
 
       // Step 2: Free the object on a background thread with timeout.
       // If the Indy destructor hangs, we abandon it — ExitProcess cleans up.
-      logger.Info('[IcomTransport:' + FRadioName + '] DestroySockets: Freeing ' + Name);
+      logger.Debug('[IcomTransport:' + FRadioName + '] DestroySockets: Freeing ' + Name);
       FreeThread := BeginThread(nil, 0, @FreeObjectThread, Pointer(Socket), 0, ThreadId);
       if FreeThread <> 0 then
          begin
@@ -561,7 +561,7 @@ procedure TIcomNetworkTransport.DestroySockets;
             end
          else
             begin
-            logger.Info('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' freed OK');
+            logger.Debug('[IcomTransport:' + FRadioName + '] DestroySockets: ' + Name + ' freed OK');
             end;
          end
       else
@@ -578,7 +578,7 @@ procedure TIcomNetworkTransport.DestroySockets;
 begin
   SafeFreeSocket(FControlSocket, 'Control');
   SafeFreeSocket(FCivSocket, 'CIV');
-  logger.Info('[IcomTransport:' + FRadioName + '] DestroySockets: complete');
+  logger.Debug('[IcomTransport:' + FRadioName + '] DestroySockets: complete');
 end;
 
 // Use the UDP connect trick to find which local interface routes to the radio.
@@ -812,7 +812,7 @@ begin
           if (FState = icsConnected) and (FCivRemoteId = 0) then
           begin
             FCivRemoteId := Pkt.SentID;
-            logger.Info('[IcomTransport:' + FRadioName + '] CI-V I Am Here received, remoteId=$%.8x',
+            logger.Debug('[IcomTransport:' + FRadioName + '] CI-V I Am Here received, remoteId=$%.8x',
                         [FCivRemoteId]);
 
             // Send "Are You Ready" on CI-V socket (seq=1, untracked, like wfview)
@@ -826,7 +826,7 @@ begin
           if FState = icsWaitingForHere then
           begin
             FRemoteId := Pkt.SentID;
-            logger.Info('[IcomTransport:' + FRadioName + '] Control I Am Here received, remoteId=$%.8x',
+            logger.Debug('[IcomTransport:' + FRadioName + '] Control I Am Here received, remoteId=$%.8x',
                         [FRemoteId]);
 
             // Kill AYT timer
@@ -852,7 +852,7 @@ begin
           // CI-V I Am Ready (within Connected state)
           if (FState = icsConnected) and (FCivRemoteId <> 0) and (not FCivStreamOpen) then
           begin
-            logger.Info('[IcomTransport:' + FRadioName + '] CI-V I Am Ready received');
+            logger.Debug('[IcomTransport:' + FRadioName + '] CI-V I Am Ready received');
 
             // Send CI-V Open
             SendCivOpen;
@@ -880,7 +880,7 @@ begin
         begin
           if FState = icsWaitingForReady then
           begin
-            logger.Info('[IcomTransport:' + FRadioName + '] Control I Am Ready received');
+            logger.Debug('[IcomTransport:' + FRadioName + '] Control I Am Ready received');
 
             // Send Login
             SendLoginPacket;
@@ -1088,7 +1088,7 @@ begin
   if FCivPort = 0 then
     FCivPort := ICOM_DEFAULT_CIV_PORT;  // Fallback
 
-  logger.Info('[IcomTransport:' + FRadioName + '] Status received, CI-V port=%d', [FCivPort]);
+  logger.Debug('[IcomTransport:' + FRadioName + '] Status received, CI-V port=%d', [FCivPort]);
 
   // CI-V socket was already created in HandleCapabilities
   FCivMyId := CalculateMyIdFromSocket(FCivSocket);
@@ -1539,7 +1539,7 @@ procedure TIcomNetworkTransport.SetState(NewState: TIcomConnectionState);
 begin
   if FState <> NewState then
   begin
-    logger.Info('[IcomTransport:' + FRadioName + '] State: %s -> %s',
+    logger.Debug('[IcomTransport:' + FRadioName + '] State: %s -> %s',
                 [IcomStateToString(FState), IcomStateToString(NewState)]);
     FState := NewState;
 

--- a/tr4w/src/uProcessCommand.pas
+++ b/tr4w/src/uProcessCommand.pas
@@ -685,8 +685,8 @@ begin
 
   Radio1.SetRadioFreq(R1VFO.Frequency, R1VFO.Mode, 'A');
   Radio2.SetRadioFreq(R2VFO.Frequency, R2VFO.Mode, 'A');
-} 
-
+}
+  logger.Debug('Entering scExchangeRadios');
   if Radio1.FilteredStatus.Freq = 0 then Exit;
   if Radio2.FilteredStatus.Freq = 0 then Exit;
 
@@ -695,6 +695,8 @@ begin
 
   Radio1.SetRadioFreq(R1REC.Freq, R1REC.Mode, 'A'{VFPLETTERARRAY[Radio1.FilteredStatus.VFOStatus]});
   Radio2.SetRadioFreq(R2REC.Freq, R2REC.Mode, 'A'{VFPLETTERARRAY[Radio2.FilteredStatus.VFOStatus]});
+
+  logger.Debug('Exiting scExchangeRadios');
 end;
 
 procedure csMMTTY_GRABLASTCALL;

--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -88,7 +88,7 @@ begin
          // Use periodic polling instead (same approach as legacy K3 code).
          Self.SetAIMode(0);
          Self.requiresPolling := True;
-         Self.pollingInterval  := 1000;
+         Self.pollingInterval  := 100; // Default; overridden by FREQUENCY POLL RATE in pNetworkRadio
          end
       else
          begin

--- a/tr4w/src/uRadioIcomBase.pas
+++ b/tr4w/src/uRadioIcomBase.pas
@@ -1502,14 +1502,9 @@ procedure TIcomRadio.SetMode(mode: TRadioMode; vfo: TVFO = nrVFOA);
 var
   modeCmd: Byte;
   filterCmd: Byte;
+  dataMode: Byte;
 begin
   logger.Info('[%s.SetMode] Setting VFO %s to TRadioMode=%d', [radioModel, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode)]);
-  // To set VFO B mode: select VFO B ($07 $01), send $06, then restore VFO A ($07 $00).
-  // $25/$26 are read/set band-info commands, not VFO-select commands — using them here
-  // queues a read query whose response can race with the $06 mode command.
-  // For VFO A no selection step is needed: $06 always targets the active (main) VFO.
-  if vfo = nrVFOB then
-     SendToRadio(BuildCIVCommand($07, #$01));
 
   // Map TRadioMode to Icom mode numbers
   filterCmd := $01;  // Default filter
@@ -1523,8 +1518,8 @@ begin
     rmCWRev:  modeCmd := $07;
     rmFSKRev: modeCmd := $08;
     rmAFSK,
-    rmData:     modeCmd := $01;  // USB base mode + data sub-mode via $1A $06
-    rmDataRev:  modeCmd := $00;  // LSB base mode + data sub-mode via $1A $06
+    rmData:     modeCmd := $01;  // USB base mode + data sub-mode
+    rmDataRev:  modeCmd := $00;  // LSB base mode + data sub-mode
     rmPSK:    modeCmd := $12;
     rmPSKRev: modeCmd := $13;
     rmDV:     modeCmd := $17;  // D-STAR digital voice
@@ -1532,45 +1527,63 @@ begin
     modeCmd := $01;  // Default to USB
   end;
 
-  logger.Info('[%s.SetMode] Sending $06 with modeCmd=$%.2x filterCmd=$%.2x', [radioModel, modeCmd, filterCmd]);
-  SendToRadio(BuildCIVCommand($06, Chr(modeCmd) + Chr(filterCmd)));
-
-  // Set or clear the Icom data sub-mode flag ($1A $06):
-  //   Entering data mode  → turn flag ON  ($1A $06 D1/D2/D3) via FDataModeID
-  //   Leaving data mode for a voice mode → turn flag OFF ($1A $06 $00)
-  //   Only send the clear command when the previous mode was actually a data
-  //   mode; sending $1A $06 $00 unnecessarily (e.g. USB→USB on a retune) is
-  //   known to kill the IC-7760 CI-V transceive stream (same failure mode as
-  //   the now-disabled $26 $01 VFO B mode query).
-  //   CW/CW-R: the radio auto-clears data mode on $06 $03 — no $1A $06 needed.
-  //   FSK/PSK: use native Icom mode numbers and need no $1A $06 command.
-  if SupportsDataMode then
+  if (vfo = nrVFOB) and FSupportsExtendedVFOBCommands then
      begin
+     // Use $26 $01 <mode> <dataMode> <filter> to set VFO B mode directly,
+     // without any VFO-swap sequence. The $07 $01 / $06 / $07 $00 approach
+     // races with CI-V transceive pushes over network connections — the $06
+     // command lands on whichever VFO is active when the radio processes it,
+     // which may still be VFO A. $26 $01 targets VFO B unconditionally.
+     // This matches the serial path (LOGRADIO.PAS IcomRadiosThatSupportVFOB).
      if mode in [rmAFSK, rmData, rmDataRev] then
-        begin
-        logger.Info('[%s.SetMode] Sending $1A $06 $%.2x (data mode ON, D%d)', [radioModel, FDataModeID, FDataModeID]);
-        SendToRadio(BuildCIVCommand($1A, #$06 + Chr(FDataModeID)));
-        end
-     else if (mode in [rmUSB, rmLSB, rmAM, rmFM]) and
-             (Self.vfo[vfo].Mode in [rmData, rmDataRev, rmAFSK]) then
-        begin
-        // Clear the data sub-mode flag only if we were previously in a data
-        // mode.  Sending $1A $06 $00 while already in a plain voice mode is
-        // redundant and risks stalling the IC-7760 CI-V stream.
-        logger.Info('[%s.SetMode] Sending $1A $06 $00 (leaving data mode, prev TRadioMode=%d)', [radioModel, Ord(Self.vfo[vfo].Mode)]);
-        SendToRadio(BuildCIVCommand($1A, #$06 + #$00));
-        end;
-     end;
+        dataMode := FDataModeID
+     else
+        dataMode := 0;
+     logger.Info('[%s.SetMode] Sending $26 $01 modeCmd=$%.2x dataMode=$%.2x filterCmd=$%.2x',
+        [radioModel, modeCmd, dataMode, filterCmd]);
+     SendToRadio(BuildCIVCommand($26, #$01 + Chr(modeCmd) + Chr(dataMode) + Chr(filterCmd)));
+     end
+  else
+     begin
+     // VFO A, or radios without $25/$26 support: use $06 targeting the active VFO.
+     // For VFO B on older radios, swap to VFO B first, then restore VFO A after.
+     if vfo = nrVFOB then
+        SendToRadio(BuildCIVCommand($07, #$01));
 
-  // Restore VFO A after setting VFO B mode
-  if vfo = nrVFOB then
-     SendToRadio(BuildCIVCommand($07, #$00));
+     logger.Info('[%s.SetMode] Sending $06 modeCmd=$%.2x filterCmd=$%.2x', [radioModel, modeCmd, filterCmd]);
+     SendToRadio(BuildCIVCommand($06, Chr(modeCmd) + Chr(filterCmd)));
+
+     // Set or clear the Icom data sub-mode flag ($1A $06):
+     //   Entering data mode  → turn flag ON  ($1A $06 D1/D2/D3) via FDataModeID
+     //   Leaving data mode for a voice mode → turn flag OFF ($1A $06 $00)
+     //   Only send the clear command when the previous mode was actually a data
+     //   mode; sending $1A $06 $00 unnecessarily (e.g. USB→USB on a retune) is
+     //   known to kill the IC-7760 CI-V transceive stream.
+     //   CW/CW-R: the radio auto-clears data mode on $06 $03 — no $1A $06 needed.
+     //   FSK/PSK: use native Icom mode numbers and need no $1A $06 command.
+     if SupportsDataMode then
+        begin
+        if mode in [rmAFSK, rmData, rmDataRev] then
+           begin
+           logger.Info('[%s.SetMode] Sending $1A $06 $%.2x (data mode ON, D%d)', [radioModel, FDataModeID, FDataModeID]);
+           SendToRadio(BuildCIVCommand($1A, #$06 + Chr(FDataModeID)));
+           end
+        else if (mode in [rmUSB, rmLSB, rmAM, rmFM]) and
+                (Self.vfo[vfo].Mode in [rmData, rmDataRev, rmAFSK]) then
+           begin
+           logger.Info('[%s.SetMode] Sending $1A $06 $00 (leaving data mode, prev TRadioMode=%d)', [radioModel, Ord(Self.vfo[vfo].Mode)]);
+           SendToRadio(BuildCIVCommand($1A, #$06 + #$00));
+           end;
+        end;
+
+     if vfo = nrVFOB then
+        SendToRadio(BuildCIVCommand($07, #$00));
+     end;
 
   // Optimistic update: reflect the new mode in our cached VFO state immediately.
   // The polling thread reads vfo.Mode on every cycle; without this update, the
   // stale mode triggers ProcessFilteredStatus to override the display back to
   // the old mode before the transceive-push confirmation from the radio arrives.
-  // This mirrors the frequency optimistic update already done in SetFrequency.
   // rmAFSK maps to rmData because that is what the radio confirms: a $01 $01
   // (USB) transceive push combined with the $1A $06 $01 (data ON) response.
   if mode = rmAFSK then

--- a/tr4w/src/uRadioIcomBase.pas
+++ b/tr4w/src/uRadioIcomBase.pas
@@ -483,21 +483,21 @@ begin
   // port/socket that is about to be closed by inherited Disconnect below.
   if FCIVSendThread <> nil then
      begin
-     logger.Info('[TIcomRadio.Disconnect] Stopping CI-V send queue thread');
+     logger.Debug('[TIcomRadio.Disconnect] Stopping CI-V send queue thread');
      FCIVSendThread.Stop;
      FCIVSendThread.WaitFor;
      FreeAndNil(FCIVSendThread);
-     logger.Info('[TIcomRadio.Disconnect] CI-V send queue thread stopped');
+     logger.Debug('[TIcomRadio.Disconnect] CI-V send queue thread stopped');
      end;
 
   if IsNetworkConnection and (FNetworkTransport <> nil) then
      begin
-     logger.Info('[TIcomRadio.Disconnect] Calling FNetworkTransport.Disconnect (state=%s)',
+     logger.Debug('[TIcomRadio.Disconnect] Calling FNetworkTransport.Disconnect (state=%s)',
                  [IcomStateToString(FNetworkTransport.State)]);
      FNetworkTransport.Disconnect;
-     logger.Info('[TIcomRadio.Disconnect] FNetworkTransport.Disconnect returned, calling FreeAndNil');
+     logger.Debug('[TIcomRadio.Disconnect] FNetworkTransport.Disconnect returned, calling FreeAndNil');
      FreeAndNil(FNetworkTransport);
-     logger.Info('[TIcomRadio.Disconnect] FreeAndNil complete');
+     logger.Debug('[TIcomRadio.Disconnect] FreeAndNil complete');
      end
   else
      inherited Disconnect;
@@ -578,7 +578,7 @@ procedure TIcomRadio.OnNetworkStateChange(Sender: TObject);
 begin
   if FNetworkTransport = nil then Exit;
 
-  logger.Info('[TIcomRadio.OnNetworkStateChange] Transport state: %s',
+  logger.Debug('[TIcomRadio.OnNetworkStateChange] Transport state: %s',
               [IcomStateToString(FNetworkTransport.State)]);
 
   { At StreamRequested the capabilities packet has been received and the transport
@@ -921,7 +921,7 @@ begin
             begin
             // VFO selection changed — refresh both frequencies and modes
             FActiveVFO := vfoSlot;
-            logger.Info('[%s] $07 $D2: active VFO changed to VFO %s — refreshing',
+            logger.Debug('[%s] $07 $D2: active VFO changed to VFO %s — refreshing',
                [radioModel, IfThen(FActiveVFO = nrVFOA, 'A', 'B')]);
             QueryVFOAFrequency;
             QueryVFOAMode;
@@ -938,7 +938,7 @@ begin
 
     $03:  // Read operating frequency response — returns the active VFO's frequency
       begin
-        logger.Info('[%s] $03 response received, data len=%d', [radioModel, Length(data)]);
+        logger.Debug('[%s] $03 response received, data len=%d', [radioModel, Length(data)]);
         if Length(data) >= 5 then
         begin
           freq := BCDToFreq(Copy(data, 1, 5));
@@ -971,7 +971,7 @@ begin
             FBandMemory[vfo[vfoSlot].Band] := freq;
           if subCmd = $00 then
             FVFOQueryPending := False;  // Query pair complete — allow next $00 to trigger
-          logger.Info('[%s] $25/$%.2x → radio object vfo[%s] freq = %d Hz',
+          logger.Debug('[%s] $25/$%.2x → radio object vfo[%s] freq = %d Hz',
              [radioModel, subCmd, IfThen(vfoSlot = nrVFOA, 'nrVFOA', 'nrVFOB'), freq]);
         end
         else if Length(data) = 5 then  // IC-7610/standard format: freq(5) only, no subcmd
@@ -1000,7 +1000,7 @@ begin
            end
         else
            begin
-           logger.Info('[%s] $04 response received, data len=%d', [radioModel, Length(data)]);
+           logger.Debug('[%s] $04 response received, data len=%d', [radioModel, Length(data)]);
            if Length(data) >= 1 then
            begin
              modeNum := Ord(data[1]);
@@ -1020,7 +1020,7 @@ begin
                else radioMode := rmNone;
              end;
              vfoSlot := FActiveVFO;
-             logger.Info('[%s] $04 mode: byte=$%.2x → TRadioMode=%d → VFO %s',
+             logger.Debug('[%s] $04 mode: byte=$%.2x → TRadioMode=%d → VFO %s',
                 [radioModel, modeNum, Ord(radioMode), IfThen(vfoSlot = nrVFOA, 'A', 'B')]);
              FLastBaseMode := radioMode;
              Self.vfo[vfoSlot].Mode := radioMode;
@@ -1107,7 +1107,7 @@ begin
       // IC-7760 format (FSupportsExtendedVFOBCommands): $01 <freq5> <mode> <filter>
       // Standard format: <freq5> <mode> <filter>
       begin
-        logger.Info('[%s] $26 response received, data len=%d, extended=%s',
+        logger.Debug('[%s] $26 response received, data len=%d, extended=%s',
            [radioModel, Length(data), BoolToStr(FSupportsExtendedVFOBCommands, True)]);
         if FSupportsExtendedVFOBCommands then
           begin
@@ -1141,7 +1141,7 @@ begin
               else radioMode := rmNone;
             end;
             vfo[nrVFOB].Mode := radioMode;
-            logger.Info('[%s] VFO B freq+mode ($26 push): %d Hz, mode=$%.2x → TRadioMode=%d',
+            logger.Debug('[%s] VFO B freq+mode ($26 push): %d Hz, mode=$%.2x → TRadioMode=%d',
                [radioModel, freq, modeNum, Ord(radioMode)]);
             end
           else if Length(data) >= 3 then
@@ -1176,14 +1176,14 @@ begin
               begin
               vfo[vfoSlot].Mode := rmData;
               vfo[vfoSlot].dataMode := rmData;
-              logger.Info('[%s] $26/$%.2x → radio object vfo[%s] mode=$%.2x + data mode D%d → rmData',
+              logger.Debug('[%s] $26/$%.2x → radio object vfo[%s] mode=$%.2x + data mode D%d → rmData',
                  [radioModel, subCmd, IfThen(vfoSlot = nrVFOA, 'nrVFOA', 'nrVFOB'), modeNum, Ord(data[3])]);
               end
             else
               begin
               vfo[vfoSlot].Mode := radioMode;
               vfo[vfoSlot].dataMode := rmNone;
-              logger.Info('[%s] $26/$%.2x → radio object vfo[%s] mode=$%.2x → TRadioMode=%d',
+              logger.Debug('[%s] $26/$%.2x → radio object vfo[%s] mode=$%.2x → TRadioMode=%d',
                  [radioModel, subCmd, IfThen(vfoSlot = nrVFOA, 'nrVFOA', 'nrVFOB'), modeNum, Ord(radioMode)]);
               end;
             end
@@ -1201,7 +1201,7 @@ begin
             vfo[nrVFOB].Band := FreqToRadioBand(freq);
             if vfo[nrVFOB].Band <> rbNone then
               FBandMemory[vfo[nrVFOB].Band] := freq;
-            logger.Info('[%s] VFO B freq ($26): %d Hz', [radioModel, freq]);
+            logger.Debug('[%s] VFO B freq ($26): %d Hz', [radioModel, freq]);
             end;
           if Length(data) >= 6 then
             begin
@@ -1222,7 +1222,7 @@ begin
               else radioMode := rmNone;
             end;
             vfo[nrVFOB].Mode := radioMode;
-            logger.Info('[%s] VFO B mode ($26): byte=$%.2x → TRadioMode=%d',
+            logger.Debug('[%s] VFO B mode ($26): byte=$%.2x → TRadioMode=%d',
                [radioModel, modeNum, Ord(radioMode)]);
             end;
           end;
@@ -1332,9 +1332,9 @@ begin
         // Initial state queries are sent directly by the polling thread on connect —
         // this response is logged for diagnostics only.
         if Length(data) >= 2 then
-          logger.Info('[%s] Transceiver ID confirmed, CI-V address=$%.2x', [radioModel, Ord(data[2])])
+          logger.Debug('[%s] Transceiver ID confirmed, CI-V address=$%.2x', [radioModel, Ord(data[2])])
         else
-          logger.Info('[%s] Transceiver ID response received (no address byte)', [radioModel]);
+          logger.Debug('[%s] Transceiver ID response received (no address byte)', [radioModel]);
       end;
 
     $FB:  // Command OK (ACK)
@@ -1460,7 +1460,7 @@ procedure TIcomRadio.SetFrequency(freq: longint; vfo: TVFO; mode: TRadioMode);
 var
   bcdFreq: string;
 begin
-  logger.Info('[%s.SetFrequency] freq=%d VFO=%s TRadioMode=%d', [radioModel, freq, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode)]);
+  logger.Debug('[%s.SetFrequency] freq=%d VFO=%s TRadioMode=%d', [radioModel, freq, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode)]);
   bcdFreq := FreqToBCD(freq);
   if (vfo = nrVFOB) and FSupportsExtendedVFOBCommands then
      begin
@@ -1504,7 +1504,7 @@ var
   filterCmd: Byte;
   dataMode: Byte;
 begin
-  logger.Info('[%s.SetMode] Setting VFO %s to TRadioMode=%d', [radioModel, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode)]);
+  logger.Debug('[%s.SetMode] Setting VFO %s to TRadioMode=%d', [radioModel, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode)]);
 
   // Map TRadioMode to Icom mode numbers
   filterCmd := $01;  // Default filter
@@ -1539,7 +1539,7 @@ begin
         dataMode := FDataModeID
      else
         dataMode := 0;
-     logger.Info('[%s.SetMode] Sending $26 $01 modeCmd=$%.2x dataMode=$%.2x filterCmd=$%.2x',
+     logger.Debug('[%s.SetMode] Sending $26 $01 modeCmd=$%.2x dataMode=$%.2x filterCmd=$%.2x',
         [radioModel, modeCmd, dataMode, filterCmd]);
      SendToRadio(BuildCIVCommand($26, #$01 + Chr(modeCmd) + Chr(dataMode) + Chr(filterCmd)));
      end
@@ -1550,7 +1550,7 @@ begin
      if vfo = nrVFOB then
         SendToRadio(BuildCIVCommand($07, #$01));
 
-     logger.Info('[%s.SetMode] Sending $06 modeCmd=$%.2x filterCmd=$%.2x', [radioModel, modeCmd, filterCmd]);
+     logger.Debug('[%s.SetMode] Sending $06 modeCmd=$%.2x filterCmd=$%.2x', [radioModel, modeCmd, filterCmd]);
      SendToRadio(BuildCIVCommand($06, Chr(modeCmd) + Chr(filterCmd)));
 
      // Set or clear the Icom data sub-mode flag ($1A $06):
@@ -1565,13 +1565,13 @@ begin
         begin
         if mode in [rmAFSK, rmData, rmDataRev] then
            begin
-           logger.Info('[%s.SetMode] Sending $1A $06 $%.2x (data mode ON, D%d)', [radioModel, FDataModeID, FDataModeID]);
+           logger.Debug('[%s.SetMode] Sending $1A $06 $%.2x (data mode ON, D%d)', [radioModel, FDataModeID, FDataModeID]);
            SendToRadio(BuildCIVCommand($1A, #$06 + Chr(FDataModeID)));
            end
         else if (mode in [rmUSB, rmLSB, rmAM, rmFM]) and
                 (Self.vfo[vfo].Mode in [rmData, rmDataRev, rmAFSK]) then
            begin
-           logger.Info('[%s.SetMode] Sending $1A $06 $00 (leaving data mode, prev TRadioMode=%d)', [radioModel, Ord(Self.vfo[vfo].Mode)]);
+           logger.Debug('[%s.SetMode] Sending $1A $06 $00 (leaving data mode, prev TRadioMode=%d)', [radioModel, Ord(Self.vfo[vfo].Mode)]);
            SendToRadio(BuildCIVCommand($1A, #$06 + #$00));
            end;
         end;
@@ -1591,7 +1591,7 @@ begin
   else
      Self.vfo[vfo].Mode := mode;
 
-  logger.Info('[%s.SetMode] Done — VFO %s TRadioMode=%d modeCmd=$%.2x', [radioModel, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode), modeCmd]);
+  logger.Debug('[%s.SetMode] Done — VFO %s TRadioMode=%d modeCmd=$%.2x', [radioModel, IfThen(vfo = nrVFOA, 'A', 'B'), Ord(mode), modeCmd]);
 end;
 
 procedure TIcomRadio.BufferCW(cwChars: string);

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -155,6 +155,8 @@ begin
    RadioWaitLoops := RadioTimeoutTime Div RadioWaitTime; // how may loops to make
 
    repeat
+      if rig^.PollingStopRequested then Exit;
+
       inc(rig^.tPollCount);
 
       NumberOfSucceffulPolls := 0;
@@ -188,6 +190,7 @@ begin
 
             while BufferNotChanged < RadioWaitLoops do
               begin
+                if rig^.PollingStopRequested then Exit;
                 Sleep(RadioWaitTime);  // wait a little for some bytes
                 ClearCommError(rig^.tCATPortHandle, Errs, @stat);
                 if stat.cbInQue > BytesInBuffer then
@@ -774,6 +777,16 @@ begin
             reconnectDelay := RECONNECT_INITIAL_DELAY;  // Reset backoff on successful connection
             SetRadioAlertState(False);  // TCP reconnected — clear alert (operational check below)
 
+            // For serial radios that require active polling, honour the user-configurable
+            // FREQUENCY POLL RATE setting (FreqPollRate, default 10ms, range 10-1000ms).
+            // This keeps serial K4 poll latency consistent with legacy K3 behaviour.
+            if ro.requiresPolling and (ro.serialPort <> NoPort) then
+               begin
+               ro.pollingInterval := FreqPollRate;
+               logger.Debug('[pNetworkRadio] Serial polling interval set to %dms (FREQUENCY POLL RATE)',
+                            [ro.pollingInterval]);
+               end;
+
             // Query freq and mode directly from the polling thread.
             // The OnInitialPollSeeding timer window is created on this thread, which has
             // no Win32 message pump (it only calls Sleep), so WM_TIMER is never dispatched
@@ -1138,6 +1151,8 @@ begin
    Step := KenwoodPollCount;
    NextPoll:
    Sleep(FreqPollRate);
+
+   if rig^.PollingStopRequested then Exit;
 
    if rig.CommandsBufferPointer <> 0 then
       begin
@@ -3093,7 +3108,7 @@ begin
                BandMapCursorFrequency := rig.FilteredStatus.Freq;
                BandMapBand := ActiveBand;
                BandMapMode := ActiveMode;
-               DisplayBandMap;
+               BandMapNeedsRefresh := True; // coalesced via 250ms timer — avoids flash on every VFO poll
             end;
       end
    else
@@ -3121,7 +3136,7 @@ begin
                BandMapMode := rig.FilteredStatus.Mode;
                VisibleDupeSheetChanged := True;
                BandMapCursorFrequency := rig.FilteredStatus.Freq;
-               DisplayBandMap;     
+               BandMapNeedsRefresh := True; // coalesced via 250ms timer — avoids flash on every VFO poll
             end;
 
          //GAV End of added

--- a/tr4w/src/uSpots.pas
+++ b/tr4w/src/uSpots.pas
@@ -340,6 +340,11 @@ begin
     SendMessage(BandMapListBox, LB_ADDSTRING, 0, FiltSpotIndex[k]);
   tLB_SETCURSEL(BandMapListBox, CurrentCursorPos);
   tSetWindowRedraw(BandMapListBox, True);
+  // WM_SETREDRAW(True) causes the list box to queue an erase+paint, which
+  // produces a visible flash. Cancel the pending erase, then repaint
+  // immediately without erasing — owner-draw items fill their own background.
+  ValidateRect(BandMapListBox, nil);
+  RedrawWindow(BandMapListBox, nil, 0, RDW_INVALIDATE or RDW_NOERASE or RDW_UPDATENOW);
   asm push NumberEntriesDisplayed
   end;
   wsprintf(wsprintfBuffer, TC_SPOTS);

--- a/tr4w/src/uTelnet.pas
+++ b/tr4w/src/uTelnet.pas
@@ -102,7 +102,7 @@ const
 var
   ItemsInTelnetPopupMenu: integer;
   ClientStatus: TClientStatus = (csID: NET_CLIENTSTATUS_ID);
-  BandMapNeedsRefresh: boolean = False;
+  // BandMapNeedsRefresh moved to LogWind so it is accessible from uRadioPolling without circular dependencies
   //  ClusterTypeDetermined            : boolean;
 
   //  tClusterType                          : ClusterType = ctDXSpider;

--- a/tr4w/src/uTelnet.pas
+++ b/tr4w/src/uTelnet.pas
@@ -102,6 +102,7 @@ const
 var
   ItemsInTelnetPopupMenu: integer;
   ClientStatus: TClientStatus = (csID: NET_CLIENTSTATUS_ID);
+  BandMapNeedsRefresh: boolean = False;
   //  ClusterTypeDetermined            : boolean;
 
   //  tClusterType                          : ClusterType = ctDXSpider;
@@ -770,8 +771,13 @@ begin
   begin
     sleep(BMDelay);
     // So we do not drive the serial port and radio too fast.    // 4.93.beta       // 4.102.5
-    if TestSocketBuffer < 1 then
-      DisplayBandMap; //Gav 4.44.6
+    // Signal the 250ms refresh timer rather than repainting immediately.
+    // The timer coalesces bursts of spots into a single repaint, eliminating
+    // flashing. The spot data (FList) is always current; the display is at
+    // most 250ms behind.
+    if BandMapAllBands or (TempSpot.FBand = BandmapBand) then
+      if BandMapAllModes or (TempSpot.FMode = BandmapMode) then
+        BandMapNeedsRefresh := True;
 
 {$IFDEF AUTOSPOT}
     if TwoRadioMode then

--- a/tr4w/src/uTelnet.pas
+++ b/tr4w/src/uTelnet.pas
@@ -824,6 +824,7 @@ var
   DivHertz: boolean;
   QSXBand: BandType;
   QSXMode: ModeType;
+  UpKhz: integer;
 
   Offset: integer;
   ct: Cardinal;
@@ -990,6 +991,30 @@ begin
         TempSpot.FQSXFrequency := TempSpot.FFrequency + 4000;
       if PInteger(@TelnetBuffer[i])^ = $20355055 {UP5 } then
         TempSpot.FQSXFrequency := TempSpot.FFrequency + 5000;
+
+      // Handle "UP <n>" format (space between UP and number, e.g. "UP 5", "UP 10").
+      // Word-boundary guard: require a space (or start of comment field) before
+      // "UP" so that words like "PUP", "CUP", "SOUP" in spot comments don't
+      // trigger a false split.
+      // "UP <n>" with space-separated number, e.g. "UP 5", "UP 10".
+      // Require a space before 'U' (word boundary) and a digit after "UP ".
+      if (TelnetBuffer[i] = 'U') and
+         (TelnetBuffer[i + 1] = 'P') and
+         (TelnetBuffer[i + 2] = ' ') and
+         (TelnetBuffer[i - 1] = ' ') and
+         (TelnetBuffer[i + 3] in ['0'..'9']) then
+         begin
+         UpKhz := 0;
+         for QSXPos := 3 to 8 do
+            begin
+            TempChar := TelnetBuffer[i + QSXPos];
+            if not (TempChar in ['0'..'9']) then
+               Break;
+            UpKhz := UpKhz * 10 + (Ord(TempChar) - 48);
+            end;
+         if UpKhz > 0 then
+            TempSpot.FQSXFrequency := TempSpot.FFrequency + UpKhz * 1000;
+         end;
     end;
   end;
 

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -671,6 +671,7 @@ begin
   if not tHandLogMode then
      begin
      SetTimer(tr4whandle, ONE_SECOND_TIMER_HANDLE, 1000, @OneSecTimerProc);
+     SetTimer(tr4whandle, BANDMAP_REFRESH_TIMER_HANDLE, 250, @BandMapRefreshTimerProc);
      for c := menu_alt_increment_time_1 to menu_alt_increment_time_0 do EnableMenuItem(tr4w_main_menu, c, MF_GRAYED + MF_BYCOMMAND);
      end
   else


### PR DESCRIPTION
## Summary

- **Band map flicker on spot arrival** (#688): 250ms coalesced refresh timer, `WS_EX_COMPOSITED`, `RDW_NOERASE` on redraws, remove duplicate `DisplayBandMap` on startup — flicker greatly reduced
- **Band map flicker on VFO change**: `ProcessFilteredStatus` was calling `DisplayBandMap` directly on every poll cycle; now sets `BandMapNeedsRefresh` so VFO movement coalesces through the same 250ms timer
- **`BandMapNeedsRefresh` relocated**: moved from `uTelnet` to `LogWind` alongside other `BandMap*` globals, eliminating circular dependency risk with `uRadioPolling`
- **Spot deletion**: `DeleteSpotFromBandmap` now calls `DisplayBandMap` immediately; previously deleted spots stayed visible until the next spot arrival
- **K4 serial VFO responsiveness**: `pollingInterval` now follows `FREQUENCY POLL RATE` config setting (default 10ms) instead of hardcoded 1000ms — VFO display updates now match K3 speed
- **Clean shutdown (K3/K4 serial)**: `pKenwood2` and `pKenwoodNew` now check `PollingStopRequested` at the outer loop and inner byte-wait loop — K3/K4 serial polling threads exit in ~20ms on quit instead of timing out after 3000ms
- **Radio logging**: Demote ~25 per-packet/sub-step `logger.Info` calls to `logger.Debug` in `uRadioIcomBase.pas` and `uIcomNetworkTransport.pas`

## Notable: 250ms timer (needs N4AF review)

The coalesced refresh timer is a behavioral change — spot arrivals and VFO changes no longer trigger an immediate repaint; the display updates at most once every 250ms. See comment on #688 for full details. N4AF approval requested before merge.

## Test plan

- [ ] Start TR4W with a saved `BandMap.bin` — verify clean startup, no flash
- [ ] Connect to DX cluster with high spot rate — verify band map updates smoothly without constant flicker
- [ ] Tune VFO — verify band map cursor moves without flashing
- [ ] Right-click band map → Delete a spot — verify it disappears immediately
- [ ] Quit TR4W with K3 or K4 serial connected — verify shutdown is near-instant (was ~4 seconds)
- [ ] Spot click tunes correct radio (regression check for `$26 $01` VFO B mode write)
- [ ] Spot comment containing "Pup" or similar does not trigger false split (UP parser fix regression)
- [ ] Radio log at INFO level no longer shows per-packet CI-V responses