### PR TITLE
Issue #817: Yaesu FTX-1F/FTX-1R radio support

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -5263,6 +5263,22 @@ begin
     TempBuffer1[4] := #0; //temp
     if PInteger(@TempBuffer1)^ <> CURRENTVERSIONASINTEGER then
     begin
+      // If the file is NEWER than this program we cannot safely open or convert
+      // it. Show a clear error and stop — never attempt a downgrade conversion.
+      if StrPas(TempBuffer1) > LOGVERSION then
+         begin
+         logger.Fatal('Log file version ' + StrPas(TempBuffer1) +
+            ' is newer than this program (' + LOGVERSION + ').' +
+            ' Upgrade TR4W to open this log.');
+         ShowMessage(PChar(
+            'This log file was created by a newer version of TR4W (' +
+            StrPas(TempBuffer1) + ').' + #13#10 +
+            'This program understands up to version ' + LOGVERSION + '.' + #13#10 +
+            'Please upgrade TR4W to open this log.'));
+         CloseLogFile;
+         Halt;
+         end;
+
       Format(wsprintfBuffer, TC_DIFVERSION, _LOGFILE, LogHeader.lhVersionString,
         TempBuffer1);
       showwarning(wsprintfBuffer);

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -985,6 +985,7 @@ type
     FT100,
     FTDX10,
     FTDX101,
+    FTX1F,     // Yaesu FTX-1F/FTX-1R — rtYaesu4, 30-byte IF response (Issue #817)
     FT450,
     FT710,
     FT736R,

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -503,6 +503,7 @@ const
     ({Name: 'FT100';      } BR:BR4800;  P: 1; C: 0; S: 0; T:1; RA: $00; SW: 1; SFOC: $0A; SMOC: $0C; SPOC: $00; RX: $00; TX: $00; MB: 3; CW: $02;  LSB: $00; USB: $01; FM: $06; AM: $04; DIGL: $05; DIGU: $05; hamlibID: 1021; rt: rtYaesu1),
     ({Name: 'FTDX10';     } BR:BR4800;  P: 1; C: 1; S: 1; T:1; RA: $00; SW: 1; SFOC: $00; SMOC: $00; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $00;  LSB: $00; USB: $00; FM: $00; AM: $00; DIGL: $00; DIGU: $00; hamlibID: 1042; rt: rtYaesu4),
     ({Name: 'FTDX101';    } BR:BR4800;  P: 1; C: 1; S: 1; T:1; RA: $00; SW: 1; SFOC: $00; SMOC: $00; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $00;  LSB: $00; USB: $00; FM: $00; AM: $00; DIGL: $00; DIGU: $00; hamlibID: 1040; rt: rtYaesu4),
+    ({Name: 'FTX1F';      } BR:BR4800;  P: 1; C: 1; S: 1; T:1; RA: $00; SW: 1; SFOC: $00; SMOC: $00; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $00;  LSB: $00; USB: $00; FM: $00; AM: $00; DIGL: $00; DIGU: $00; hamlibID: 1051; rt: rtYaesu4),  // FTX-1F/FTX-1R — Issue #817
     ({Name: 'FT450';      } BR:BR4800;  P: 1; C: 1; S: 1; T:1; RA: $00; SW: 1; SFOC: $00; SMOC: $00; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $00;  LSB: $00; USB: $00; FM: $00; AM: $00; DIGL: $00; DIGU: $00; hamlibID: 1027; rt: rtYaesu2),
     ({Name: 'FT710';      } BR:BR4800;  P: 1; C: 1; S: 1; T:1; RA: $00; SW: 1; SFOC: $00; SMOC: $00; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $00;  LSB: $00; USB: $00; FM: $00; AM: $00; DIGL: $00; DIGU: $00; rt: rtYaesu4),   // Issue 640 ny4i
     ({Name: 'FT736R';     } BR:BR4800;  P: 0; C: 0; S: 0; T:0; RA: $00; SW: 0; SFOC: $01; SMOC: $07; SPOC: $00; RX: $00; TX: $00; MB: 0; CW: $02;  LSB: $00; USB: $01; FM: $08; AM: $00; DIGL: $00; DIGU: $00; hamlibID: 1010; rt: rtYaesu1),
@@ -607,6 +608,7 @@ const
       'FT100',
       'FTDX10',
       'FTDX101',
+      'FTX-1',
       'FT450',
       'FT710',
       'FT736R',
@@ -953,7 +955,7 @@ begin
 
    case IntRadioType of
       TS140, TS440, TS450, TS480, TS570, TS590, TS690, TS850, TS870, TS940,
