### PR TITLE
May 2026 maintenance: rover/state-QP, ADIF, networking, WinKeyer

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -588,6 +588,17 @@ begin
     TempRX.QTHString := DequeuePendingCounty;
     FoundDomesticQTH(TempRX);  // refresh DomMultQTH/DomesticQTH
     TempRX.ExchString := PerQSOExchString(TempRX);   // Issue #889
+    // QSO-party rule: a station that changes county is a new station and
+    // is NOT a dupe of an earlier QSO with the same call.  The follow-up
+    // county records share callsign+band+mode with the first one, so the
+    // generic dupe check would otherwise flag them, blank their points,
+    // and emit "AF4O is a dupe and will be logged with zero QSO points."
+    // Setting ceClearDupeSheet=True bypasses both LogContact's and
+    // tUpdateLog(actRescore)'s dupe-stamping for this record only.
+    TempRX.ceClearDupeSheet := True;
+    // Each county leg is a distinct logged QSO and should carry its own
+    // sequential NumberSent rather than reuse the first record's value.
+    Inc(TempRX.NumberSent);
     LogContact(TempRX, True);
     end;
 end;
@@ -613,6 +624,60 @@ end;
 //   - the suffix validates as a domestic QTH (so /M, /P, /4 etc. are left
 //     alone for other code paths to handle)
 // On True, RoverCounty is populated with the validated county abbreviation.
