### PR TITLE
Issue 871: WinKeyer trace logging + K4 ParseIF log demotion

### DIFF
--- a/tr4w/src/trdos/LogCW.pas
+++ b/tr4w/src/trdos/LogCW.pas
@@ -198,7 +198,7 @@ begin
 
    //localMsg                                               := Format('Adding %s to CW Buffer', [Msg]);
    //AddStringToTelnetConsole(PChar(localMsg),tstAlert);
-   logger.Debug('[AddStringToBuffer] Adding %s to CW Buffer',[Msg]);
+   logger.Debug('[AddStringToBuffer] Adding (%s) to CW Buffer',[Msg]);
    if ( (Msg = CWByCATBufferTerminator) or
         ((CWEnable and CWEnabled and IsCWByCATActive )) ) then   // ny4i 4.44.5    + Issue 111
       begin

--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -471,15 +471,15 @@ if applicable (0=DATA A, 1=AFSK A, 2= FSK D, 3=PSK D)
 
    Self.localRITOffset := (ritOffset * ritMultiplier);
    Self.localXITOffset := (Self.localRITOffset); // Because on K4, these are the same
-   logger.debug('[ParseIFCommand] RITOffset = %d',[Self.localRITOffset]);
+   logger.trace('[ParseIFCommand] RITOffset = %d',[Self.localRITOffset]);
    
    Delete(s,1,4);                      // rx*00tmvspbd1*;
    Self.RITState := AnsiLeftStr(s,1) = '1';
-   logger.Debug('In IF processor, RIT is %s',[AnsiLeftStr(s,1)]);
+   logger.trace('In IF processor, RIT is %s',[AnsiLeftStr(s,1)]);
 
    Delete(s,1,1);                      // x*00tmvspbd1*;
    Self.XITState := AnsiLeftStr(s,1) = '1';
-   logger.Debug('In IF processor, XIT is %s',[AnsiLeftStr(s,1)]);
+   logger.trace('In IF processor, XIT is %s',[AnsiLeftStr(s,1)]);
 
    Delete(s,1,1);
    Delete(s,1,1); // Skip space       // *00tmvspbd1*;
@@ -494,11 +494,11 @@ if applicable (0=DATA A, 1=AFSK A, 2= FSK D, 3=PSK D)
       Self.RadioState := rsReceive;
       end;
    Delete(s,1,1);
-   logger.debug('[ParseIFCommand] string at mode = %s',[s]);
+   logger.trace('[ParseIFCommand] string at mode = %s',[s]);
    sMode := AnsiLeftStr(s,1);          // mvspbd1*;
 
    Delete(s,1,1);
-   logger.debug('[ParseIFCommand] string at vfo = %s',[s]);
+   logger.trace('[ParseIFCommand] string at vfo = %s',[s]);
    sVFO := AnsiLeftStr(s,1);           // vspbd1*;
 
    Delete(s,1,2); // Skip s as we do not care if scanning  // spbd1*;

--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -502,7 +502,7 @@ if applicable (0=DATA A, 1=AFSK A, 2= FSK D, 3=PSK D)
    sVFO := AnsiLeftStr(s,1);           // vspbd1*;
 
    Delete(s,1,2); // Skip s as we do not care if scanning  // spbd1*;
-   logger.debug('[ParseIFComand] Checking split command in %s',[s]);
+   logger.trace('[ParseIFComand] Checking split command in %s',[s]);
    Self.localSplitEnabled := AnsiLeftStr(s,1) = '1';           // pbd1*;
 
 
@@ -626,7 +626,7 @@ begin
 
    Case AnsiIndexText(AnsiUppercase(sCommand), ['AI','BI','BN','DT','FA','FB','FT','IF','KS','MA','MD','RT','RX','TX','XT','RO', 'FP']) of
       0: begin                                     // AI
-         logger.info('[ProcessMessage] AI command set to %s',[sData]);
+         logger.debug('[ProcessMessage] AI command set to %s',[sData]);
          end;
       1: begin            // BI
          if sData = '1' then
@@ -642,7 +642,7 @@ begin
             end;
          vfo.band := Self.BandNumToBand(sData);   // if I just set this, then CurrentStatus.band does not get set. It requires the next line to show up upon resetting the ports.
          Self.vfo[nrVFOA].band := Self.BandNumToBand(sData);     // These two things should be the same.
-         logger.debug('[ProcessMessage] Received band number of %s',[sData]);
+         logger.trace('[ProcessMessage] Received band number of %s',[sData]);
          end;
       3: begin             // DT
          // DT updates only the remembered data sub-mode.
@@ -685,7 +685,7 @@ begin
          end;
       6: begin             // FT
          Self.localSplitEnabled := AnsiLeftStr(sData,1) = '1';
-         logger.debug('[ProcessMessage] FT (Split) received - Split is %s - localSplitEnabled = %s',[AnsiLeftStr(sData,1),BoolToString(Self.localSplitEnabled)]);
+         logger.trace('[ProcessMessage] FT (Split) received - Split is %s - localSplitEnabled = %s',[AnsiLeftStr(sData,1),BoolToString(Self.localSplitEnabled)]);
          end;
       7: begin             // IF
          Self.ParseIFCommand(sData);
@@ -722,7 +722,7 @@ begin
       14:begin              // XT
          vfo.XITState := AnsiLeftStr(sData,1) = '1';
          //Self.XITState := AnsiLeftStr(sData,1) = '1';
