### PR TITLE
Fix Alt-D residue when clicking shorter callsign (issue #872)

### DIFF
--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -116,7 +116,7 @@ var
   BandMapDisplayGhz: boolean;
 
 implementation
-uses MainUnit;
+uses MainUnit, uDupesheet;
 
 function BandmapDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam:
   lParam): BOOL; stdcall;
@@ -441,7 +441,9 @@ begin
               if ((radio1.filteredstatus.freq <> 0) and (radio2.filteredstatus.freq <> 0)) and (QSYInactiveRadio) then
               begin
                 InActiveRadioPtr.BandMemory := Spot.FBand;
-                dupeinfocall := spot.fcall; // 4.135.1
+                tClearDupeInfoCall;              // issue 872: zero buffer before assign to prevent PChar read-past-end
+                ClearAltD;
+                dupeinfocall := spot.fcall;
                 dupecheckoninactiveradio(true);
                 logger.trace('[BandMap::BandmapDlgProc] Calling TuneRadioToSpot for Inactive Radio');
                 TuneRadioToSpot(SpotsList.Get(TempInt), InActiveRadio);


### PR DESCRIPTION
## Summary

- **Root cause:** In `uBandmap.pas`, the double-click path for QSY INACTIVE RADIO assigned `DupeInfoCall` without zeroing the buffer first. `DupeCheckOnInactiveRadio` passes `@DupeInfoCall[1]` as a raw PChar to `wsprintf`, which reads until it finds `#0`. When the new callsign is shorter than the previous one, stale bytes from the old call are read as part of the new string (e.g. clicking `DF9II` after `HB0/PA3CNO` shows `DF9IIA3CNO`).
- **The missing call:** `tClearDupeInfoCall` (which does `ZeroMemory` on the full `Str20` buffer) was not called before the assignment. The correct pattern is established in `uSpots.pas` `TuneDupeCheck` (lines 711-714) and was simply not applied when this code path was added in v4.135.1 (commit 8ce3ce8).
- **Fix:** Add `tClearDupeInfoCall` + `ClearAltD` before `dupeinfocall := spot.fcall` in `uBandmap.pas`, matching the pattern from `uSpots.pas`. Also added `uDupesheet` to `uBandmap`'s implementation uses to make `ClearAltD` visible.

## Repro sequence

1. SO2R mode, `QSY INACTIVE RADIO = TRUE`, `TUNE ALT-D ENABLE = TRUE`, both radios reporting frequency
2. Double-click a **long** callsign in the bandmap (e.g. `HB0/PA3CNO`) — displays correctly
3. Double-click a **shorter** callsign (e.g. `DF9II`) — Alt-D window shows `DF9IIA3CNO` (residue from step 2)

## Test plan

- [ ] Double-click long callsign in bandmap with QSY INACTIVE RADIO enabled — Alt-D shows correct call
- [ ] Double-click shorter callsign — Alt-D shows only the new call, no residue
- [ ] Verify space bar still logs the correct call
- [ ] Verify single-radio mode bandmap click unaffected