-      TS950, TS990, TS2000, FLEX, K2, K3, K4, FTDX10, FTDX101, FT450, FT891, FT950, FT991, FT1200, FT2000, FTDX3000,
+      TS950, TS990, TS2000, FLEX, K2, K3, K4, FTDX10, FTDX101, FTX1F, FT450, FT891, FT950, FT991, FT1200, FT2000, FTDX3000,
       FTDX5000, FTDX9000:
          begin
          ActiveRadioPtr.WriteBufferToCATPort('RC;');
@@ -2057,7 +2059,7 @@ begin
          begin
          ActiveRadioPtr.WriteToCATPort('ST1;', 4);
          end;
-      FTDX10, FTDX101, FT991:
+      FTDX10, FTDX101, FTX1F, FT991:
          begin
          ActiveRadioPtr.WriteToCATPort('FT3;', 4);
          end;
@@ -2121,7 +2123,7 @@ begin
          begin
           ActiveRadioPtr.WriteToCATPort('ST0;', 4);
          end;
-      FTDX10, FTDX101, FT991:
+      FTDX10, FTDX101, FTX1F, FT991:
          begin
          ActiveRadioPtr.WriteToCATPort('FT2;', 4);
          end;
@@ -4072,7 +4074,7 @@ begin
             end;
          end;
 
-      FTDX10, FTDX101, FT710, FT450, FT950, FT891, FT991, FT1200, FT2000,
+      FTDX10, FTDX101, FTX1F, FT710, FT450, FT950, FT891, FT991, FT1200, FT2000,
       FTDX3000, FTDX5000, FTDX9000:
          begin
          if PTTOn then
@@ -4193,14 +4195,14 @@ begin
                             IC7800, IC7850, IC7851, IC9100, IC9700, IC905, IC7300MK2, Orion];
    // ny4i Issue 119
    RadioSupportsCWSpeedSync :=