+
+// Wrap ctyLocateCall so a state-QP rover suffix (KG1S/MON) is stripped
+// off the call before the country/zone lookup.  /M would otherwise be
+// interpreted as a Great Britain prefix indicator, mislabeling the QSO
+// with country=G.  The caller's Call value is unchanged; only the lookup
+// uses the bare form.
+//
+// Falls through to plain ctyLocateCall behaviour when:
+//   - active exchange is not a state-QP type
+//   - the call has no '/'
+//   - the suffix doesn't validate as a domestic QTH (e.g. /M, /P, /4)
+//
+// Used by ParametersOkay (live entry) and ParseADIFRecord at EOR (import).
+
+function ctyLocateCallStripRover(const Call: CallString; var QTH: QTHRecord): Boolean;
+var
+  LookupCall  : CallString;
+  SlashPos    : Integer;
+  ProbeRX     : ContestExchange;
+  FoundQTH    : Boolean;
+  ProbeSuffix : string;
+begin
+  LookupCall := Call;
+  logger.Info('[ctyLocateCallStripRover] ENTER Call=[%s] ActiveExchange=%d',
+              [string(Call), Ord(ActiveExchange)]);
+  if ((ActiveExchange = RSTDomesticQTHExchange) or
+      (ActiveExchange = RSTQTHExchange) or
+      (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
+     begin
+     SlashPos := Pos('/', string(LookupCall));
+     logger.Info('[ctyLocateCallStripRover] QP exchange, SlashPos=%d', [SlashPos]);
+     if SlashPos > 0 then
+        begin
+        FillChar(ProbeRX, SizeOf(ProbeRX), 0);
+        ProbeSuffix := UpperCase(
+           Copy(string(LookupCall), SlashPos + 1,
+                Length(string(LookupCall)) - SlashPos));
+        ProbeRX.QTHString := ProbeSuffix;
+        FoundQTH := FoundDomesticQTH(ProbeRX);
+        logger.Info('[ctyLocateCallStripRover] suffix=[%s] FoundDomesticQTH=%s',
+                    [ProbeSuffix, BoolToStr(FoundQTH, True)]);
+        if FoundQTH then
+           LookupCall := Copy(string(LookupCall), 1, SlashPos - 1);
+        end;
+     end
+  else
+     begin
+     logger.Info('[ctyLocateCallStripRover] NOT a QP exchange, skipping strip', []);
+     end;
+  Result := ctyLocateCall(LookupCall, QTH);
+  logger.Info('[ctyLocateCallStripRover] EXIT LookupCall=[%s] Result=%s CountryID=[%s] Prefix=[%s]',
+              [string(LookupCall), BoolToStr(Result, True),
+               string(QTH.CountryID), string(QTH.Prefix)]);
+end;
 
 function DetectRoverSlashInCall(out RoverCounty: string): Boolean;
 var
@@ -4547,11 +4612,6 @@ function ParametersOkay(Call: CallString;
 var
   RST: Word;
   //s1, s2, s3, s4: str20;
-  // State-QP rover (KG1S/MON) — locals used only for the ctyLocateCall
-  // path below to look up the country/zone with the suffix stripped.
-  RoverLookupCall : CallString;
-  RoverSlashPos   : Integer;
-  RoverProbeRX    : ContestExchange;
 begin
   logger.debug('>>>Entering ParametersOkay');
   logger.debug('Calling ParametersOkay with call = %s, Band = %s, Mode = %s, freq = %d, ExchangeString = %s', [call, BandStringsArray[Band], ModeStringArray[Mode], freq, ExchangeString]);
@@ -4699,30 +4759,11 @@ begin
   else
     DefaultRST := 599;
 
-  // State-QP rover (KG1S/MON): the country/zone lookup must run on the
-  // BARE call (KG1S) rather than the slashed form, otherwise /M is
-  // interpreted as a Great Britain prefix indicator and the QSO ends up
-  // tagged with country=G.  Detect a state-QP /COUNTY suffix and strip
-  // it for this lookup only; the original RData.Callsign is preserved
-  // unchanged so the rover form survives into the log and Cabrillo.
-  RoverLookupCall := RData.Callsign;
-  if ((ActiveExchange = RSTDomesticQTHExchange) or
-      (ActiveExchange = RSTQTHExchange) or
-      (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
-     begin
-     RoverSlashPos := Pos('/', string(RoverLookupCall));
-     if RoverSlashPos > 0 then
-        begin
-        FillChar(RoverProbeRX, SizeOf(RoverProbeRX), 0);
-        RoverProbeRX.QTHString := UpperCase(
-           Copy(string(RoverLookupCall), RoverSlashPos + 1,
-                Length(string(RoverLookupCall)) - RoverSlashPos));
-        if FoundDomesticQTH(RoverProbeRX) then
-           RoverLookupCall := Copy(string(RoverLookupCall), 1,
-                                   RoverSlashPos - 1);
-        end;
-     end;
-  ctyLocateCall(RoverLookupCall, RData.QTH);
+  // State-QP rover (KG1S/MON): use ctyLocateCallStripRover so the
+  // country/zone lookup runs on the bare call (KG1S) instead of the
+  // slashed form (which would be misinterpreted as a GB prefix
+  // indicator).  RData.Callsign itself is preserved.
+  ctyLocateCallStripRover(RData.Callsign, RData.QTH);
 
   if DoingDXMults then
     GetDXQTH(RData);
@@ -6095,6 +6136,19 @@ var
   RescoredRXData: ContestExchangePtr;
   LogSize: Cardinal;
   QSOCounter: Cardinal;
+  // Snapshot of fields that actRescore can mutate, captured before the
+  // rescore work so we can log a single line per record describing the
+  // before/after when anything actually changed.  Useful for catching
+  // silent rescore-induced corruption (e.g. rover-call /M -> DX=G).
+  beforeCountryID : DXMultiplierString;
+  beforePrefix    : PrefixMultiplierString;
+  beforeDXQTH     : DXMultiplierString;
+  beforeDomMult   : Boolean;
+  beforeDXMult    : Boolean;
+  beforePrefixMult: Boolean;
+  beforeZoneMult  : Boolean;
+  beforeQSOPoints : Word;
+  beforeDupe      : Boolean;
 begin
 
   if not OpenLogFile then
@@ -6145,12 +6199,27 @@ begin
       if RescoredRXData^.ceQSO_Deleted = False then
         if RescoredRXData^.ceQSO_Skiped = False then
         begin
+          // Snapshot before rescore so we can report what (if anything) changed.
+          beforeCountryID  := RescoredRXData^.QTH.CountryID;
+          beforePrefix     := RescoredRXData^.Prefix;
+          beforeDXQTH      := RescoredRXData^.DXQTH;
+          beforeDomMult    := RescoredRXData^.DomesticMult;
+          beforeDXMult     := RescoredRXData^.DXMult;
+          beforePrefixMult := RescoredRXData^.PrefixMult;
+          beforeZoneMult   := RescoredRXData^.ZoneMult;
+          beforeQSOPoints  := RescoredRXData^.QSOPoints;
+          beforeDupe       := RescoredRXData^.ceDupe;
+
           if DoingPrefixMults then
           begin
             Windows.ZeroMemory(@RescoredRXData.QTH, SizeOf(RescoredRXData.QTH));
             Windows.ZeroMemory(@RescoredRXData.DXQTH,
               SizeOf(RescoredRXData.DXQTH));
-            ctyLocateCall(RescoredRXData^.Callsign, RescoredRXData.QTH);
+            // State-QP rover (KG1S/MON): strip suffix for country lookup so
+            // /M doesn't get misread as a GB prefix.  Without this the
+            // rescore wipes the correct USA lookup done at log-time and
+            // restamps the record as DX=G.
+            ctyLocateCallStripRover(RescoredRXData^.Callsign, RescoredRXData.QTH);
             SetPrefix(RescoredRXData^);
           end;
           // if (RXData.Prefix <> '') and DoingPrefixMults then
@@ -6166,7 +6235,11 @@ begin
             Windows.ZeroMemory(@RescoredRXData.QTH, SizeOf(RescoredRXData.QTH));
             Windows.ZeroMemory(@RescoredRXData.DXQTH,
               SizeOf(RescoredRXData.DXQTH));
-            ctyLocateCall(RescoredRXData^.Callsign, RescoredRXData.QTH);
+            // State-QP rover (KG1S/MON): strip suffix for country lookup so
+            // /M doesn't get misread as a GB prefix.  Without this the
+            // rescore wipes the correct USA lookup done at log-time and
+            // restamps the record as DX=G.
+            ctyLocateCallStripRover(RescoredRXData^.Callsign, RescoredRXData.QTH);
             GetDXQTH(RescoredRXData^);
             //.DXQTH := RescoredRXData.QTH.CountryID;
           end;
@@ -6200,6 +6273,35 @@ begin
           end
           else
             RescoredRXData^.ceDupe := False;
+
+          // Report whenever actRescore actually mutated a record.  One line
+          // per changed record makes silent rescore-induced corruption
+          // (rover-call DX=G, mult-flag flip, points change, etc.) visible.
+          if (beforeCountryID  <> RescoredRXData^.QTH.CountryID) or
+             (beforePrefix     <> RescoredRXData^.Prefix)        or
+             (beforeDXQTH      <> RescoredRXData^.DXQTH)         or
+             (beforeDomMult    <> RescoredRXData^.DomesticMult)  or
+             (beforeDXMult     <> RescoredRXData^.DXMult)        or
+             (beforePrefixMult <> RescoredRXData^.PrefixMult)    or
+             (beforeZoneMult   <> RescoredRXData^.ZoneMult)      or
+             (beforeQSOPoints  <> RescoredRXData^.QSOPoints)     or
+             (beforeDupe       <> RescoredRXData^.ceDupe) then
+             begin
+             logger.Info('[actRescore] %s [%d] changed: ' +
+                'CountryID [%s]->[%s] Prefix [%s]->[%s] DXQTH [%s]->[%s] ' +
+                'DomMult %s->%s DXMult %s->%s PrefixMult %s->%s ZoneMult %s->%s ' +
+                'QSOPoints %d->%d Dupe %s->%s',
+                [string(RescoredRXData^.Callsign), QSOCounter,
+                 string(beforeCountryID),  string(RescoredRXData^.QTH.CountryID),
+                 string(beforePrefix),     string(RescoredRXData^.Prefix),
+                 string(beforeDXQTH),      string(RescoredRXData^.DXQTH),
+                 BoolToStr(beforeDomMult,    True), BoolToStr(RescoredRXData^.DomesticMult, True),
+                 BoolToStr(beforeDXMult,     True), BoolToStr(RescoredRXData^.DXMult,       True),
+                 BoolToStr(beforePrefixMult, True), BoolToStr(RescoredRXData^.PrefixMult,   True),
+                 BoolToStr(beforeZoneMult,   True), BoolToStr(RescoredRXData^.ZoneMult,     True),
+                 beforeQSOPoints, RescoredRXData^.QSOPoints,
+                 BoolToStr(beforeDupe, True), BoolToStr(RescoredRXData^.ceDupe, True)]);
+             end;
 
           Sheet.AddQSOToSheets(@RescoredRXData^, False);
           CallsignsList.AddCallsign(RescoredRXData^.Callsign,
@@ -7328,7 +7430,9 @@ begin
         testStr := MidStr(sADIF_UPPER, i, 4);
         if MidStr(sADIF_UPPER, i, 4) = 'EOR>' then
         begin
-          ctyLocateCall(exch.Callsign, exch.QTH);
+          // State-QP rover (KG1S/MON): strip suffix for country lookup
+          // so /M doesn't get misread as a GB prefix indicator.
+          ctyLocateCallStripRover(exch.Callsign, exch.QTH);
           Result := true;
           break;
         end
@@ -7550,7 +7654,9 @@ begin
         else if (MidStr(sADIF_UPPER, i, 5) = '<EOR>') or
           (MidStr(sADIF_UPPER, i, 4) = 'EOR>') then
         begin
-          ctyLocateCall(exch.Callsign, exch.QTH);
+          // State-QP rover (KG1S/MON): strip suffix for country lookup
+          // so /M doesn't get misread as a GB prefix indicator.
+          ctyLocateCallStripRover(exch.Callsign, exch.QTH);
           // if DoingDXMults then GetDXQTH(TempRXData);
           // if DoingPrefixMults then SetPrefix(TempRXData);
           // Sheet.SetMultFlags(TempRXData);
@@ -7849,7 +7955,11 @@ begin
       ClearContestExchange(TempRXData);
       if ParseADIFRecord(sBuffer, TempRXData) then // processed a record if true
       begin
-        ctyLocateCall(TempRXData.Callsign, TempRXData.QTH);
+        // State-QP rover (KG1S/MON): strip suffix for country lookup so
+        // the /M tail isn't misread as a GB prefix indicator.  Without
+        // this wrapper the post-ParseADIFRecord lookup overwrites the
+        // QTH set inside ParseADIFRecord and we end up with DX=G.
+        ctyLocateCallStripRover(TempRXData.Callsign, TempRXData.QTH);
         CalculateQSOPoints(TempRXData);
         tWriteFile(LogHandle, TempRXData, SizeOf(ContestExchange),
           lpNumberOfBytesWritten);

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -596,9 +596,14 @@ begin
     // Setting ceClearDupeSheet=True bypasses both LogContact's and
     // tUpdateLog(actRescore)'s dupe-stamping for this record only.
     TempRX.ceClearDupeSheet := True;
-    // Each county leg is a distinct logged QSO and should carry its own
-    // sequential NumberSent rather than reuse the first record's value.
-    Inc(TempRX.NumberSent);
+    // NumberSent is intentionally NOT incremented for county-line follow-up
+    // records: per CQ Magazine guidance for the California QSO Party (and
+    // other state QPs that combine serial numbers with county-line ops),
+    // ALL legs of a single on-air exchange share the one transmitted serial
+    // number.  Both records inherit it from the first.  See issue #892 for
+    // the related "next station's serial jumps by N" question, which is a
+    // separate architectural concern (TotalContacts/QSOTotals is bumped per
+    // LogContact call rather than per distinct station worked).
     LogContact(TempRX, True);
     end;
 end;

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -472,7 +472,8 @@ type
     tAdifRST_RCVD, tAdifRST_SENT, tAdifRX_PWR, tAdifSRX, tAdifSRX_STRING,
     tAdifSTATE, tAdifSTX, tAdifSTX_STRING, tAdifSUBMODE, tAdifTEN_TEN,
     tAdifVE_PROV, tAdifAPP_TR4W_HQ, tAdifAPP_N1MM_HQ, tAdifSTATION_CALLSIGN,
-    tAdifQTH, tAdifPROGRAMID, tAdifAPP_N1MM_EXCHANGE1, tAdifAPP_N1MM_ID, tAdifAPP_TR4W_ID,tAdifSIG, tAdifSIG_INFO, tAdifPOTAREF
+    tAdifQTH, tAdifPROGRAMID, tAdifAPP_N1MM_EXCHANGE1, tAdifAPP_N1MM_ID, tAdifAPP_TR4W_ID,tAdifSIG, tAdifSIG_INFO, tAdifPOTAREF,
+    tAdifAPP_TR4W_ROVERCALL
     );
 var
   FreeMemCount: integer;
@@ -589,6 +590,91 @@ begin
     TempRX.ExchString := PerQSOExchString(TempRX);   // Issue #889
     LogContact(TempRX, True);
     end;
+end;
+
+// State-QP rover slash-in-call ("KG1S/MON"):
+//
+// The operator types a call with a /COUNTY suffix to indicate the rover's
+// current county.  TR4W keeps the call AS-IS in the log (KG1S/MON) so the
+// operator's intent is preserved end-to-end.  Cabrillo emits the literal
+// KG1S/MON; ADIF emits the bare call in the standard <CALL> field plus the
+// full form in a TR4W-specific <APP_TR4W_ROVERCALL> field (handled at
+// export time in PostUnit.PAS).
+//
+// At submit time (Enter, just before TryLogContact runs), if the operator
+// has not already typed an exchange, move the county from the call's slash-
+// suffix into the exchange field so the standard exchange parser sees a
+// clean "MON" and produces the right multiplier / log row.  No keystroke-
+// time interference — the operator can edit the call freely while typing.
+
+// Detect a state-QP rover slash-in-call.  Returns True when:
+//   - active exchange is a state-QP type
+//   - CallWindowString contains a '/'
+//   - the suffix validates as a domestic QTH (so /M, /P, /4 etc. are left
+//     alone for other code paths to handle)
+// On True, RoverCounty is populated with the validated county abbreviation.
+
+function DetectRoverSlashInCall(out RoverCounty: string): Boolean;
+var
+  CallStr  : string;
+  SlashPos : Integer;
+  ProbeRX  : ContestExchange;
+begin
+  Result := False;
+  RoverCounty := '';
+
+  if not ((ActiveExchange = RSTDomesticQTHExchange) or
+          (ActiveExchange = RSTQTHExchange) or
+          (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
+     Exit;
+
+  CallStr := string(CallWindowString);
+  SlashPos := Pos('/', CallStr);
+  if SlashPos = 0 then
+     Exit;
+
+  RoverCounty := UpperCase(Copy(CallStr, SlashPos + 1, Length(CallStr) - SlashPos));
+  if RoverCounty = '' then
+     Exit;
+
+  // Validate the suffix against the domestic-mults table using a scratch
+  // ContestExchange so we don't disturb any global state.
+  FillChar(ProbeRX, SizeOf(ProbeRX), 0);
+  ProbeRX.QTHString := RoverCounty;
+  if not FoundDomesticQTH(ProbeRX) then
+     Exit;  // /M, /P, /4 or any non-county suffix — leave alone
+
+  Result := True;
+end;
+
+// When the operator hits Enter in the call window with a rover call
+// ("KG1S/MON") and no exchange typed yet, copy the county from the call's
+// slash-suffix into the exchange field and move focus there so the
+// operator can confirm with another Enter to log.
+//
+// Called from the start of ReturnInCQOpMode / ReturnInSAPOpMode (the
+// Enter-in-call-window handlers) — NOT from TryLogContact, which fires
+// only when both call and exchange are filled.
+//
+// The call itself is left untouched: KG1S/MON is the operator's intent
+// and survives through the log, Cabrillo, and the ADIF APP_TR4W_ROVERCALL
+// field.
+
+procedure PrefillExchangeFromRoverCallSuffix;
+var
+  RoverCounty : string;
+begin
+  if ExchangeWindowString <> '' then
+     Exit;
+  if not DetectRoverSlashInCall(RoverCounty) then
+     Exit;
+  ExchangeWindowString := RoverCounty;
+  Windows.SetWindowText(wh[mweExchange], PChar(string(ExchangeWindowString)));
+  // Move focus to exchange.  The caller's existing focus-move logic only
+  // fires when ExchangeWindowString is empty (which won't be true after
+  // we just populated it), so we have to do it ourselves here.
+  if not LeaveCursorInCallWindow then
+     tExchangeWindowSetFocus;
 end;
 
 function TryLogContact: boolean;
@@ -1086,6 +1172,12 @@ begin
     end;
     Exit;
   end;
+
+  // State-QP rover (KG1S/MON): if call has /COUNTY suffix and exchange
+  // is empty, copy the county to the exchange and move focus there so
+  // the operator can confirm with another Enter.
+  PrefillExchangeFromRoverCallSuffix;
+
   if (length(CallWindowString) <> 0) and (length(ExchangeWindowString) = 0) and
     SwitchNext then // 4.52.8
     if tAutoSendMode and (AutoSendCharacterCount > 0) then
@@ -1260,6 +1352,11 @@ begin
         SendFunctionKeyMessage(F1, OpMode);
       Exit;
     end;
+
+  // State-QP rover (KG1S/MON): if call has /COUNTY suffix and exchange
+  // is empty, copy the county to the exchange and move focus there so
+  // the operator can confirm with another Enter.
+  PrefillExchangeFromRoverCallSuffix;
 
   // if tr4w_CallWindowActive then
   if (length(CallWindowString) >= 3) then
@@ -4450,6 +4547,11 @@ function ParametersOkay(Call: CallString;
 var
   RST: Word;
   //s1, s2, s3, s4: str20;
+  // State-QP rover (KG1S/MON) — locals used only for the ctyLocateCall
+  // path below to look up the country/zone with the suffix stripped.
+  RoverLookupCall : CallString;
+  RoverSlashPos   : Integer;
+  RoverProbeRX    : ContestExchange;
 begin
   logger.debug('>>>Entering ParametersOkay');
   logger.debug('Calling ParametersOkay with call = %s, Band = %s, Mode = %s, freq = %d, ExchangeString = %s', [call, BandStringsArray[Band], ModeStringArray[Mode], freq, ExchangeString]);
@@ -4597,7 +4699,30 @@ begin
   else
     DefaultRST := 599;
 
-  ctyLocateCall(RData.Callsign, RData.QTH);
+  // State-QP rover (KG1S/MON): the country/zone lookup must run on the
+  // BARE call (KG1S) rather than the slashed form, otherwise /M is
+  // interpreted as a Great Britain prefix indicator and the QSO ends up
+  // tagged with country=G.  Detect a state-QP /COUNTY suffix and strip
+  // it for this lookup only; the original RData.Callsign is preserved
+  // unchanged so the rover form survives into the log and Cabrillo.
+  RoverLookupCall := RData.Callsign;
+  if ((ActiveExchange = RSTDomesticQTHExchange) or
+      (ActiveExchange = RSTQTHExchange) or
+      (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
+     begin
+     RoverSlashPos := Pos('/', string(RoverLookupCall));
+     if RoverSlashPos > 0 then
+        begin
+        FillChar(RoverProbeRX, SizeOf(RoverProbeRX), 0);
+        RoverProbeRX.QTHString := UpperCase(
+           Copy(string(RoverLookupCall), RoverSlashPos + 1,
+                Length(string(RoverLookupCall)) - RoverSlashPos));
+        if FoundDomesticQTH(RoverProbeRX) then
+           RoverLookupCall := Copy(string(RoverLookupCall), 1,
+                                   RoverSlashPos - 1);
+        end;
+     end;
+  ctyLocateCall(RoverLookupCall, RData.QTH);
 
   if DoingDXMults then
     GetDXQTH(RData);
@@ -7175,11 +7300,18 @@ var
   tempPOTAREF: string;
   tempSIG_INFO: string;
   saveDecimalSeparator: char;
+  // State-QP rover round-trip: when APP_TR4W_ROVERCALL is present in
+  // an imported record, it carries the full operator-typed callsign
+  // (e.g. KG1S/MON) and overrides whatever the standard <CALL> field
+  // delivered.  The two fields can appear in either order in the ADIF
+  // record, so we use a flag rather than positional logic.
+  haveRoverCall: Boolean;
 
 begin
   lookingForFieldName := false;
   lookingForFieldLen := false;
   lookingForFieldValue := false;
+  haveRoverCall := false;
 
   try
     sADIF_UPPER := ANSIUPPERCASE(sADIF); // For testing without changing original
@@ -7225,14 +7357,28 @@ begin
                 'RST_RCVD', 'RST_SENT', 'RX_PWR', 'SRX', 'SRX_STRING',
                 'STATE', 'STX', 'STX_STRING', 'SUBMODE', 'TEN_TEN',
                 'VE_PROV', 'APP_TR4W_HQ', 'APP_N1MM_HQ', 'STATION_CALLSIGN',
-                'QTH', 'PROGRAMID', 'APP_N1MM_EXCHANGE1', 'APP_N1MM_ID', 'APP_TR4W_ID','SIG', 'SIG_INFO', 'POTA_REF'])) of
+                'QTH', 'PROGRAMID', 'APP_N1MM_EXCHANGE1', 'APP_N1MM_ID', 'APP_TR4W_ID','SIG', 'SIG_INFO', 'POTA_REF',
+                'APP_TR4W_ROVERCALL'])) of
               tAdifARRL_SECT: tempARRL_Sect := fieldValue;
               //exch.QTHString := fieldValue;
               tAdifBAND:
                 begin
                   exch.Band := GetADIFBand(fieldValue);
                 end;
-              tAdifCALL: exch.Callsign := AnsiUpperCase(fieldValue);
+              tAdifCALL:
+                // If we have already seen APP_TR4W_ROVERCALL in this record,
+                // it carries the full rover form (KG1S/MON) and we keep that
+                // instead of the stripped-down standard CALL value.
+                if not haveRoverCall then
+                   exch.Callsign := AnsiUpperCase(fieldValue);
+              tAdifAPP_TR4W_ROVERCALL:
+                // TR4W-specific full rover callsign (KG1S/MON) — overrides
+                // whatever the standard CALL field delivered.  See the
+                // matching emit code in PostUnit.PAS::ExportToADIF.
+                begin
+                exch.Callsign := AnsiUpperCase(fieldValue);
+                haveRoverCall := true;
+                end;
               tAdifCHECK: exch.Check := StrToInt(fieldValue);
               tAdifCLASS: exch.ceClass := AnsiUpperCase(fieldValue);
               tAdifCQ_Z: exch.Zone := StrToInt(fieldValue);

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -3693,10 +3693,36 @@ if StringIsAllNumbers(ThirdString)  then
 
 function ProcessRSTAndDomesticOrDXQTHExchange(Exchange: ShortString {Str80}; var
   RXData: ContestExchange): boolean;
-
+var
+  // State-QP rover detection (KG1S/MON): the country lookup in
+  // ParametersOkay treats /M as a Great Britain prefix indicator and
+  // sets RXData.QTH.Country to G, which causes DomesticCountryCall
+  // below to return False and routes the exchange to the DX parser
+  // (which discards the county).  Detect the rover form here and
+  // force the domestic-parser route so MON gets logged as the county.
+  RoverSlashPos : Integer;
+  RoverProbeRX  : ContestExchange;
 begin
   ProcessRSTAndDomesticOrDXQTHExchange := False;
-   
+
+  // Rover-form override: if the call has a /COUNTY suffix and COUNTY
+  // validates as a domestic QTH, treat as domestic regardless of
+  // DomesticCountryCall's verdict on the slashed form.
+  RoverSlashPos := Pos('/', string(RXData.Callsign));
+  if RoverSlashPos > 0 then
+     begin
+     FillChar(RoverProbeRX, SizeOf(RoverProbeRX), 0);
+     RoverProbeRX.QTHString := UpperCase(
+        Copy(string(RXData.Callsign), RoverSlashPos + 1,
+             Length(string(RXData.Callsign)) - RoverSlashPos));
+     if FoundDomesticQTH(RoverProbeRX) then
+        begin
+        ProcessRSTAndDomesticOrDXQTHExchange :=
+          ProcessRSTAndDomesticQTHExchange(Exchange, RXData);
+        Exit;
+        end;
+     end;
+
   if DomesticCountryCall(RXData.Callsign) then
   begin
     ProcessRSTAndDomesticOrDXQTHExchange :=

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -1397,8 +1397,13 @@ begin
   if MobileCall(RXData.Callsign) and (ActiveDomesticMult = DomesticFile) and (RXData.DomesticQTH <> '')then    // n4af 4.41.8 Add Q.P. Rover  // 4.98.6
      RXData.Callsign := PrecedingString(RXData.Callsign,'/')  + '/' + RXData.DomesticQTH;  // n4af 4.41.7
 
-  if VisibleLog.CallIsADupe(RXData.Callsign, RXData.Band, RXData.Mode) or
-    ((ActiveDomesticMult = GridSquares) and RoverCall(RXData.Callsign) and (NumberGridSquaresInList > 0)) then
+  // ceClearDupeSheet bypass: county-line / Nfer follow-up records carry
+  // this flag so the dupe check below (and the matching one in
+  // tUpdateLog(actRescore)) does NOT flag them as dupes.  See
+  // MainUnit.DrainPendingMultiQSORefs for where the flag is set.
+  if (not RXData.ceClearDupeSheet) and
+    (VisibleLog.CallIsADupe(RXData.Callsign, RXData.Band, RXData.Mode) or
+    ((ActiveDomesticMult = GridSquares) and RoverCall(RXData.Callsign) and (NumberGridSquaresInList > 0))) then
     if not (ActiveQSOPointMethod = AlwaysOnePointPerQSO) then
     begin
         //      if Trace then Write('#');

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1765,6 +1765,14 @@ var
   sMode                                 : string;
   sSubMode                              : string;
   saveDecimalSeparator                  : char;
+  // State-QP rover (KG1S/MON): per-record bare call for the standard
+  // <CALL> field, plus the full form for <APP_TR4W_ROVERCALL>.  Computed
+  // per QSO in the read loop below and consumed by the <CALL> Format
+  // and the WriteADIFField call that follows.
+  adifCallStr                           : string;
+  adifRoverFullCall                     : string;
+  roverSlashPos                         : Integer;
+  roverSuffix                           : string;
 //  IOTAstring                            : Str10;
 begin
   sMode := '';
@@ -1856,8 +1864,35 @@ begin
       //if TempRXData.RSTSent > 99 then tRSTSendStringLength := 3 else tRSTSendStringLength := 2;
       //if TempRXData.RSTReceived > 99 then tRSTRcvdStringLength := 3 else tRSTRcvdStringLength := 2;
 
+      // State-QP rover (KG1S/MON): if the QSO record's call has a slash
+      // and the suffix matches the QSO's QTHString, it's a rover entry.
+      // Emit the bare call ("KG1S") in the standard <CALL> field and
+      // the full call ("KG1S/MON") in the TR4W-specific
+      // <APP_TR4W_ROVERCALL> field.  Gate on ActiveExchange so we only
+      // do this for state-QP contests; ActiveExchange is set to the
+      // contest type that created the log even at export time.
+      adifCallStr      := string(TempRXData.Callsign);
+      adifRoverFullCall := '';
+      if ((ActiveExchange = RSTDomesticQTHExchange) or
+          (ActiveExchange = RSTQTHExchange) or
+          (ActiveExchange = RSTDomesticOrDXQTHExchange)) then
+         begin
+         roverSlashPos := Pos('/', adifCallStr);
+         if roverSlashPos > 0 then
+            begin
+            roverSuffix := Copy(adifCallStr, roverSlashPos + 1,
+                                Length(adifCallStr) - roverSlashPos);
+            if (roverSuffix <> '') and
+               (UpperCase(roverSuffix) = UpperCase(string(TempRXData.QTHString))) then
+               begin
+               adifRoverFullCall := adifCallStr;
+               adifCallStr := Copy(adifCallStr, 1, roverSlashPos - 1);
+               end;
+            end;
+         end;
+
       sBuffer := SysUtils.Format('<CALL:%u>%s <BAND:%u>%s <QSO_DATE:8>%04d%.2d%.2d <TIME_ON:6>%.2d%.2d%.2d <TIME_OFF:6>%.2d%.2d%.2d <RST_SENT:%u>%d <RST_RCVD:%u>%d '  // Moved CONTEST_ID below to make it conditional
-                  ,[length(TempRXData.Callsign), TempRXData.Callsign
+                  ,[Length(adifCallStr), adifCallStr
                   ,length(ADIFBANDSTRINGSARRAY[TempRXData.Band]), ADIFBANDSTRINGSARRAY[TempRXData.Band]
                  // ,length(ExtendedModeStringArray[TempRXData.Mode]), ExtendedModeStringArray[TempRXData.Mode]
                  // ,length(ModeStringArray[TempRXData.Mode]), ModeStringArray[TempRXData.Mode]
@@ -1876,6 +1911,12 @@ begin
                   ]
                   );
       sWriteFileFromString(tReportFileWrite, sBuffer);
+
+      // State-QP rover: emit the full original (KG1S/MON) in the TR4W
+      // app-specific field so the operator's intent survives ADIF
+      // round-trips.  Empty string when the QSO wasn't a rover entry.
+      if adifRoverFullCall <> '' then
+         WriteADIFField('APP_TR4W_ROVERCALL', adifRoverFullCall);
 
       if not (Contest in [POTA,GENERALQSO]) then
          begin

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -2038,7 +2038,25 @@ begin
             end;
          end
       else
-         WriteADIFField('SRX_STRING', TempRXData.ExchString);
+         begin
+         // Normalize SRX_STRING to include the implied RST so it is symmetric
+         // with STX_STRING (which GetMyExchangeForExport always builds with
+         // RST).  Without this, in contests where the operator does not
+         // type the RST (e.g. FQP CW, 599 implied), single-QSO exchanges
+         // export as "<SRX_STRING:3>HIL" while multi-county legs (built by
+         // PerQSOExchString in MainUnit) export as "<SRX_STRING:7>599 HIL".
+         // RST_RCVD lives in its own ADIF field; this purely normalizes the
+         // SRX_STRING display.  Stored ExchString is unchanged so Cabrillo
+         // emit is unaffected.
+         sTemp := IntToStr(TempRXData.RSTReceived);
+         if (TempRXData.ExchString <> '') and
+            (Copy(TempRXData.ExchString, 1, Length(sTemp) + 1) = sTemp + ' ') then
+            WriteADIFField('SRX_STRING', TempRXData.ExchString)
+         else if TempRXData.ExchString = '' then
+            WriteADIFField('SRX_STRING', sTemp)
+         else
+            WriteADIFField('SRX_STRING', sTemp + ' ' + TempRXData.ExchString);
+         end;
       stxString := GetMyExchangeForExport;
       WriteADIFField('STX_STRING',Trim(DeleteRepeatedSpaces(stxString)));
 

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -471,6 +471,8 @@ uses
   uCbrSum,
   MainUnit,
   uCFG;
+  // mo.DomList (ADIF CNTY long-name lookup) is reachable via the
+  // interface-section 'uses uMults' clause above.
 
 procedure WriteADIFField(sFieldName: string; sFieldValue: string);
 var sBuffer: string;
@@ -484,6 +486,31 @@ begin
       begin
       DEBUGMSG('[WriteADIFField] ' + sFieldName + ' value is blank - skipping');
       end;
+end;
+
+// For state-based QSO parties, return the host state's 2-letter ADIF
+// postal code; for any other contest return ''.  Used during ADIF export
+// when QTHString carries a county/section code instead of a 2-letter
+// state code -- in those contests we know the state by the contest itself.
+function GetStateForContest(c: ContestType): string;
+begin
+   case c of
+      CALQSOPARTY        : Result := 'CA';
+      FLORIDAQSOPARTY    : Result := 'FL';
+      MICHQSOPARTY       : Result := 'MI';
+      MINNQSOPARTY       : Result := 'MN';
+      MOQSOPARTY         : Result := 'MO';
+      NCQSOPARTY         : Result := 'NC';
+      OHIOQSOPARTY       : Result := 'OH';
+      TEXASQSOPARTY      : Result := 'TX';
+      WISCONSINQSOPARTY  : Result := 'WI';
+      TENNESSEEQSOPARTY  : Result := 'TN';
+      COLORADOQSOPARTY   : Result := 'CO';
+      PAQSOPARTY         : Result := 'PA';
+      INQSOPARTY         : Result := 'IN';
+   else
+      Result := '';
+   end;
 end;
 
 procedure CreateCabrilloFile;
@@ -1773,6 +1800,10 @@ var
   adifRoverFullCall                     : string;
   roverSlashPos                         : Integer;
   roverSuffix                           : string;
+  // ADIF CNTY emit: index into mo.DomList for the worked station's
+  // county code so we can pull the long-form county name (FAltName)
+  // loaded from <state>_cty.dom files.
+  cntyIdx                               : Integer;
 //  IOTAstring                            : Str10;
 begin
   sMode := '';
@@ -2048,10 +2079,35 @@ begin
    //      else if LooksLikeAState(TempRXData.QTHString) then
    else if not(Stringhasnumber(TempRXData.QTHString)) then
             begin
-            // MO QSO Party: 3-letter county codes (BAR, BOO, etc.) must not be
-            // exported as STATE.  Only 2-letter codes (TX, MO, etc.) are states.
-            if (Contest <> MOQSOPARTY) or (Length(TempRXData.QTHString) = 2) then
-               WriteADIFField('STATE',TempRXData.QTHString);
+            // ADIF STATE is the worked station's 2-letter US state postal
+            // code.  In state QSO parties, in-state stations send a county
+            // code in QTHString (3-letter for FL/MO/etc., variable elsewhere)
+            // -- those are NOT valid STATE values.  Three cases:
+            //   * QTHString is 2 letters: looks like a postal code, emit it.
+            //   * QTHString is multi-letter and we know the contest's host
+            //     state: emit that state (e.g. FQP county MON -> FL).
+            //   * Otherwise: skip.  Better no STATE than a bogus one.
+            if Length(TempRXData.QTHString) = 2 then
+               WriteADIFField('STATE', TempRXData.QTHString)
+            else
+               begin
+               sTemp := GetStateForContest(Contest);
+               if sTemp <> '' then
+                  begin
+                  WriteADIFField('STATE', sTemp);
+                  // ADIF CNTY = "<state>,<county-full-name>".  The long
+                  // form is loaded from <state>_cty.dom into FAltName by
+                  // LOGDOM.PAS when the file ships entries like
+                  // "Mon = MON,^Monroe".  Some state QP dom files do not
+                  // (yet) carry the ^Long second field (e.g. florida_cty.dom,
+                  // tennessee_cty.dom) -- in those cases FAltName is empty
+                  // and we just skip CNTY rather than emit a bogus value.
+                  if mo.DomList.FindMult(TempRXData.QTHString, cntyIdx) and
+                     (mo.DomList.FList[cntyIdx].FAltName <> '') then
+                     WriteADIFField('CNTY',
+                        sTemp + ',' + mo.DomList.FList[cntyIdx].FAltName);
+                  end;
+               end;
             end;
 
         //if ContestsArray[Contest].DM = DomesticMult

--- a/tr4w/src/uWinKey.pas
+++ b/tr4w/src/uWinKey.pas
@@ -268,6 +268,10 @@ uses
   MainUnit;
 
 function wkOpen: boolean;
+var
+  versionByte : Byte;
+  family      : Byte;
+  msg         : string;
 begin
   Result := False;
 
@@ -297,21 +301,23 @@ begin
   asm mov dword ptr wkREADBuffer[0], 0 end;
   if wkRead(1) then
   begin
-    WK2 := wkREADBuffer[0] >= 20;
-    asm
-    xor eax,eax
-    mov al,byte ptr wkREADBuffer[0]
-    push eax
-
-    xor  eax,eax
-    mov  al,byte ptr wk2
-    add  eax,1
-    push eax
-    end;
-    wsprintf(@wkREADBuffer, 'WK%u v%u');
-    asm add esp,16
-    end;
-    SetMainWindowText(mweWinKey, @wkREADBuffer);
+    // The keyer's HOST OPEN response is its firmware-revision byte.
+    // Map it to a family digit for the status display:
+    //   v < 20   -> WK1     (legacy WinKeyer)
+    //   v 20-29  -> WK2     (WinKeyer2)
+    //   v >= 30  -> WK3     (WinKeyer3 — was previously displayed as WK2
+    //                        because the family was tracked as a single
+    //                        Boolean WK2 := version >= 20.  Issue #891)
+    versionByte := wkREADBuffer[0];
+    WK2 := versionByte >= 20;
+    if versionByte >= 30 then
+      family := 3
+    else if versionByte >= 20 then
+      family := 2
+    else
+      family := 1;
+    msg := Format('WK%d v%d', [family, versionByte]);
+    SetMainWindowText(mweWinKey, PChar(msg));
   end;
   logger.Info('Calling tCreateThread from WkOpen');
   tCreateThread(@wkReadThreadProc, wkThreadID);


### PR DESCRIPTION
## Summary

May 2026 maintenance bundle (13 commits) covering several issues plus test, ADIF, and infrastructure cleanup.  Commits are tested locally and grouped by area below.

## Commits by area

### State QSO parties — rover, county-line, ADIF round-trip

- `202f14d` State-QP rover (KG1S/MON) — exchange auto-fill, ADIF round-trip with APP_TR4W_ROVERCALL field.
- `1ff9234` Per-QSO SRX_STRING for multi-county and multi-park (Issue TR4W/TR4W#889).
- `61238d5` State-QP rover/county-line round-trip fixes:
  - `ctyLocateCallStripRover` wrapper applied in import + rescore so a state-QP rover call no longer gets re-tagged as DX=G via the `/M` GB-prefix interpretation.
  - ADIF STATE map for 13 known state QPs (CA/FL/MI/MN/MO/NC/OH/TX/WI/TN/CO/PA/IN); replaces the prior MO-only special case.
  - ADIF CNTY emitted as `<state>,<long-name>` when `mo.DomList.FAltName` is populated for the worked QTH.
  - `DrainPendingMultiQSORefs` sets `ceClearDupeSheet=True` on follow-up county records; `LOGSUBS2.LogContact` honors the flag in its dupe-check, so the "is a dupe and will be logged with zero QSO points" banner / three-harmonic beep are suppressed for follow-up legs.
  - Diagnostic logging in `ctyLocateCallStripRover` and `tUpdateLog(actRescore)` (one INFO line per record when anything actually changes during rescore).
- `288c321` County-line legs share one transmitted serial (Refs TR4W/TR4W-D12#28) — per CQ Magazine guidance for CQP, all legs of a single on-air exchange share one transmitted serial.  The "next station's serial jumps by N" issue is tracked separately as TR4W/TR4W-D12#28.
- `f048dc7` Normalize ADIF SRX_STRING to include implied RST so it is symmetric with STX_STRING (e.g. FQP CW where 599 is implied).

### WinKeyer

- `a19a0d5` Replace inline-asm `wsprintf` with `Format`/`PChar` for port-open error message (Delphi 7 ABI mismatch was producing garbage error strings).
- `f183cbb` Detect WK3 hardware in status display (Closes TR4W/TR4W#891).  Previously WK3 reported as "WK2 v31"; now classified by K1EL firmware-version convention.

### Networking

- `f50c636` Log connect retries only on state change (suppresses repeated identical messages).
- `6708783` Show active operator in network window (Issue TR4W/TR4W#770).
- `88d10a3` Replace raw WinSock2 POST with TIdHTTP+TLS in uGetScores (Issue TR4W/TR4W#26).

### Other

- `0bbb649` Delete .TRW when overwriting existing contest (Issue TR4W/TR4W#674).
- `b417054` Programmable Messages: insert command at cursor on double-click (Issue TR4W/TR4W#47).
- `ff88e00` Add utils_text unit tests (StringIsAll* and StringWithFirstWordDeleted).

## Test plan

- [x] Issue TR4W/TR4W#885 follow-up: log a county-line QSO, both records non-dupe, share serial number, ADIF round-trip preserves county data.
- [x] State-QP rover call (KG1S/MON) imports with USA + correct QTH (not DX=G), exports with APP_TR4W_ROVERCALL, re-imports cleanly.
- [x] FQP CW single-county QSO exports with `<SRX_STRING:7>599 HIL` form (matches multi-county legs).
- [x] WK3 hardware shows "WK3 v31" in status field (was "WK2 v31").
- [ ] Cabrillo export sanity-check on a state QP log (no changes expected to Cabrillo path).
- [ ] Network multi-op window shows active operator name.
- [ ] uGetScores POSTs to score sites successfully over TLS.
- [ ] `.TRW` file is removed when creating a new contest with an existing name.
- [ ] Programmable message editor: double-click a command to insert at cursor.
- [ ] uWinKey port-open error displays a readable Windows error message (not garbage).
- [ ] Run `tr4w_unit_tests.dpr` — utils_text tests pass.

## Open follow-ups (not in this PR)

- TR4W/TR4W-D12#28 — "Next station's serial number jumps by N after a multi-county / Nfer entry."  Architectural fix needs separate `NextSerialCounter`; out of scope for this maintenance bundle.
- FL/TN `_cty.dom` files lack `^Long` county-name entries, so ADIF CNTY is silently skipped for those states.  Data file additions for future work.