### PR TITLE
K4 PING/PONG keep-alive + ADIF SRX_STRING / SRX-STX fixes

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1787,6 +1787,26 @@ begin
    Result := Result + EmitADIFField('STX_STRING',
                                     Trim(DeleteRepeatedSpaces(stxString)));
 
+   // ----- SRX_STRING (Issue #898) -----
+   // uADIF.EmitADIFRecord deliberately does NOT emit SRX_STRING because
+   // its shape is contest-specific:
+   //   POTA          -> park-ref shape (handled below in the POTA branch)
+   //   RST-implied   -> "RST + ExchString"  (ResolveSRXString normalizes)
+   //   no RST        -> ExchString as-is    (FD, SS, Winter FD, etc.)
+   // The "is RST part of this contest's exchange?" knowledge lives in
+   // ExchangeInformation.RST (trdos/LOGDUPE.PAS), which uADIF cannot
+   // see without taking a trdos dependency.  POTA's own SRX_STRING is
+   // emitted further down -- this branch handles every other contest.
+   if rec.ceContest <> POTA then
+      begin
+      if ExchangeInformation.RST then
+         Result := Result + EmitADIFField('SRX_STRING',
+                                          ResolveSRXString(rec))
+      else
+         Result := Result + EmitADIFField('SRX_STRING',
+                                          string(rec.ExchString));
+      end;
+
    // ----- POTA-specific (uADIF skips SRX_STRING for POTA) -----
    if rec.ceContest = POTA then
       begin

--- a/tr4w/src/uADIF.pas
+++ b/tr4w/src/uADIF.pas
@@ -1321,10 +1321,21 @@ begin
          Result := Result + EmitADIFField('RX_PWR', string(rec.Power));
       end;
 
-   // SRX / STX (numeric serials)
-   if rec.NumberReceived <> $FFFF then       // -1 as Word -> not set
+   // SRX / STX (numeric serials).  Two "unset" sentinels are in use:
+   //   $FFFF (65535) -- set by uADIF.InitContestExchangeForParse for
+   //                    records built from imported ADIF
+   //   -1            -- left in place by live-entry / binary-log
+   //                    paths for contests that don't use a serial
+   //                    (e.g. Field Day on the SRX side -- ExchString
+   //                    carries class+section, NumberReceived stays
+   //                    at its initialized value)
+   // Without the >0 guard, FD records emit garbage like <SRX:5>000-1
+   // because PadInt(-1, 5) produces the literal string "000-1".
+   if (rec.NumberReceived > 0)      and
+      (rec.NumberReceived <> $FFFF) then
       Result := Result + EmitADIFField('SRX', PadInt(rec.NumberReceived, 5));
-   if rec.NumberSent <> $FFFF then
+   if (rec.NumberSent > 0)      and
+      (rec.NumberSent <> $FFFF) then
       Result := Result + EmitADIFField('STX', PadInt(rec.NumberSent, 5));
 
    if rec.TenTenNum <> $FFFF then

