### PR TITLE
Stop treating multi-county exchanges as callsign updates (LooksLikeACallSign)

### DIFF
--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -2364,19 +2364,22 @@ begin
     end
     else if Call[CharIndex] = '/' then
     begin
-      if ((CharIndex > 3) and (CharIndex <> length(Call)) or
-        ((CharIndex < length(Call)) and (CharIndex > 1))) then
+      // A '/' at the very start or very end of the token cannot belong
+      // to a callsign (no prefix or no body to suffix).
+      if (CharIndex = 1) or (CharIndex = length(Call)) then
       begin
-        LooksLikeACallSign := True;
+        LooksLikeACallSign := False;
         Exit;
       end;
-    end;
-
-    if ((CharIndex = 1) or (CharIndex = length(Call))) and (Call[CharIndex] =
-      '/') then
-    begin
-      LooksLikeACallSign := False;
-      Exit;
+      // Otherwise: do NOT return True here just because we found a '/'.
+      // The legacy code returned True at the first interior '/' which
+      // misfires for state-QP multi-county exchanges like "PIN/HIL" --
+      // both halves are all-letter county codes that resemble nothing
+      // like a real callsign.  Real callsigns require a letter<->digit
+      // transition in the prefix/body, which the end-of-function
+      // `nChanges >= 2` check enforces.  Tokens like "PIN/HIL" have
+      // nChanges = 0 and correctly fail that check.  See the
+      // Callsign-Update-Enable / Howie / county-line discussion.
     end;
   end;
 


### PR DESCRIPTION
## Summary

In S&P mode with `CALLSIGN UPDATE ENABLE = TRUE`, typing a multi-county exchange like `PIN/HIL` into the exchange window caused TR4W to strip the exchange out as a "corrected callsign", leaving nothing for the exchange parser.  The QSO would not log.

`LooksLikeACallSign` in `trdos/LOGSTUFF.PAS` was returning True for any token whose first interior character was `/`, without requiring any letter↔digit transition first.  Real callsigns always contain digit(s) between prefix-letters and suffix-letters (1-2 letters, digit, 1-3 letters), so they accumulate `nChanges >= 2` by the time the loop reaches the slash.  County-line tokens like `PIN/HIL` have all-letter halves and `nChanges = 0`.

## Fix

Delete the early-True-at-interior-slash branch.  Keep the early-False-at-edge-slash branch (a `/` at position 1 or at the last position is still not a valid callsign shape).  Let the final `nChanges >= 2` check decide.

## Behavior matrix

| Token | Before | After | Correct? |
|---|---|---|---|
| `PIN/HIL` | True | **False** | ✓ (county-line) |
| `PIN`     | False | False | ✓ |
| `KG1S/MON` | True | True | ✓ (rover call) |
| `G/W4XYZ` | True | True | ✓ (single-letter portable prefix) |
| `K/W1AW`  | True | True | ✓ |
| `NY4I`    | True | True | ✓ |
| `NY4A→NY4I` correction | works | works | ✓ |
| `PIN/HIL NY4I` (county-line + correction combined) | broken (PIN/HIL stolen) | **works** | ✓ |

## Test plan

- [x] S&P, call window correct, exchange `PIN/HIL` → two county QSOs logged.
- [x] S&P, call window `NY4A` (wrong), exchange `PIN/HIL NY4I` → callsign updated to NY4I, two county QSOs logged.
- [x] Normal single-county callsign correction (`599 PIN K1ABC`) unchanged.
- [x] FullBuild green (119 unit tests pass).

## Out of scope / follow-up

No automated test coverage was added — `LooksLikeACallSign` lives in `trdos/LOGSTUFF.PAS` which the test runner does not link.  A future refactor that moves callsign-shape helpers into a dependency-light unit (along the lines of the Issue #887 `uADIF` extraction) would unblock automated testing here.