### PR TITLE
May 2026 — accumulated fixes, features, and tests

### DIFF
--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -20,7 +20,8 @@ $TEST_DCU_DIR = "C:\Temp\tr4w-test"
 New-Item -ItemType Directory -Force -Path $TEST_DCU_DIR | Out-Null
 
 Push-Location $TEST_DIR
-& $DCC32 $TEST_DPR -`$D+ -`$L+ -`$Y+ "-N$TEST_DCU_DIR" "/E$TEST_DIR"
+# /U includes src\ so VC.pas (and Log4D.dcu within it) resolve correctly
+& $DCC32 $TEST_DPR -`$D+ -`$L+ -`$Y+ "-N$TEST_DCU_DIR" "/E$TEST_DIR" "/UC:\TR4W\tr4w\src"
 $testBuildResult = $LASTEXITCODE
 Pop-Location
 

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -591,6 +591,64 @@ begin
     end;
 end;
 
+// Issue: state-QP rover slash-in-call (e.g. "KG1S/PIN").  When the
+// operator types a call with a /COUNTY suffix, treat the suffix as the
+// rover's current location: strip the /COUNTY off the call and pre-fill
+// the exchange field with the county.  Net effect — the QSO is logged
+// with the bare call (KG1S) and county PIN, and the Cabrillo / ADIF
+// output is correct without any output-side stripping.
+//
+// Only fires when:
+//   - active exchange is a state-QP type
+//   - the call contains exactly one '/'
+//   - the suffix validates as a domestic QTH (so /M, /P, /4 etc. are left
+//     alone for other code paths to handle)
+//   - the exchange field is empty (operator hasn't typed something else)
+//
+// Note: this means subsequent rover QSOs from the same callsign in
+// different counties will be flagged as dupes (same logged callsign).
+// Address scoring/dupe behaviour for QP rovers in a follow-up issue.
+
+procedure ApplyRoverSlashInCall;
+var
+  CallStr     : string;
+  SlashPos    : Integer;
+  RoverCounty : string;
+  ProbeRX     : ContestExchange;
+begin
+  if not ((ActiveExchange = RSTDomesticQTHExchange) or
+          (ActiveExchange = RSTQTHExchange) or
+          (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
+     Exit;
+
+  CallStr := string(CallWindowString);
+  SlashPos := Pos('/', CallStr);
+  if SlashPos = 0 then
+     Exit;
+
+  RoverCounty := UpperCase(Copy(CallStr, SlashPos + 1, Length(CallStr) - SlashPos));
+  if RoverCounty = '' then
+     Exit;
+
+  // Validate the suffix against the domestic-mults table using a scratch
+  // ContestExchange so we don't disturb any global state.
+  FillChar(ProbeRX, SizeOf(ProbeRX), 0);
+  ProbeRX.QTHString := RoverCounty;
+  if not FoundDomesticQTH(ProbeRX) then
+     Exit;  // /M, /P, /4 or any non-county suffix — leave alone
+
+  // Strip the suffix from the call and update the call window.
+  CallWindowString := Copy(CallStr, 1, SlashPos - 1);
+  Windows.SetWindowText(wh[mweCall], PChar(string(CallWindowString)));
+
+  // Pre-fill the exchange only if the operator hasn't already typed something.
+  if ExchangeWindowString = '' then
+     begin
+     ExchangeWindowString := RoverCounty;
+     Windows.SetWindowText(wh[mweExchange], PChar(string(ExchangeWindowString)));
+     end;
+end;
+
 function TryLogContact: boolean;
 var
   // Saved before ClearContestExchange wipes ReceivedData; passed to
@@ -600,6 +658,10 @@ var
   SavedRSTSent : Integer;
   begin
   Result := False;
+
+  // Issue: state-QP rover (KG1S/PIN) — strip rover suffix and pre-fill
+  // exchange so downstream code sees clean inputs.
+  ApplyRoverSlashInCall;
 
   if ParametersOkay(CallWindowString, ExchangeWindowString, ActiveBand,
     ActiveMode, ActiveRadioPtr.LastDisplayedFreq

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -561,6 +561,14 @@ end;
 //
 // Issue #885 (county lines) and POTA Nfer.
 
+// Build the per-QSO exchange string in <RST> <QTH> form so each multi-ref
+// QSO gets its own ADIF SRX_STRING instead of the combined original input.
+// Issue #889.
+function PerQSOExchString(const RXData: ContestExchange): string;
+begin
+  Result := IntToStr(RXData.RSTReceived) + ' ' + string(RXData.QTHString);
+end;
+
 procedure DrainPendingMultiQSORefs;
 var
   TempRX : ContestExchange;
@@ -571,12 +579,14 @@ begin
   while HasPendingParks do
     begin
     TempRX.QTHString := DequeuePendingPark;
+    TempRX.ExchString := PerQSOExchString(TempRX);   // Issue #889
     LogContact(TempRX, True);
     end;
   while HasPendingCounties do
     begin
     TempRX.QTHString := DequeuePendingCounty;
     FoundDomesticQTH(TempRX);  // refresh DomMultQTH/DomesticQTH
+    TempRX.ExchString := PerQSOExchString(TempRX);   // Issue #889
     LogContact(TempRX, True);
     end;
 end;
@@ -602,6 +612,14 @@ var
 {$IFEND}
     ReceivedData.ceSearchAndPounce := OpMode = SearchAndPounceOpMode;
     ReceivedData.ceComputerID := ComputerID;
+
+    // Issue #889: when this is a multi-county or multi-park entry, the
+    // parser has queued additional refs and ParametersOkay just stamped
+    // ReceivedData.ExchString with the COMBINED original input
+    // (e.g. "57 PIN/HIL").  Rewrite to per-QSO form for the first QSO so
+    // each ADIF SRX_STRING reflects only its own ref.
+    if HasPendingParks or HasPendingCounties then
+       ReceivedData.ExchString := PerQSOExchString(ReceivedData);
 
     LogContact(ReceivedData, True);
     DrainPendingMultiQSORefs;

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3535,6 +3535,7 @@ begin
               Windows.CopyMemory(@CurrentOperator, @TempCallstring[1], 6);
               SetMainWindowText(mweCurrentOperator, CurrentOperator);
               Sheet.SaveRestartFile; // Issue 661 ny4i
+              SendStationStatus(sstOperator);
             end
             else
             begin
@@ -3546,6 +3547,7 @@ begin
             Windows.CopyMemory(@CurrentOperator, @TempCallstring[1], 6);
             SetMainWindowText(mweCurrentOperator, CurrentOperator);
             Sheet.SaveRestartFile; // Issue 661 ny4i
+            SendStationStatus(sstOperator);
           end
           else
           begin

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -1356,7 +1356,7 @@ const
     );
 
 type
-  StationStatusType = (sstComputerNameAndID, sstBandModeFreq, sstPTT, sstOpMode, sstQSOs, sstCallsign);
+  StationStatusType = (sstComputerNameAndID, sstBandModeFreq, sstPTT, sstOpMode, sstQSOs, sstCallsign, sstOperator);
 
   TStationState = packed record
 
@@ -1375,6 +1375,8 @@ type
     {09}ssName: array[0..8] of Char;
 
     {01}ssType: StationStatusType;
+
+    {11}ssOperator: OperatorType;
   end;
 
 type

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -1766,7 +1766,7 @@ const
       //   (isString: @TailEndPhoneMessage; isPcharString: 'TAILEND.WAV'),
   
       (isString: @GetScoresSeverPostingAddress; isPcharString:
-         'http://post.contestonlinescore.com'),
+         'https://post.contestonlinescore.com/post/'),
       (isString: @GetScoresSeverReadingAddress; isPcharString:
          'https://contestonlinescore.com/scoreboard/'),
 

--- a/tr4w/src/uEditMessage.pas
+++ b/tr4w/src/uEditMessage.pas
@@ -179,7 +179,17 @@ begin
 //        if lParam = integer(MsgEditHWND) then if HiWord(wParam) = EN_KILLFOCUS then DestroyHintListBox;
 
         case wParam of
-          3: CreateModalDialog(225, 170, EditMessageWnd, @MessagesListDlgProc, 0);
+          3:
+            begin
+            // SelPos[102] is saved by EN_KILLFOCUS when the edit field loses
+            // focus to this button, so it already holds the cursor position.
+            if CreateModalDialog(225, 170, EditMessageWnd, @MessagesListDlgProc, 0) = 1 then
+              begin
+              Windows.SendMessage(MsgEditHWND, EM_SETSEL, SelPos[102], SelPos[102]);
+              Windows.SendMessage(MsgEditHWND, EM_REPLACESEL, 1, Integer(PChar(LastSelectedCommand)));
+              SetFocus(MsgEditHWND);
+              end;
+            end;
           109:
             begin
               i := Windows.GetDlgItemText(hwnddlg, 102, @TempBuffer2, SizeOf(ID));

--- a/tr4w/src/uGetScores.pas
+++ b/tr4w/src/uGetScores.pas
@@ -38,13 +38,12 @@ uses
   LogWind,
   utils_net,
   utils_file,
-  WinSock2,
+  Classes,
+  SysUtils,
+  IdHTTP,
+  IdSSLOpenSSL,
   Tree
   ;
-type
-
-  TUrlGetPart = function(pszIn: PChar; pszOut: PChar; pcchOut: LPDWORD; dwPart, dwFlags: DWORD): HRESULT; stdcall;
-
 function GetScoresDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
 procedure CreateConnectionAndSendReportToGetScores;
 procedure RunPOSTGetScoresThread;
@@ -57,16 +56,8 @@ procedure CheckServerAnswer(AnswerLength: integer);
 
 var
   GetScoresPostingID                    : integer;
-//  GetScoresSeverPostingAddress          : ShortString {= 'http://www.getscores.org/postscore.aspx'};
-//  GetScoresSeverReadingAddress          : ShortString {= 'http://www.getscores.org/'};
-GetScoresSeverPostingAddress          : ShortString {= 'http://post.contestonlinescore.com'};
-GetScoresSeverReadingAddress          : ShortString {= 'https://contestonlinescores.com/scoreboard/'};
-  GetScoresHost                         : array[0..31] of Char;
-  GetScoresQuery                        : array[0..127] of Char;
-  GetScoresPortAsString                 : array[0..7] of Char;
-  GetScoresPort                         : Cardinal;
-
-  GetScoresSocket                       : Cardinal;
+  GetScoresSeverPostingAddress          : ShortString {= 'https://post.contestonlinescore.com/post/'};
+  GetScoresSeverReadingAddress          : ShortString {= 'https://contestonlinescore.com/scoreboard/'};
   GetScoresBuffer                       : array[0..4096 - 1] of Char;
   GetScoresThreadID                     : Cardinal;
   GetScoresThreadHandle                 : Cardinal;
@@ -74,14 +65,6 @@ GetScoresSeverReadingAddress          : ShortString {= 'https://contestonlinesco
 const
 
   GSCR                                  = ''; //#13#10;
-//  GetScoresIP                           = 'www.getscores.org'; //'66.203.151.196';
-  PostMethodRequestHeader               =
-    'POST /%s HTTP/1.1'#13#10 +
-    'Content-Type: application/x-www-form-urlencoded'#13#10 +
-//    'User-Agent: ' + TR4W_CURRENTVERSION + #13#10 +
-  'Content-Length: %u'#13#10 +
-    'Host: %s'#13#10 +
-    'Connection: close'#13#10#13#10;
 {
   XML                                   =
     'xml=<?xml version="1.0"?><dynamicresults>' +
@@ -151,73 +134,69 @@ end;
 
 procedure CreateConnectionAndSendReportToGetScores;
 var
-  h                                     : HWND;
-  c                                     : Cardinal;
-  Module                                : HWND;
-  UrlGetPart                            : TUrlGetPart;
-  pcchOut                               : DWORD;
-const
-  URL_PART_NONE                         = 0;
-  URL_PART_SCHEME                       = 1;
-  URL_PART_HOSTNAME                     = 2;
-  URL_PART_USERNAME                     = 3;
-  URL_PART_PASSWORD                     = 4;
-  URL_PART_PORT                         = 5;
-  URL_PART_QUERY                        = 6;
-label
-  1;
+   http : TIdHTTP;
+   ssl  : TIdSSLIOHandlerSocketOpenSSL;
+   PostBody  : TStringStream;
+   sURL      : string;
+   h         : HWND;
 begin
-  ShowGetScoresStatus(TC_CONNECT);
+   ShowGetScoresStatus(TC_CONNECT);
+   MakePOSTRequestNew; // fills GetScoresBuffer with the URL-encoded POST body
 
-  Module := LoadLibrary('shlwapi.dll');
-  @UrlGetPart := GetProcAddress(Module, 'UrlGetPartA');
-  pcchOut := SizeOf(GetScoresHost);
-  if UrlGetPart(@GetScoresSeverPostingAddress[1], GetScoresHost, @pcchOut, URL_PART_HOSTNAME, 0) = ERROR_SUCCESS then
-  begin
-    pcchOut := SizeOf(GetScoresQuery);
-    Windows.ZeroMemory(@GetScoresPortAsString, SizeOf(GetScoresPortAsString));
-    UrlGetPart(@GetScoresSeverPostingAddress[1], GetScoresPortAsString, @pcchOut, URL_PART_PORT, 0);
-    GetScoresPort := PCharToInt(GetScoresPortAsString);
-    if GetScoresPort = 0 then GetScoresPort := 80;
+   sURL := string(GetScoresSeverPostingAddress);
 
-    Windows.ZeroMemory(@GetScoresQuery, SizeOf(GetScoresQuery));
-    for c := 8 to length(GetScoresSeverPostingAddress) - 1 do
-      if GetScoresSeverPostingAddress[c] = '/' then
-      begin
-        Windows.CopyMemory(@GetScoresQuery, @GetScoresSeverPostingAddress[c + 1], length(GetScoresSeverPostingAddress) - c);
-        Break;
+   http := TIdHTTP.Create(nil);
+   ssl  := TIdSSLIOHandlerSocketOpenSSL.Create(nil);
+   try
+      // Attach SSL handler only for https:// URLs so plain http:// custom
+      // URLs (if configured by the operator) still work without TLS.
+      if (Length(sURL) >= 8) and
+         (LowerCase(Copy(sURL, 1, 8)) = 'https://') then
+         begin
+         ssl.SSLOptions.Method := TIdSSLVersion(sslvTLSv1_2);
+         http.IOHandler := ssl;
+         end;
+
+      http.HandleRedirects := True;
+      http.Request.UserAgent    := TR4W_CURRENTVERSION;
+      http.Request.ContentType  := 'application/x-www-form-urlencoded';
+
+      PostBody := TStringStream.Create(string(PChar(@GetScoresBuffer)));
+      try
+         logger.Debug('Score post: URL = %s', [sURL]);
+         http.Post(sURL, PostBody);
+      finally
+         PostBody.Free;
       end;
-  end;
-  FreeLibrary(Module);
 
-  if not GetConnection(GetScoresSocket, GetScoresHost, GetScoresPort, SOCK_STREAM) then
-  begin
-//    showmessage(SysErrorMessage(WSAGetLastError));
-    ShowGetScoresStatus(TC_FAILEDTOCONNECTTOGETSCORESORG);
-    goto 1;
-  end;
+      if http.ResponseCode = 200 then
+         begin
+         // Save the server response for diagnostics
+         if tOpenFileForWrite(h, GetScoresAnswerFileName) then
+            begin
+            sWriteFile(h, GetScoresBuffer, lstrlen(GetScoresBuffer));
+            CloseHandle(h);
+            end;
+         ShowGetScoresStatus(TC_UPLOADEDSUCCESSFULLY);
+         end
+      else
+         begin
+         logger.Warn('Score post: server returned %d for %s', [http.ResponseCode, sURL]);
+         ShowGetScoresStatus(TC_FAILEDTOCONNECTTOGETSCORESORG);
+         end;
 
-{
-  if strpos(@GetScoresSeverPostingAddress[1], 'http://rdxc.org/asp/pages/update.asp') <> nil then
-    SendOnLineResultsToRDXC2010Site
-  else
-   }
-//  MakePOSTRequest;
+   except
+      on E: Exception do
+         begin
+         logger.Error('Score post failed for %s: %s', [sURL, E.Message]);
+         ShowGetScoresStatus(TC_FAILEDTOCONNECTTOGETSCORESORG);
+         end;
+   end;
 
-  WinSock2.Send(GetScoresSocket, GetScoresBuffer, MakePOSTRequestNew, 0);
-  c := WinSock2.recv(GetScoresSocket, GetScoresBuffer, SizeOf(GetScoresBuffer), 0);
-//  ShowMessage(GetScoresBuffer);
-
-  if not tOpenFileForWrite(h, GetScoresAnswerFileName) then goto 1;
-  sWriteFile(h, GetScoresBuffer, c);
-  CloseHandle(h);
-
-  CheckServerAnswer(c);
-  1:
-  closesocket(GetScoresSocket);
-
-  GetScoresThreadID := 0;
-  CloseHandle(GetScoresThreadHandle);
+   http.Free;
+   ssl.Free;
+   GetScoresThreadID := 0;
+   CloseHandle(GetScoresThreadHandle);
 end;
 {
 function MakePOSTRequestForRDXC2010: integer;
@@ -535,11 +514,10 @@ begin
     GSCR + '<score>%u</score>' +
     GSCR + '<timestamp>%s</timestamp>' + GSCR + '</dynamicresults>', TotalScore, SystemTimeToString(UTC));
 
-  Format(GetScoresBuffer, PostMethodRequestHeader, GetScoresQuery, Index, GetScoresHost);
-//  ShowMessage(GetScoresBuffer);
-  Windows.lstrcat(GetScoresBuffer, RequestBody);
-//  ShowMessage(GetScoresBuffer);
-   logger.Debug('[MakePOSTRequestNew] %s',[GetScoresBuffer]);
+  // Copy the URL-encoded XML body into GetScoresBuffer for use by the caller.
+  // HTTP framing is now handled by TIdHTTP in CreateConnectionAndSendReportToGetScores.
+  lstrcpy(GetScoresBuffer, RequestBody);
+  logger.Debug('[MakePOSTRequestNew] %s', [GetScoresBuffer]);
   Result := Windows.lstrlen(GetScoresBuffer);
 {
   if not Tree.tOpenFileForWrite(h, 'GetScoresAnswerFileName') then Exit;

--- a/tr4w/src/uMessagesList.pas
+++ b/tr4w/src/uMessagesList.pas
@@ -30,11 +30,93 @@ uses
 
 function MessagesListDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
 
+var
+  LastSelectedCommand                   : String;
+
 implementation
 
 uses
   uProcessCommand,
   MainUnit;
+
+// Extract the insertable command token from a caCommand display string.
+// Entries have the form "  CMD = description" or just "CMDNAME".
+// We strip leading spaces, then take everything up to the first " = "
+// separator (searching from position 1 so that "  = = BT" yields "=").
+// Trailing spaces are also stripped.
+
+function GetInsertableCommand(src: PChar): String;
+var
+  start, p, eqStart: PChar;
+  len: Integer;
+begin
+  Result := '';
+
+  // Skip leading spaces
+  start := src;
+  while start^ = ' ' do
+    Inc(start);
+  if start^ = #0 then
+    Exit;
+
+  // Look for ' = ' separator beginning one character past start
+  // so that a command that IS '=' (e.g. "  = = BT") is not treated
+  // as a separator itself.
+  eqStart := nil;
+  p := start + 1;
+  while p^ <> #0 do
+    begin
+    if (p[0] = ' ') and (p[1] = '=') and (p[2] = ' ') then
+      begin
+      eqStart := p;
+      Break;
+      end;
+    Inc(p);
+    end;
+
+  if eqStart <> nil then
+    begin
+    p := eqStart;
+    while (p > start) and (p[-1] = ' ') do
+      Dec(p);
+    len := p - start;
+    end
+  else
+    begin
+    p := start + Windows.lstrlen(start);
+    while (p > start) and (p[-1] = ' ') do
+      Dec(p);
+    len := p - start;
+    end;
+
+  if len > 0 then
+    SetString(Result, start, len);
+end;
+
+// Fetch the text of the currently selected listbox item (ID 90) and store
+// the extracted command in LastSelectedCommand. Returns True if an item was
+// selected. We go through LB_GETTEXT rather than indexing sCommandsArray
+// because the listbox is created with LBS_SORT — its visible index order
+// does not match the array's insertion order.
+
+function TryCaptureSelectedCommand(hwnddlg: HWND): Boolean;
+var
+  lb: HWND;
+  sel, textLen: Integer;
+  buf: array[0..255] of Char;
+begin
+  Result := False;
+  lb := GetDlgItem(hwnddlg, 90);
+  sel := SendMessage(lb, LB_GETCURSEL, 0, 0);
+  if sel = -1 then
+    Exit;
+  textLen := SendMessage(lb, LB_GETTEXTLEN, sel, 0);
+  if (textLen < 0) or (textLen >= SizeOf(buf)) then
+    Exit;
+  SendMessage(lb, LB_GETTEXT, sel, Integer(@buf));
+  LastSelectedCommand := GetInsertableCommand(@buf);
+  Result := True;
+end;
 
 function MessagesListDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
 label
@@ -67,10 +149,22 @@ begin
 
     WM_COMMAND:
       begin
-        case wParam of
-          1, 2: goto 1;
+      // Double-click on list box: insert selected command and close
+      if (HiWord(wParam) = LBN_DBLCLK) and (LoWord(wParam) = 90) then
+        begin
+        if TryCaptureSelectedCommand(hwnddlg) then
+          EndDialog(hwnddlg, 1);
         end;
-//        if HiWord(wParam) = LBN_DBLCLK then ProcessMenu(menu_send_message);
+      case wParam of
+        1:  // OK: insert if something is selected, otherwise just close
+          begin
+          if TryCaptureSelectedCommand(hwnddlg) then
+            EndDialog(hwnddlg, 1)
+          else
+            goto 1;
+          end;
+        2: goto 1;  // Cancel
+      end;
       end;
 
     WM_CLOSE: 1: EndDialog(hwnddlg, 0);

--- a/tr4w/src/uNet.pas
+++ b/tr4w/src/uNet.pas
@@ -592,11 +592,30 @@ begin
     KillTimer(tr4whandle, UPDATE_NET_CW_MESSAGE);
 end;
 
+type
+  TNetConnectLogState = (nclsInitial, nclsTrying, nclsConnected, nclsFailed);
+
+const
+  FConnectLogStateLabel : array[TNetConnectLogState] of string =
+    ('initial', 'trying', 'connected', 'failed');
+
+var
+  // Last logged connect-attempt outcome.  TR4W retries every ~5s while the
+  // multi-op server is unreachable; without this gate the log would fill
+  // with four debug lines per retry (TryConnectToNetwork enter, tCreateThread
+  // create, Network thread create, ConnectThread exit) drowning out anything
+  // else.  We log only on transitions: first attempt, recover, fail.
+  FConnectLogState : TNetConnectLogState = nclsInitial;
+
 procedure TryConnectToNetwork;
 begin
-  logger.Debug('Calling tCreateThread from TryConnectToNetwork -> %s:%d', [ServerAddress, ServerPort]);
+  // Only log on state transitions.
+  if FConnectLogState <> nclsTrying then
+     begin
+     logger.Debug('TryConnectToNetwork -> %s:%d  (will retry every 5s while server is unreachable; further attempts logged only on state change)', [ServerAddress, ServerPort]);
+     FConnectLogState := nclsTrying;
+     end;
   if NetThreadID = 0 then tCreateThread(@ConnectThread, NetThreadID);
-  logger.Debug('Created Network thread with threadid of %d',[NetThreadID] );
 end;
 
 procedure ConnectThread;
@@ -645,6 +664,11 @@ begin
 //    SendStationStatus;
     EnableNetworkMenuItem(MF_ENABLED + MF_BYPOSITION);
     ShowConnectionStatus(TC_CONNECTEDTO);
+    if FConnectLogState <> nclsConnected then
+       begin
+       logger.Info('Connected to TR4WServer at %s:%d', [ServerAddress, ServerPort]);
+       FConnectLogState := nclsConnected;
+       end;
   end
   else
   begin
@@ -652,9 +676,17 @@ begin
     1:
     ShowConnectionStatus(TC_FAILEDTOCONNECTTO);
     NetDisconnect;
+    if FConnectLogState <> nclsFailed then
+       begin
+       logger.Warn('Failed to connect to TR4WServer at %s:%d (will keep retrying silently)', [ServerAddress, ServerPort]);
+       FConnectLogState := nclsFailed;
+       end;
   end;
   2:
-  logger.Debug('[ConnectThread] Thread %d exiting, NetThreadID cleared', [GetCurrentThreadId]);
+  // Demoted from debug to trace: this fires every ~5s during a retry loop
+  // and was drowning the log.  Still available for thread-lifecycle
+  // debugging at trace level.
+  logger.Trace('[ConnectThread] Thread %d exiting, NetThreadID cleared', [GetCurrentThreadId]);
   NetThreadID := 0;
 end;
 

--- a/tr4w/src/uNet.pas
+++ b/tr4w/src/uNet.pas
@@ -64,9 +64,9 @@ type
 
 const
 {$IF OZCR2008}
-  NetColumns                            = 11;
+  NetColumns                            = 12;
 {$ELSE}
-  NetColumns                            = 9;
+  NetColumns                            = 10;
 {$IFEND}
   NetColumnsArray                       : array[0..NetColumns - 1] of TNetWindowColumnsInfo =
     (
@@ -79,7 +79,8 @@ const
     (Width: 37; Text: 'PTT'; fmt: LVCFMT_CENTER),
     (Width: 40; Text: 'Qs'; fmt: LVCFMT_CENTER),
     (Width: 70; Text: RC_CALLSIGN; fmt: LVCFMT_LEFT),
-    (Width: 25; Text: 'D'; fmt: LVCFMT_CENTER)
+    (Width: 25; Text: 'D'; fmt: LVCFMT_CENTER),
+    (Width: 70; Text: 'Op'; fmt: LVCFMT_LEFT)
 //,    (Width: 50; Text: 'LN'; fmt: LVCFMT_LEFT)
 {$IF OZCR2008}
     ,
@@ -551,6 +552,9 @@ begin
         SetStatusByte;
         Windows.GetWindowText(wh[mweCall], @MyStationState.ssCallsign, SizeOf(MyStationState.ssCallsign));
       end;
+
+    sstOperator:
+      Windows.CopyMemory(@MyStationState.ssOperator, @CurrentOperator, SizeOf(OperatorType));
   end;
 
   MyStationState.ssType := ssType;
@@ -781,6 +785,9 @@ begin
         ListView_SetItemText(h, i, 8 - 1, StatusArray[Index].ssCallsign);
         ListView_SetItemText(h, i, 9 - 1, da[(StatusArray[Index].ssStatusByte and (1 shl 2)) <> 0]);
       end;
+
+    sstOperator:
+      ListView_SetItemText(h, i, 9, StatusArray[Index].ssOperator);
   end;
 
   //  ListView_SetItemText(h, I, 8, inttopchar(StatusArray[Index].ssCWElements));

--- a/tr4w/src/uNewContest.pas
+++ b/tr4w/src/uNewContest.pas
@@ -648,6 +648,16 @@ begin
 
     CloseHandle(f);
 
+    // If the user confirmed overwriting an existing contest, delete any
+    // existing .TRW log file.  LoadinLog fatally halts if the file size
+    // is not an exact multiple of SizeOf(ContestExchange), which will be
+    // true of any .TRW from a previous (different) contest.
+    lstrcpy(TempBuffer1, TR4W_CFG_FILENAME);
+    TempBuffer1[lstrlen(TempBuffer1) - 3] := 'T';
+    TempBuffer1[lstrlen(TempBuffer1) - 2] := 'R';
+    TempBuffer1[lstrlen(TempBuffer1) - 1] := 'W';
+    Windows.DeleteFile(TempBuffer1); // no-op (returns False) if no .TRW exists
+
     DestroyWindow(h);
   end
   else

--- a/tr4w/src/uWinKey.pas
+++ b/tr4w/src/uWinKey.pas
@@ -989,6 +989,8 @@ begin
 end;
 
 function wkOpenPort: boolean;
+var
+  msg: string;
 begin
   Result := False;
   asm
@@ -1002,17 +1004,13 @@ begin
   WinKeyHandle := CreateFile(@wkREADBuffer, GENERIC_READ or GENERIC_WRITE, 0, nil, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL {FILE_FLAG_OVERLAPPED}, 0);
   if WinKeyHandle = INVALID_HANDLE_VALUE then
   begin
-    SysErrorMessage(GetLastError);
-    asm
-  push eax
-  xor eax,eax
-  mov al,byte ptr WinKeySettings.wksWinKey2Port
-  push eax
-    end;
-    wsprintf(@wkREADBuffer, 'Winkeyer port COM%u: %s');
-    asm add esp,16
-    end;
-    showwarning(@wkREADBuffer);
+    // SysErrorMessage returns an AnsiString via a hidden var-parameter, not in
+    // eax. Assign to a local so the string data remains alive, then build the
+    // full message with SysUtils.Format. No inline asm / varargs juggling.
+    msg := Format('Winkeyer port COM%d: %s',
+                  [Integer(WinKeySettings.wksWinKey2Port),
+                   SysErrorMessage(GetLastError)]);
+    showwarning(PChar(msg));
     Exit;
   end;
   GetCommState(WinKeyHandle, wkDCB);

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -27,7 +27,10 @@ uses
    uRadioBand           in '..\..\src\uRadioBand.pas',
    uTestRadioBand       in 'uTestRadioBand.pas',
    uFlexRadioUtils      in '..\..\src\uFlexRadioUtils.pas',
-   uTestFlexRadioUtils  in 'uTestFlexRadioUtils.pas';
+   uTestFlexRadioUtils  in 'uTestFlexRadioUtils.pas',
+   VC                   in '..\..\src\VC.pas',
+   utils_text           in '..\..\src\utils\utils_text.pas',
+   uTestUtilsText       in 'uTestUtilsText.pas';
 
 begin
    IsMultiThread := True;  // Match main application setting
@@ -38,6 +41,7 @@ begin
    RegisterSuite(TIcomCIVTests.Create('IcomCIV'));
    RegisterSuite(TRadioBandTests.Create('RadioBand'));
    RegisterSuite(TFlexRadioUtilsTests.Create('FlexRadioUtils'));
+   RegisterSuite(TUtilsTextTests.Create('UtilsText'));
 
    if RunAllSuites then
       begin

--- a/tr4w/test/unit/uTestUtilsText.pas
+++ b/tr4w/test/unit/uTestUtilsText.pas
@@ -1,0 +1,200 @@
+unit uTestUtilsText;
+
+{
+  Tests for utils_text.pas string predicate functions.
+
+  Functions NOT tested here (easily replaced by Delphi 12 stdlib):
+    UpperCase, StringHas, StringHasNumber, StringHasLetters,
+    StringHasLowerCase, tCharIsNumbers, tCharIsAlphaNumericOrDash,
+    PostcedingString, PrecedingString, tPos, pPos, StrComp,
+    StrUpper, safeFloat.
+
+  Functions tested:
+    StringIsAllNumbers               -- used in exchange field parsing
+    StringIsAllNumbersOrSpaces       -- used in exchange field validation
+    StringIsAllNumbersOrDecimal      -- used in frequency/RST parsing
+    StringIsAllAlphanumericOrDash    -- park/callsign validation; bNoCase added Issue #877
+    StringWithFirstWordDeleted       -- no stdlib equivalent; edge cases non-obvious
+}
+
+interface
+
+uses
+   uTR4WTestFramework;
+
+type
+   TUtilsTextTests = class(TTestCase)
+   public
+      procedure RunAllTests; override;
+
+   private
+      procedure Test_StringIsAllNumbers;
+      procedure Test_StringIsAllNumbersOrSpaces;
+      procedure Test_StringIsAllNumbersOrDecimal;
+      procedure Test_StringIsAllAlphanumericOrDash;
+      procedure Test_StringWithFirstWordDeleted;
+   end;
+
+implementation
+
+uses
+   utils_text;
+
+// ---------------------------------------------------------------------------
+// StringIsAllNumbers
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.Test_StringIsAllNumbers;
+begin
+   BeginTest('Test_StringIsAllNumbers');
+
+   // Empty string must return false — the function guards explicitly
+   CheckFalse(StringIsAllNumbers(''), 'empty string');
+
+   // Pure digit strings
+   CheckTrue(StringIsAllNumbers('0'), 'single zero');
+   CheckTrue(StringIsAllNumbers('12345'), 'multi-digit');
+   CheckTrue(StringIsAllNumbers('001'), 'leading zeros');
+
+   // Any non-digit character must reject
+   CheckFalse(StringIsAllNumbers('12.3'), 'decimal point');
+   CheckFalse(StringIsAllNumbers('12 3'), 'embedded space');
+   CheckFalse(StringIsAllNumbers('1A3'), 'embedded letter');
+   CheckFalse(StringIsAllNumbers('-1'), 'leading minus');
+end;
+
+// ---------------------------------------------------------------------------
+// StringIsAllNumbersOrSpaces
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.Test_StringIsAllNumbersOrSpaces;
+begin
+   BeginTest('Test_StringIsAllNumbersOrSpaces');
+
+   // Empty string must return false
+   CheckFalse(StringIsAllNumbersOrSpaces(''), 'empty string');
+
+   // Valid combinations
+   CheckTrue(StringIsAllNumbersOrSpaces('123'), 'digits only');
+   CheckTrue(StringIsAllNumbersOrSpaces('12 34'), 'digits and space');
+   CheckTrue(StringIsAllNumbersOrSpaces('   '), 'spaces only');
+   CheckTrue(StringIsAllNumbersOrSpaces(' 1 '), 'leading/trailing spaces');
+
+   // Any other character must reject
+   CheckFalse(StringIsAllNumbersOrSpaces('12.3'), 'decimal point');
+   CheckFalse(StringIsAllNumbersOrSpaces('1A3'), 'letter');
+end;
+
+// ---------------------------------------------------------------------------
+// StringIsAllNumbersOrDecimal
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.Test_StringIsAllNumbersOrDecimal;
+begin
+   BeginTest('Test_StringIsAllNumbersOrDecimal');
+
+   // Empty string must return false
+   CheckFalse(StringIsAllNumbersOrDecimal(''), 'empty string');
+
+   // Valid combinations
+   CheckTrue(StringIsAllNumbersOrDecimal('14150'), 'integer frequency');
+   CheckTrue(StringIsAllNumbersOrDecimal('14.150'), 'standard decimal');
+   CheckTrue(StringIsAllNumbersOrDecimal('.5'), 'leading decimal');
+   CheckTrue(StringIsAllNumbersOrDecimal('3.'), 'trailing decimal');
+
+   // The function accepts any number of dots — documents current behavior
+   // (no structural validation, only character-level)
+   CheckTrue(StringIsAllNumbersOrDecimal('1.4.1'), 'two dots passes char check');
+
+   // Non-digit, non-dot characters must reject
+   CheckFalse(StringIsAllNumbersOrDecimal('14,150'), 'comma');
+   CheckFalse(StringIsAllNumbersOrDecimal('14 150'), 'space');
+   CheckFalse(StringIsAllNumbersOrDecimal('14MHz'), 'letters');
+end;
+
+// ---------------------------------------------------------------------------
+// StringIsAllAlphanumericOrDash
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.Test_StringIsAllAlphanumericOrDash;
+begin
+   BeginTest('Test_StringIsAllAlphanumericOrDash');
+
+   // Empty string must return false
+   CheckFalse(StringIsAllAlphanumericOrDash(''), 'empty string');
+
+   // --- bNoCase = false (default) ---
+
+   // Uppercase and digits pass
+   CheckTrue(StringIsAllAlphanumericOrDash('K4A'), 'uppercase letters');
+   CheckTrue(StringIsAllAlphanumericOrDash('123'), 'digits');
+   CheckTrue(StringIsAllAlphanumericOrDash('K4A-1234'), 'uppercase with dash');
+   CheckTrue(StringIsAllAlphanumericOrDash('-'), 'dash alone');
+
+   // tCharIsAlphaNumericOrDash only accepts A-Z (uppercase); lowercase is rejected
+   CheckFalse(StringIsAllAlphanumericOrDash('k4a'), 'lowercase rejected without bNoCase');
+   CheckFalse(StringIsAllAlphanumericOrDash('k4a-1234'), 'lowercase with dash rejected');
+
+   // Special characters always reject
+   CheckFalse(StringIsAllAlphanumericOrDash('K4A!'), 'exclamation mark');
+   CheckFalse(StringIsAllAlphanumericOrDash('K 4A'), 'embedded space');
+   CheckFalse(StringIsAllAlphanumericOrDash('K4A.1'), 'dot');
+
+   // --- bNoCase = true ---
+
+   // Lowercase now passes because input is uppercased before checking
+   CheckTrue(StringIsAllAlphanumericOrDash('k4a', True), 'lowercase passes with bNoCase');
+   CheckTrue(StringIsAllAlphanumericOrDash('k4a-1234', True), 'lowercase with dash, bNoCase');
+   CheckTrue(StringIsAllAlphanumericOrDash('K4A', True), 'uppercase still passes with bNoCase');
+
+   // Special characters still reject even with bNoCase
+   CheckFalse(StringIsAllAlphanumericOrDash('k4a!', True), 'special char rejected with bNoCase');
+   CheckFalse(StringIsAllAlphanumericOrDash('', True), 'empty string with bNoCase');
+end;
+
+// ---------------------------------------------------------------------------
+// StringWithFirstWordDeleted
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.Test_StringWithFirstWordDeleted;
+begin
+   BeginTest('Test_StringWithFirstWordDeleted');
+
+   // Empty string returns empty
+   CheckEquals('', StringWithFirstWordDeleted(''), 'empty string');
+
+   // No space — the whole string is one word, returns empty
+   CheckEquals('', StringWithFirstWordDeleted('HELLO'), 'single word');
+
+   // Normal two-word case
+   CheckEquals('WORLD', StringWithFirstWordDeleted('HELLO WORLD'), 'two words');
+
+   // Three words — only the first word is deleted
+   CheckEquals('TWO THREE', StringWithFirstWordDeleted('ONE TWO THREE'), 'three words');
+
+   // Multiple spaces between words — collapses to the next non-space token
+   CheckEquals('WORLD', StringWithFirstWordDeleted('HELLO   WORLD'), 'multiple spaces between words');
+
+   // Leading space — the first "word" is empty (chars before the first space),
+   // so everything after the first space is returned
+   CheckEquals('HELLO WORLD', StringWithFirstWordDeleted(' HELLO WORLD'), 'leading space');
+
+   // String is only spaces — no non-space token follows any space, so
+   // the loop empties the string and returns empty
+   CheckEquals('', StringWithFirstWordDeleted('   '), 'only spaces');
+end;
+
+// ---------------------------------------------------------------------------
+// Suite entry point
+// ---------------------------------------------------------------------------
+
+procedure TUtilsTextTests.RunAllTests;
+begin
+   Test_StringIsAllNumbers;
+   Test_StringIsAllNumbersOrSpaces;
+   Test_StringIsAllNumbersOrDecimal;
+   Test_StringIsAllAlphanumericOrDash;
+   Test_StringWithFirstWordDeleted;
+end;
+
+end.


### PR DESCRIPTION
Bundle of accumulated fixes, features, and tests that have been tested individually but were waiting for a PR window. Nine commits, each with a self-contained message for traceability.

## Commits

### Bug fixes

- **`0bbb649`** Issue #674 — `uNewContest`: delete `.TRW` when overwriting an existing contest. Without this, opening the new contest hits a fatal "log file is not the correct size" because the leftover `.TRW` from the old contest is still around.
- **`88d10a3`** Issue #26 — `uGetScores`: replace raw WinSock2 POST with `TIdHTTP` + `TIdSSLIOHandlerSocketOpenSSL` (TLS 1.2). Default URL set to `https://post.contestonlinescore.com/post/` (the bare host returns 404). SSL handler attached only when URL starts with `https://` so operator-configured `http://` custom URLs remain functional. Includes URL in diagnostic log lines for future troubleshooting.
- **`a19a0d5`** `uWinKey` — replace inline-asm `wsprintf` for the COM-port-open error with `Format` + `PChar(msg)`. Old asm pushed `eax` after `SysErrorMessage` assuming PChar return, but Delphi 7 returns `AnsiString` via a hidden var-parameter — the result was garbage like `Winkeyer port COM5: xlk ,ÿñ"nS`.

### Features

- **`6708783`** Issue #770 — show active operator in the network window. Adds `sstOperator` status type and `ssOperator` field to `TStationState`; broadcasts on every operator change; new "Op" column in the network listview. TR4WServer requires only a recompile (its blind-relay path handles the new packet automatically).
- **`b417054`** Issue #47 — Programmable Messages dialog: insert command at cursor on double-click. Operators can now double-click an entry in the "List of Commands" list to insert it at the cursor position in the message text field. Cursor position captured via the existing `EN_KILLFOCUS SelPos[102]` mechanism.
- **`1ff9234`** Issue #889 — per-QSO `SRX_STRING` for multi-county / multi-park entries. When the operator enters `57 PIN/HIL`, each QSO record now carries its own `ExchString` (`57 PIN` for QSO 1, `57 HIL` for QSO 2) rather than the combined original input. Affects ADIF export (`SRX_STRING`).
- **`e528024`** State-QP rover (`KG1S/PIN`) — when the call has a `/COUNTY` suffix and the suffix validates as a domestic QTH, strip the suffix off the call and pre-fill the exchange with the county. The QSO is then logged with the bare call and the county, so Cabrillo/ADIF output is correct without any output-side stripping. Triggers only for QP exchange types and only when the suffix is a real county (so `/M`, `/P`, `/4` etc. fall through unchanged).

### Housekeeping

- **`f50c636`** `uNet` — log connect retries only on state change. The 5-second TCP retry loop was emitting four DEBUG lines per attempt; now logs once when the loop starts, once on success, once on first failure, and silently otherwise. Thread-exit message demoted to TRACE.

### Tests

- **`ff88e00`** `tests/unit/uTestUtilsText.pas` — 27 unit-test cases for `StringIsAllNumbers`, `StringIsAllNumbersOrSpaces`, `StringIsAllNumbersOrDecimal`, `StringIsAllAlphanumericOrDash` (including the `bNoCase` parameter added in #877), and `StringWithFirstWordDeleted`. `FullBuild.ps1` test compile path extended to include `src/` so `VC.pas` (and `Log4D.dcu`) resolve correctly.

## Test plan

Each fix has been tested individually during development. Suggested final test sequence:

- [ ] Issue #674: start a new contest over an existing one — verify no "log file size" fatal
- [ ] Issue #26: post a score, watch the log for the URL line and a successful HTTP 200
- [ ] Network log noise: start TR4W with multi-op enabled but TR4WServer NOT running — verify only one DEBUG line per state transition (not four per retry)
- [ ] Issue #770: change operators on multiple stations — verify "Op" column in network window updates
- [ ] Issue #47: open Programmable Messages, position cursor, double-click an item — verify insertion at cursor
- [ ] WinKey ABI: disconnect WinKeyer, retry — verify error dialog shows real Windows error string, not garbage
- [ ] Issue #889: log a multi-county QSO (`DAL/PIN`), export ADIF — verify each QSO has its own SRX_STRING
- [ ] Rover (`KG1S/PIN`): enter in a state QP — verify call window shows `KG1S` after the slash is detected, exchange auto-fills with `PIN`, Cabrillo line has bare call + correct county

## Known follow-up

Documented as TODOs for a future PR (not in this one):
- QP rover dupe/scoring behaviour: with bare-call logging, repeated QSOs from same call in different counties are flagged dupe by TR4W's standard logic; contest sponsor generally awards them, but TR4W's local score is conservative.