--- a/tr4w/src/uADIF.pas
+++ b/tr4w/src/uADIF.pas
@@ -257,6 +257,16 @@ function ExportADIFToString(const records: TContestExchangeArray;
 // reachable from both uADIF (export) and the test runner.
 function GetStateForContest(c: ContestType): string;
 
+// Build the RST-normalized SRX_STRING value: if ExchString already
+// starts with the literal RSTReceived (e.g. operator typed `599 HIL`),
+// return ExchString unchanged; otherwise prepend `RSTReceived ` so
+// the field is symmetric with STX_STRING.  Used by the export tail
+// emitter for contests whose exchange convention includes an implied
+// RST (ExchangeInformation.RST = True) -- state QPs and zone
+// contests.  Contests whose exchange has no RST (FD, SS, Winter FD,
+// etc.) should emit SRX_STRING = ExchString directly, NOT call this.
+function ResolveSRXString(const rec: ContestExchange): string;
+
 implementation
 
 var
@@ -1267,13 +1277,15 @@ begin
    // FREQ (locale-independent, '.' separator)
    Result := Result + EmitADIFField('FREQ', freqStr);
 
-   // SRX_STRING (received exchange, RST-normalized).
-   // POTA uses a different SRX_STRING shape (park ref instead of
-   // RST-prefixed exchange).  The tail emitter handles POTA's
-   // SRX_STRING -- uADIF skips it here to avoid a double-emit
-   // where the last-wins parse would lose the park ref.
-   if rec.ceContest <> POTA then
-      Result := Result + EmitADIFField('SRX_STRING', ResolveSRXString(rec));
+   // SRX_STRING is NOT emitted here.  The correct shape depends on the
+   // contest's exchange convention (does it include an implied RST?
+   // is it a park ref?  is it the literal ExchString?), and that
+   // knowledge lives in ExchangeInformation.RST (in trdos/LOGDUPE.PAS)
+   // which uADIF deliberately does not depend on.  PostUnit's tail
+   // emitter (EmitContestSpecificTailForExport) handles SRX_STRING
+   // for all contests using ExchangeInformation -- see Issue #898.
+   // ResolveSRXString below is exported as a helper for the tail
+   // emitter's RST-normalizing branch.
 
    // STATE - emit when QTHString is a 2-letter postal code, OR when this
    // is a single-state QSO party and QTHString is a county code.

--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -92,7 +92,16 @@ begin
          end
       else
          begin
+         // Network: AI5 pushes state changes -- no polling needed for
+         // state.  But the K4 server drops clients that send nothing
+         // for 10 seconds (per K4 Programmer's Reference, PING/PONG
+         // section -- Issue #897).  Enable a 1 Hz poll that sends
+         // PING; as a keep-alive.  ProcessMessage handles the PONG;
+         // response explicitly (case 17, 'PO') and at the top calls
+         // UpdateLastValidResponse, refreshing the inbound watchdog.
          Self.SetAIMode(5);
+         Self.requiresPolling := True;
+         Self.pollingInterval := 1000; // 1 Hz keep-alive ping
          end;
       Self.SendToRadio('RT;XT;RO;FT;ID;MD;DT$;IF;');
       Self.SendToRadio('RT$;XT$;RO$;MD$;DT$;IF$;');
@@ -624,7 +633,7 @@ begin
       SetLength(sData,length(sData)-1);
       end;
 
-   Case AnsiIndexText(AnsiUppercase(sCommand), ['AI','BI','BN','DT','FA','FB','FT','IF','KS','MA','MD','RT','RX','TX','XT','RO', 'FP']) of
+   Case AnsiIndexText(AnsiUppercase(sCommand), ['AI','BI','BN','DT','FA','FB','FT','IF','KS','MA','MD','RT','RX','TX','XT','RO','FP','PO']) of
       0: begin                                     // AI
          logger.debug('[ProcessMessage] AI command set to %s',[sData]);
          end;
@@ -761,6 +770,18 @@ begin
             logger.error('[ProcessMessage] For FP command, invalid value in sData (%s)',[sData]);
             end;
          end;
+      17:begin    // PO (response to PING -- the full token is PONG;)
+         // The K4 server drops clients that send nothing for 10 s.
+         // We send PING; at 1 Hz from PollRadioState in network mode
+         // (see Connect's network branch and Issue #897).  PONG; is
+         // the documented response.  Nothing to do here: the call to
+         // UpdateLastValidResponse at the top of ProcessMessage has
+         // already refreshed the inbound watchdog, which is the only
+         // state PONG carries.  Explicit case branch (rather than a
+         // fall-through) so future maintainers can see that PONG is
+         // an expected message and is handled, not ignored by accident.
+         logger.Trace('[ProcessMessage] PONG keep-alive response');
+         end;
    end; // of case
    if firstProcessMessage then
       begin
@@ -802,9 +823,22 @@ end;
 
 procedure TK4Radio.PollRadioState;
 begin
-   // IF gives VFO A freq + mode + RIT/XIT/split/TX state in one response.
-   // FB gives VFO B frequency.
-   Self.SendToRadio('IF;FB;');
+   if Self.serialPort <> NoPort then
+      begin
+      // Serial: poll state (no AI on serial).
+      // IF gives VFO A freq + mode + RIT/XIT/split/TX state in one response.
+      // FB gives VFO B frequency.
+      Self.SendToRadio('IF;FB;');
+      end
+   else
+      begin
+      // Network: AI5 already pushes state changes; just keep the
+      // connection alive.  PING; is the documented keep-alive
+      // command (Issue #897, K4 Programmer's Reference).  The K4
+      // server drops clients that go silent for 10 s, so we send
+      // PING; at 1 Hz from Connect's pollingInterval.
+      Self.SendToRadio('PING;');
+      end;
 end;
 
 procedure TK4Radio.SetAIMode(i: integer);


### PR DESCRIPTION
## Summary

Three independent fixes that surfaced while doing Field Day prep testing:

1. **K4 PING/PONG keep-alive in network mode** (closes #897)
2. **ADIF `<SRX_STRING>` no longer prepends `59` for FD / SS / Winter FD** (closes #898)
3. **ADIF `<SRX>` / `<STX>` no longer emit garbage like `<SRX:5>000-1` for unset serials** (no issue — surfaced during the FD export verification for #898)

## 1. K4 PING/PONG keep-alive (`uRadioElecraftK4.pas`, Issue #897)

A K4 server (K4 in remote/host mode, `k4remote.elecraft.com`, etc.) drops a client that sends nothing for 10 seconds. TR4W's K4 network mode uses AI5 — state changes are pushed from the radio to the client — but the client itself sends nothing during operator idle periods. An operator who tunes once and then sits quietly for >10 s would silently lose the K4 connection.

Fix: in network mode, enable the existing polling infrastructure at 1 Hz and use it to send `PING;`. Serial mode is unchanged (still sends `IF;FB;` for state polling, since AI is disabled on serial to avoid flooding the COM port).

- `Connect` (network branch): `requiresPolling := True; pollingInterval := 1000`.
- `PollRadioState`: branches on `serialPort` — serial sends `IF;FB;` (current), network sends `PING;`.
- `ProcessMessage`: `'PO'` added to `AnsiIndexText` list with an explicit case 17 that logs the PONG keep-alive response. PONG also refreshes the inbound watchdog via the existing `UpdateLastValidResponse` at the top of `ProcessMessage`. Explicit case branch (rather than fall-through) so PONG appears in the dispatch list alongside every other K4 message — a future reader sees it's handled, not silently dropped.

## 2. `<SRX_STRING>` no longer prepends `59` for FD / SS / Winter FD (`uADIF.pas` + `PostUnit.PAS`, Issue #898)

`ResolveSRXString` was added in PR #896 to normalize `<SRX_STRING>` with an implied RST prefix so it would be symmetric with `<STX_STRING>` for state QSO parties (where the operator types just the county and the RST is implied 599). That assumption is wrong for any contest whose exchange does not include RST: ARRL Field Day, Winter Field Day, ARRL Sweepstakes (CW/SSB), etc. For Field Day, the exchange is class + section (e.g. `1D WCF`) and the emit was producing `<SRX_STRING:9>59 1D WCF` — the leading `59` is bogus.

The "does this contest's exchange include RST?" knowledge already lives in `ExchangeInformation.RST` (`trdos/LOGDUPE.PAS`), which is set per-contest by `SetUpExchangeInformation`. `uADIF` cannot read that without taking on a trdos dependency, which would defeat the testability premise of Issue #887.

Fix: move `<SRX_STRING>` emission out of `uADIF.EmitADIFRecord` and into `PostUnit.EmitContestSpecificTailForExport` — the established tail-emitter callback for contest-specific ADIF fields, which already handles POTA's park-ref-shaped `<SRX_STRING>`. The tail emitter now decides the `<SRX_STRING>` shape:

| Case | Behaviour |
|---|---|
| `POTA` | park-ref shape (existing branch, unchanged) |
| `ExchangeInformation.RST = True`  | `ResolveSRXString` — `"RST + ExchString"` (state QPs / zone contests) |
| `ExchangeInformation.RST = False` | `ExchString` as-is (FD, SS, Winter FD, ...) |

`ResolveSRXString` is promoted from a private helper to a public function in `uADIF`'s interface so the tail emitter can call it.

## 3. `<SRX>` / `<STX>` guard against unset-serial sentinels (`uADIF.pas`)

Two distinct "unset" sentinels for `NumberReceived` / `NumberSent` are in use:

| Sentinel | Source |
|---|---|
| `$FFFF` (65535) | `uADIF.InitContestExchangeForParse` for records built from imported ADIF |
| `-1`            | live-entry / binary-log paths for contests that don't use a serial |

The prior guard was just `<> $FFFF`, written when these fields were a `Word` type (where `$FFFF` was the natural -1-as-unsigned representation). The fields are now signed `Integer`, so `-1` stays `-1` — the `$FFFF` check no longer catches it. For Field Day, where SRX is unused and stays at `-1`, `EmitADIFRecord` was producing `<SRX:5>000-1`: `PadInt(-1, 5)` calls `IntToStr(-1) = '-1'` and then zero-pads to width 5, yielding the literal `"000-1"`. That's malformed ADIF for a numeric field.

Fix: require the value to be positive AND not the parse sentinel. Same guard applied symmetrically to STX so future code paths that leave `NumberSent` unset don't produce the same garbage.

## Test plan

- [x] Full build clean (`FullBuild.ps1`)
- [x] All 561 unit tests pass (`tr4w_unit_tests.exe`)
- [x] Live Field Day export — verified: `<SRX_STRING:6>1D WCF` instead of `<SRX_STRING:9>59 1D WCF`; no `<SRX:5>000-1` garbage; `<STX:5>00001` still emitted for the operator's auto-incremented serial; second `<STX_STRING>` (legacy `MyFDClass + MySection` form) still emitted as before.
- [x] State QP export regression-check — `<SRX_STRING>` still has the RST prefix as before; SRX with positive serials still emitted.
- [x] **K4 network keep-alive — verified on real K4 hardware.** Connection stayed up through idle periods >10 s. `tr4w.log` at TRACE/DEBUG showed `[ProcessMessage] PONG keep-alive response` ~1× per second as expected.