-      [TS850, K2, K3, K4, TS480, TS570, TS590, TS990, TS2000, FLEX, FTDX10, FTDX101, FT450, FT710, FT891, FT950, FT991,
+      [TS850, K2, K3, K4, TS480, TS570, TS590, TS990, TS2000, FLEX, FTDX10, FTDX101, FTX1F, FT450, FT710, FT891, FT950, FT991,
       FT1200, FT2000, FTDX3000, FTDX5000, FTDX9000, IC718, IC746, IC746PRO, IC756PROII,
       IC756PROIII, IC910, IC705, IC7100, IC7200, IC7300, IC7410, IC7600, IC7610,
       IC7700, IC7760, IC7800, IC7850, IC7851, IC9100, IC9700, IC905, IC7300MK2, Orion];  // ny4i Issue 120
 
    RadioSupportsPlayDVK := [ K2, K3, K4 // We do not support the KX2 and KX3? I guess not a lot of call for it.
                             ,IC705, IC7300, IC7610, IC7760, IC7850, IC7851, IC9100, IC9700, IC905, IC7300MK2
-                            ,FT710, FT991, FT1200, FTDX3000, FTDX5000, FTDX9000, FTDX10, FTDX101
+                            ,FT710, FT991, FT1200, FTDX3000, FTDX5000, FTDX9000, FTDX10, FTDX101, FTX1F
                             ,TS480, TS570, TS590, TS850, TS950, TS990, TS2000
                             ]; // NY4I Issue 639
    IcomRadiosThatSupportRIT := [IC705, IC7100, IC7300, IC7800, IC7850, IC7851, IC7600, IC7610, IC7700, IC7760, IC9700, IC905, IC7300MK2];
@@ -4209,7 +4211,7 @@ begin
    ICOMRadios := [IC78..IC9700, IC905, IC7300MK2];
    KenwoodRadios := [TS140, TS440, TS450, TS480, TS570, TS590, TS690, TS850,
                      TS870, TS940, TS950, TS990, TS2000, FLEX];
-   YaesuRadios := [FTDX10, FTDX101, FT450, FT710, FT736R, FT747GX, FT767, FT817,
+   YaesuRadios := [FTDX10, FTDX101, FTX1F, FT450, FT710, FT736R, FT747GX, FT767, FT817,
                    FT818, FT840, FT847, FT857, FT890, FT891, FT897, FT900, FT920,
                    FT950, FT990, FT991, FT1000, FT1000MP, FT1200, FT2000,
                    FTDX3000, FTDX5000, FTDX9000];

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -78,6 +78,7 @@ procedure SetVFOModeExtendedMode(rig: RadioPtr; which: Cardinal; mode: ModeType;
 
 procedure pFTDX9000(rig: RadioPtr);
 procedure pFTDX10_FTDX101(rig: RadioPtr);
+procedure pFTX1F(rig: RadioPtr);
 procedure pFT891_FT991(rig: RadioPtr);
 procedure pOrion(rig: RadioPtr);
 procedure pOrion3(rig: RadioPtr);
@@ -96,6 +97,8 @@ function GetFrequencyForYaesuFT747(a: PChar): Cardinal;
 procedure GetVFOInfoForYaesuType3(buf: PChar; var VFO: VFOStatusType;
    FrequencyAdder: integer);
 procedure GetVFOInfoForYaesuType5(buf: PChar; var VFO: VFOStatusType;
+   FrequencyAdder: integer);
+procedure GetVFOInfoForYaesuFTX1(buf: PChar; var VFO: VFOStatusType;
    FrequencyAdder: integer);
 procedure BeginPolling(rig: RadioPtr); stdcall;
 procedure SetDCBForIcom(port: HWND);
@@ -3474,6 +3477,8 @@ begin
          pFT891_FT991(rig); // ny4i Issue218 9 byte frequency
       FTDX10, FTDX101, FT710:
          pFTDX10_FTDX101(rig);
+      FTX1F:
+         pFTX1F(rig);
       IC78..IC9700, OMNI6:
          pIcomNew(rig);
       //    pIcom(rig);
@@ -3751,6 +3756,216 @@ begin
    VFO.Mode := TempMode;
    VFO.ExtendedMode := tempExtendedMode;
 
+end;
+//------------------------------------------------------------------------------
+procedure GetVFOInfoForYaesuFTX1(buf: PChar; var VFO: VFOStatusType;
+   FrequencyAdder: integer);
+   // FTX-1F/FTX-1R IF response layout (30 bytes total, Issue #817):
+   //   Pos 1-2:   "IF"
+   //   Pos 3-7:   P1  VFO/memory channel (5 bytes — 2 longer than FTDX10's 3-byte P1)
+   //   Pos 8-16:  P2  VFO frequency Hz (9 bytes)
+   //   Pos 17:    P3  Clarifier direction (+/-)
+   //   Pos 18-21: P3  Clarifier offset 0000-9990 Hz (4 bytes)
+   //   Pos 22:    P4  RX CLAR on/off
+   //   Pos 23:    P5  TX CLAR on/off
+   //   Pos 24:    P6  Mode
+   //   Pos 25:    P7  VFO type
+   //   Pos 26:    P8  CTCSS
+   //   Pos 27-28: P9  Fixed "00"
+   //   Pos 29:    P10 Simplex/shift
+   //   Pos 30:    ";"
+var
+   TempMode         : ModeType;
+   TempExtendedMode : ExtendedModeType;
+begin
+   TempMode := NoMode;
+   VFO.Frequency := BufferToInt(buf, 8, 9) + FrequencyAdder;
+   CalculateBandMode(VFO.Frequency, VFO.Band, VFO.Mode);
+   VFO.RITFreq := BufferToInt(buf, 17, 5);  // direction byte + 4-digit offset
+   VFO.RIT     := buf[22 - 1] = '1';        // P4 RX CLAR
+   VFO.XIT     := buf[23 - 1] = '1';        // P5 TX CLAR
+   case buf[24 - 1] of                       // P6 MODE
+      '1':
+         begin
+         TempMode         := Phone;
+         TempExtendedMode := eLSB;
+         end;
+      '2':
+         begin
+         TempMode         := Phone;
+         TempExtendedMode := eUSB;
+         end;
+      '3':
+         begin
+         TempMode         := CW;
+         TempExtendedMode := eCW;
+         end;
+      '4':
+         begin
+         TempMode         := FM;
+         TempExtendedMode := eFM;
+         end;
+      '5':
+         begin
+         TempMode         := Phone;
+         TempExtendedMode := eAM;
+         end;
+      '6':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eRTTY_R;
+         end;
+      '7':
+         begin
+         TempMode         := CW;
+         TempExtendedMode := eCW_R;
+         end;
+      '8':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eData_R;
+         end;
+      '9':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eRTTY;
+         end;
+      'A':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eData_FM;
+         end;
+      'B':
+         begin
+         TempMode         := FM;
+         TempExtendedMode := eFM_N;
+         end;
+      'C':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eData;
+         end;
+      'D':
+         begin
+         TempMode         := Phone;
+         TempExtendedMode := eAM_N;
+         end;
+      'E':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := ePSK31;
+         end;
+      'F':
+         begin
+         TempMode         := Digital;
+         TempExtendedMode := eData_FM;
+         end;
+      'H':
+         begin
+         // C4FM-DN (digital narrow) Yaesu System Fusion digital voice
+         TempMode         := Phone;
+         TempExtendedMode := eC4FM;
+         end;
+      'I':
+         begin
+         // C4FM-VW (digital voice wide) Yaesu System Fusion digital voice
+         TempMode         := Phone;
+         TempExtendedMode := eC4FM;
+         end;
+      '0', 'G', 'J':
+         begin
+         // Unused/reserved mode values in FTX-1 CAT manual
+         TempMode         := NoMode;
+         TempExtendedMode := eNoMode;
+         end;
+      else
+         begin
+         logger.Error('Unknown mode value for FTX-1F: ' + buf[24 - 1]);
+         TempMode         := NoMode;
+         TempExtendedMode := eNoMode;
+         end;
+   end;
+   VFO.Mode         := TempMode;
+   VFO.ExtendedMode := TempExtendedMode;
+end;
+//------------------------------------------------------------------------------
+procedure pFTX1F(rig: RadioPtr);
+   // FTX-1F/FTX-1R polling procedure (Issue #817).
+   // IF; and OI; responses are 30 bytes (vs 28 for FTDX10) because the
+   // VFO/memory-channel field (P1) is 5 bytes instead of 3.
+label
+   1;
+var
+   TempVFO: VFOStatusType;
+begin
+   repeat
+      inc(rig.tPollCount);
+
+      rig.WritePollRequest('IF;', 3);
+         // Retrieves VFO A (Primary). Get other VFO with OI; command.
+      if ((not ReadFromCOMPort(30, rig)) or
+         (PWORD(@rig.tBuf)^ <> $4649)) then
+         begin
+         ClearRadioStatus(rig);
+         goto 1;
+         end;
+
+      GetVFOInfoForYaesuFTX1(@rig.tBuf, rig.CurrentStatus.VFO[VFOA],
+         rig.FrequencyAdder);
+
+      rig.WritePollRequest('OI;', 3);  // Opposite VFO information
+      if ((not ReadFromCOMPort(30, rig)) or
+         (PWORD(@rig.tBuf)^ <> $494F)) then
+         begin
+         ClearRadioStatus(rig);
+         goto 1;
+         end;
+
+      GetVFOInfoForYaesuFTX1(@rig.tBuf, rig.CurrentStatus.VFO[VFOB],
+         rig.FrequencyAdder);
+
+      TempVFO := rig.CurrentStatus.VFO[VFOA];
+      rig^.CurrentStatus.VFOStatus := VFOA;
+
+      rig.WritePollRequest('FT;', 3);
+      if not ReadFromCOMPort(4, rig) then
+         begin
+         ClearRadioStatus(rig);
+         goto 1;
+         end;
+      if rig.tBuf[3] = '1' then
+         rig^.CurrentStatus.Split := true
+      else if rig.tBuf[3] = '0' then
+         rig^.CurrentStatus.Split := false
+      else
+         begin
+         logger.Error('FTX-1F: unexpected FT; response (Split set to false): ' + rig.tBuf);
+         rig^.CurrentStatus.Split := false;
+         end;
+
+      rig.WritePollRequest('TX;', 3);
+      if not ReadFromCOMPort(4, rig) then
+         begin
+         ClearRadioStatus(rig);
+         goto 1;
+         end;
+      if rig.tBuf[3] in ['1', '2'] then
+         rig^.CurrentStatus.TXOn := true
+      else if rig.tBuf[3] = '0' then
+         rig^.CurrentStatus.TXOn := false
+      else
+         begin
+         logger.Error('FTX-1F: unexpected TX; response (TXOn set to false): ' + rig.tBuf);
+         rig^.CurrentStatus.TXOn := false;
+         end;
+
+      rig.CurrentStatus.ExtendedMode := TempVFO.ExtendedMode;
+      rig.CurrentStatus.RITFreq     := TempVFO.RITFreq;
+      rig.CurrentStatus.RIT         := TempVFO.RIT;
+      rig.CurrentStatus.XIT         := TempVFO.XIT;
+      1:
+      UpdateStatus(rig);
+   until rig.tPollCount < 0;
 end;
 
 procedure SetVFOA(rig: RadioPtr);


### PR DESCRIPTION
## Summary

- **FTX-1F/FTX-1R serial CAT support**: new polling procedure `pFTX1F` and parser `GetVFOInfoForYaesuFTX1` using the `rtYaesu4` protocol family. The FTX-1 IF response is 30 bytes (vs FTDX10's 28) due to a 5-byte P1 field, shifting all subsequent field positions by +2. C4FM voice modes (H/I) map to `Phone`/`eC4FM`.
- **LOGRADIO.PAS**: `RadioParametersArray` entry with HamLib model 1051, radio added to all required sets (RIT clear, split, PTT, CW speed sync, DVK, YaesuRadios).
- **Log version guard** (`MainUnit.pas`): opening a log file whose version exceeds the program's `LOGVERSION` now shows a clear error dialog and halts, rather than offering a meaningless downgrade conversion.

## Test plan

- [ ] Select FTX-1 from radio dropdown — confirm polling starts without errors
- [ ] Verify frequency and mode update correctly from radio
- [ ] Test split TX/RX (FT3;/FT2;)
- [ ] Confirm opening a log file with a future version (e.g. v1.8) shows the error dialog and exits cleanly