-         logger.debug('[ProcessMessage] XIT Enabled is %s',[AnsiLeftStr(sData,1)]);
+         logger.trace('[ProcessMessage] XIT Enabled is %s',[AnsiLeftStr(sData,1)]);
          end;
       15:begin    // RO
          RITSign := IfThen(AnsiLeftStr(sData,1) = '-',-1,1);
@@ -774,7 +774,7 @@ var
    iBand: integer;
 begin
    iBand := StrToIntDef(sBand,-9);
-   logger.debug('[BandNumToBand] Converting band string "%s" to iBand=%d', [sBand, iBand]);
+   logger.trace('[BandNumToBand] Converting band string "%s" to iBand=%d', [sBand, iBand]);
    case iBand of
       0: Result := rb160m;
       1: Result := rb80m;
@@ -797,7 +797,7 @@ begin
       Result := rbNone;
       end;
    end;
-   logger.debug('[BandNumToBand] Result band = %d', [Ord(Result)]);
+   logger.trace('[BandNumToBand] Result band = %d', [Ord(Result)]);
 end;
 
 procedure TK4Radio.PollRadioState;

--- a/tr4w/src/uWinKey.pas
+++ b/tr4w/src/uWinKey.pas
@@ -257,6 +257,7 @@ const
 
 implementation
 uses
+  SysUtils,
   uNet,
   LogDupe,
   uTelnet, {LogRadio,}
@@ -349,18 +350,23 @@ end;
 
 function wkSend(const Buffer; nNumberOfBytesToWrite: DWORD): Cardinal;
 begin
+  logger.Debug('[wkSend] writing %d byte(s) to WinKeyer', [nNumberOfBytesToWrite]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   tWriteFile(WinKeyHandle, Buffer, nNumberOfBytesToWrite, Result);
 end;
 
 procedure wkSendAdminCommand(const Buffer);
+var
+  Bytes: array[0..1] of Byte absolute Buffer;
 begin
+  logger.Debug('[wkSendAdminCommand] B1=$%s B2=$%s', [IntToHex(Bytes[0], 2), IntToHex(Bytes[1], 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   sWriteFile(WinKeyHandle, Buffer, 2);
 end;
 
 function wkSendByte(b: Byte): Cardinal;
 begin
+  logger.Debug('[wkSendByte] b=%s ($%s)', [string(Char(b)), IntToHex(b, 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   sWriteFile(WinKeyHandle, b, 1);
 {$IF K6VVA_WK_DEBUG}
@@ -376,6 +382,8 @@ function wkSendTwoBytes(B1, B2: Byte): Cardinal;
 var
   TwoBytesBuffer                        : array[0..1] of Byte;
 begin
+  logger.Debug('[wkSendTwoBytes] B1=%s ($%s) B2=%s ($%s)',
+               [string(Char(B1)), IntToHex(B1, 2), string(Char(B2)), IntToHex(B2, 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   TwoBytesBuffer[0] := B1;
   TwoBytesBuffer[1] := B2;
@@ -909,6 +917,8 @@ begin
 {$IF WINKEYDEBUG}
 //  AddStringToTelnetConsole(PChar(string(c)));
 {$IFEND}
+  logger.Debug('[wkAddCharToHostBuffer] char=%s (ord=%d $%s)',
+              [string(c), Ord(c), IntToHex(Ord(c), 2)]);
   wkInternalCWBuffer[wkHostBufferIndex] := c;
   inc(wkHostBufferIndex);
   if wkHostBufferIndex = SizeOfHostBuffer then wkHostBufferIndex := 0;
@@ -942,6 +952,8 @@ var
 begin
   if length(Msg) = 0 then
   Exit;
+
+  logger.Debug('[wkAddCWMessageToInternalBuffer] Msg="%s" len=%d', [Msg, length(Msg)]);
 
   for i := 1 to length(Msg) do
   begin
@@ -1038,6 +1050,10 @@ begin
 //    if wkXOFF then Exit;
 {$IFEND}
 
+    logger.Debug('[wkSendNextByteFromHostBuffer] sending char=%s (ord=%d $%s)',
+                 [string(wkInternalCWBuffer[wkHostBufferSendIndex]),
+                  Ord(wkInternalCWBuffer[wkHostBufferSendIndex]),
+                  IntToHex(Ord(wkInternalCWBuffer[wkHostBufferSendIndex]), 2)]);
     wkSendByte(Ord(wkInternalCWBuffer[wkHostBufferSendIndex]));
 
 {$IF K6VVA_WK_DEBUG}


### PR DESCRIPTION
## Summary

- **WinKey trace logging** (`uWinKey.pas`, `LogCW.pas`): adds Debug-level log entries to seven WinKeyer pipeline procedures (`wkSend`, `wkSendAdminCommand`, `wkSendByte`, `wkSendTwoBytes`, `wkAddCharToHostBuffer`, `wkAddCWMessageToInternalBuffer`, `wkSendNextByteFromHostBuffer`) showing printable character and hex value at each step. Needed for LU5DX to capture a trace and identify the source of the extra space in AUTO SEND CHARACTER COUNT mode (issue #871).
- **K4 log demotion** (`uRadioElecraftK4.pas`): demotes verbose ParseIFCommand sub-step log entries from Debug to Trace, reducing log noise during normal operation.

## Test plan

- [ ] Enable `DEBUG LOG LEVEL = DEBUG` in `settings/tr4w.ini`
- [ ] Trigger CW send via AUTO SEND CHARACTER COUNT
- [ ] Collect `tr4w.log` and review `[wkAddCWMessageToInternalBuffer]` and `[wkAddCharToHostBuffer]` entries for any unexpected `$20` (space) characters
- [ ] LU5DX to provide trace log for analysis