### PR TITLE
Fix IC-7760 disconnect color, recovery, and detection speed

### DIFF
--- a/tr4w/src/uIcomNetworkTypes.pas
+++ b/tr4w/src/uIcomNetworkTypes.pas
@@ -53,7 +53,7 @@ const
   ICOM_RETRANSMIT_CHECK_INTERVAL = 100;
   ICOM_CIV_WATCHDOG_INTERVAL     = 500;
   ICOM_CIV_TIMEOUT_THRESHOLD     = 2000;    // 2 seconds
-  ICOM_PING_DEAD_TIMEOUT_MS      = 15000;   // 15 seconds without a ping → full disconnect+reconnect
+  ICOM_PING_DEAD_TIMEOUT_MS      = 3000;    // 3 seconds without a ping -> declare link lost.  Radio sends pings every 100 ms, so 30 missed pings is unambiguous; a transient sub-3-second network glitch won't trigger a false reconnect cycle.  Was 15000 -- felt sluggish to operators turning the radio off (Issue: IC-7760 disconnect detection delay).
 
   // "Are You There" retry config
   ICOM_AYT_MAX_RETRIES    = 10;

--- a/tr4w/src/uNetRadioBase.pas
+++ b/tr4w/src/uNetRadioBase.pas
@@ -152,6 +152,13 @@ Type TNetRadioBase = class(TObject)
 
       function GetISConnected: boolean; virtual;
       function GetIsOperational: boolean; virtual;
+      // True if a Disconnect+Connect cycle would help when the radio sits
+      // in IsConnected=True but IsOperational=False for too long.  Default
+      // False -- safe for radios where the two dimensions are independent
+      // (e.g. Flex: TCP up vs SmartSDR slice valid).  TIcomRadio overrides
+      // to True because Icom's "operational" gap means the multi-step
+      // handshake stalled and a fresh AYH is the only recovery.
+      function GetCanRecycleOnStuckHandshake: boolean; virtual;
       function GetAuthFailed: boolean; virtual;
       function BandToFreq(band: TRadioBand): LongInt;  // Map band enum to typical calling frequency
 
@@ -195,6 +202,7 @@ Type TNetRadioBase = class(TObject)
       property IsReceiving: boolean read GetIsReceiving;
       property IsConnected: boolean read GetIsConnected;
       property IsOperational: boolean read GetIsOperational;
+      property CanRecycleOnStuckHandshake: boolean read GetCanRecycleOnStuckHandshake;
       property AuthFailed: boolean read GetAuthFailed;
       property IsRITOn[whichVFO: TVFO]: boolean read GetIsRITOn;
       property IsXITOn[whichVFO: TVFO]: boolean read GetIsXITOn;
@@ -873,6 +881,16 @@ begin
    // Default: connected = operational.
    // Radios with richer state (e.g. Flex slices) override this.
    Result := True;
+end;
+
+function TNetRadioBase.GetCanRecycleOnStuckHandshake: boolean;
+begin
+   // Default False: don't force a Disconnect+Connect cycle when stuck in
+   // IsConnected=True/IsOperational=False.  Radios where the two states
+   // are independent (Flex: TCP vs slice) would just churn TCP without
+   // fixing the actual issue.  Override and return True for radios where
+   // a fresh handshake is the right recovery path (e.g. TIcomRadio).
+   Result := False;
 end;
 
 function TNetRadioBase.GetAuthFailed: boolean;

--- a/tr4w/src/uRadioIcomBase.pas
+++ b/tr4w/src/uRadioIcomBase.pas
@@ -116,6 +116,8 @@ type
     function BCDToFreq(bcd: string): LongInt;
     procedure ProcessCIVFrame(frame: string); virtual;
     function GetIsConnected: boolean; override;
+    function GetIsOperational: boolean; override;             // Strict: true only when handshake fully complete
+    function GetCanRecycleOnStuckHandshake: boolean; override; // True for network -- fresh AYH is the recovery
     function GetAuthFailed: boolean; override;
     function IsNetworkConnection: boolean;
     function SupportsDataMode: Boolean; virtual;  // Override to True on radios that support $1A $06
@@ -552,6 +554,37 @@ begin
   end
   else
     Result := inherited GetIsConnected;
+end;
+
+// "Operational" is the strict counterpart to IsConnected: True only once the
+// transport has finished its full handshake and reached icsConnected.
+// Distinct from IsConnected (which stays True during the WaitingForHere /
+// WaitingForReady / WaitingForLogin / Authenticated / StreamRequested
+// reconnect dance so the polling thread does not interrupt the handshake).
+//
+// The UI alert color (uRadioPolling.SetRadioAlertState) keys off
+// IsOperational so the operator sees "radio lost" magenta the entire time
+// the radio is unreachable, instead of clearing back to normal the moment
+// a reconnect attempt fires (which is what happened before this override --
+// the base class's GetIsOperational returned True unconditionally).
+function TIcomRadio.GetIsOperational: boolean;
+begin
+  if IsNetworkConnection then
+    Result := (FNetworkTransport <> nil) and
+              (FNetworkTransport.State = icsConnected)
+  else
+    Result := inherited GetIsOperational;
+end;
+
+// Tell the polling thread it's safe to force a Disconnect+Connect cycle
+// when we sit in IsConnected=True / IsOperational=False for too long.
+// For network Icom this means "the multi-step handshake stalled" and a
+// fresh AYH packet is the only recovery (the transport doesn't auto-retry
+// the initial $0003).  For serial Icom this state can't really happen, so
+// return True only for the network path.
+function TIcomRadio.GetCanRecycleOnStuckHandshake: boolean;
+begin
+  Result := IsNetworkConnection;
 end;
 
 function TIcomRadio.GetAuthFailed: boolean;

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -727,21 +727,23 @@ var
    lastHeartbeatTick: LongWord;
    lastRITXITTick: LongWord;
    authErrBuf: array[0..127] of Char;
+   handshakeStuckSinceTick: LongWord;  // GetTickCount when we first noticed IsConnected but not IsOperational; 0 = not tracking
 const
    RECONNECT_INITIAL_DELAY = 1000;    // 1 second initial delay
    RECONNECT_MAX_DELAY = 30000;       // 30 seconds max delay
+   HANDSHAKE_STUCK_MS = 8000;         // Force a Disconnect+Connect cycle if the transport has been mid-handshake (IsConnected but not IsOperational) for this long.  Covers the "radio was off when Connect() fired, the initial AYH packet was lost, no further AYH retries are sent" failure mode -- without this the polling thread spins forever in the connected branch sending CI-V commands that fail with "stream not open".
 
-   // SetRadioAlertState — set or clear RadioDisconnected flag and repaint freq/name
+   // SetRadioAlertState ï¿½ set or clear RadioDisconnected flag and repaint freq/name
    // windows only on a state transition (guarded by current flag value).
    procedure SetRadioAlertState(alertOn: boolean);
    begin
       if alertOn = rig^.RadioDisconnected then
-         Exit;   // No change — do not call InvalidateRect unnecessarily
+         Exit;   // No change ï¿½ do not call InvalidateRect unnecessarily
       rig^.RadioDisconnected := alertOn;
       if alertOn then
-         logger.Info('[pNetworkRadio] %s — alert color ON', [rig^.RadioName])
+         logger.Info('[pNetworkRadio] %s ï¿½ alert color ON', [rig^.RadioName])
       else
-         logger.Info('[pNetworkRadio] %s — alert color OFF', [rig^.RadioName]);
+         logger.Info('[pNetworkRadio] %s ï¿½ alert color OFF', [rig^.RadioName]);
       if rig^.FreqWindowHandle <> 0 then
          Windows.InvalidateRect(rig^.FreqWindowHandle, nil, False);
       if rig^.RadioNameWndHandle <> 0 then
@@ -765,6 +767,7 @@ begin
    lastHeartbeatTick := 0;
    lastRITXITTick := 0;
    reconnectDelay := RECONNECT_INITIAL_DELAY;
+   handshakeStuckSinceTick := 0;
 
    // Keep polling thread alive until stop is requested (e.g. on Reset Radio Ports)
    while not rig^.PollingStopRequested do
@@ -772,13 +775,59 @@ begin
       try
          if ro.IsConnected then
          begin
+         // Stuck-handshake detector: IsConnected is the loose "transport is doing
+         // something" check that stays True throughout the multi-step Icom
+         // handshake (WaitingForHere/WaitingForReady/WaitingForLogin/etc.).
+         // If we sit in that limbo too long -- e.g. the radio was off when our
+         // initial AYH packet was sent, and the transport doesn't auto-retry --
+         // force a Disconnect so the else-branch fires Connect() again with
+         // a fresh handshake.  Without this, the polling thread spins forever
+         // in the connected branch sending CI-V commands that fail with
+         // "stream not open" until the operator manually intervenes.
+         //
+         // Gated on CanRecycleOnStuckHandshake so we only force-recycle for
+         // radios where it actually fixes things.  Flex returns False because
+         // its IsOperational drops when SmartSDR closes (TCP is fine, slice
+         // is gone) -- recycling TCP wouldn't help and would just churn.
+         if (not ro.IsOperational) and ro.CanRecycleOnStuckHandshake then
+            begin
+            if handshakeStuckSinceTick = 0 then
+               handshakeStuckSinceTick := GetTickCount
+            else if (GetTickCount - handshakeStuckSinceTick) > HANDSHAKE_STUCK_MS then
+               begin
+               logger.Warn('[pNetworkRadio] %s handshake stuck (IsConnected but not IsOperational) for >%d ms; forcing Disconnect for retry',
+                  [rig^.RadioName, HANDSHAKE_STUCK_MS]);
+               handshakeStuckSinceTick := 0;
+               try
+                  ro.Disconnect;
+               except
+                  on E: Exception do
+                     logger.Debug('[pNetworkRadio] Forced Disconnect raised: %s - %s', [E.ClassName, E.Message]);
+               end;
+               // Brief sleep so the next iteration sees the new state cleanly,
+               // then loop -- the else-branch will reset wasConnected and
+               // schedule the reconnect via the existing backoff path.
+               Sleep(100);
+               Continue;
+               end;
+            end
+         else
+            handshakeStuckSinceTick := 0;  // operational, or this radio doesn't recycle on stuck
+
          // Radio is connected - poll status
          if not wasConnected then
             begin
-            logger.trace('[pNetworkRadio] Radio connected — querying initial freq/mode/state');
+            logger.trace('[pNetworkRadio] Radio connected ï¿½ querying initial freq/mode/state');
             wasConnected := True;
             reconnectDelay := RECONNECT_INITIAL_DELAY;  // Reset backoff on successful connection
-            SetRadioAlertState(False);  // TCP reconnected — clear alert (operational check below)
+            // Don't unconditionally clear the alert here -- IsConnected is
+            // the loose "transport is doing something" check that stays True
+            // throughout the multi-step Icom handshake (WaitingForHere etc.).
+            // The IsOperational query below (and the per-iteration check at
+            // line ~944) is the strict "fully connected" gate that drives
+            // the alert color; clearing here would briefly turn the alert
+            // off during reconnect even when the radio is unreachable.
+            SetRadioAlertState(not ro.IsOperational);
 
             // For serial radios that require active polling, honour the user-configurable
             // FREQUENCY POLL RATE setting (FreqPollRate, default 10ms, range 10-1000ms).
@@ -798,12 +847,12 @@ begin
             if Assigned(ro) then
                begin
                logger.Debug('[pNetworkRadio] Querying initial freq/mode');
-               ro.QueryActiveVFO;      // $07 $D2 — must be first so FActiveVFO is set before mode routing
+               ro.QueryActiveVFO;      // $07 $D2 ï¿½ must be first so FActiveVFO is set before mode routing
                ro.QueryVFOAFrequency;
                ro.QueryVFOBFrequency;
-               ro.QueryMode;           // $04 — active VFO mode ? routed to FActiveVFO slot
-               ro.QueryVFOAMode;       // $26 $00 — inactive VFO A mode (when VFO B is active)
-               ro.QueryVFOBMode;       // $26 $01 — VFO B mode + data mode
+               ro.QueryMode;           // $04 ï¿½ active VFO mode ? routed to FActiveVFO slot
+               ro.QueryVFOAMode;       // $26 $00 ï¿½ inactive VFO A mode (when VFO B is active)
+               ro.QueryVFOBMode;       // $26 $01 ï¿½ VFO B mode + data mode
                end;
 
             // Poll the remaining states that transceive does not push
@@ -814,14 +863,14 @@ begin
                end;
 
             // CW speed on initial connection:
-            // - CWSpeedSync OFF: program is master — push CodeSpeed to radio so they agree.
-            // - CWSpeedSync ON:  radio is master — do NOT push; leave the radio's speed alone.
+            // - CWSpeedSync OFF: program is master ï¿½ push CodeSpeed to radio so they agree.
+            // - CWSpeedSync ON:  radio is master ï¿½ do NOT push; leave the radio's speed alone.
             //   The $14 $0C query sent during connect will return ro.CWSpeed, and the
             //   polling loop below (ro.CWSpeed -> CodeSpeed sync) will apply it on the
             //   first cycle that sees a valid response.
             if not rig^.CWSpeedSync and (CodeSpeed >= 6) and Assigned(ro) then
                begin
-               logger.Debug('[pNetworkRadio] CWSpeedSync off — pushing program speed %d WPM to radio', [CodeSpeed]);
+               logger.Debug('[pNetworkRadio] CWSpeedSync off ï¿½ pushing program speed %d WPM to radio', [CodeSpeed]);
                ro.SetCWSpeed(CodeSpeed);
                end;
             end;
@@ -851,7 +900,7 @@ begin
          // HamLib Direct: drain user commands first on every cycle (max 50ms latency),
          // then poll when an async callback fired or the heartbeat interval elapsed.
          // Set HAMLIB ASYNC ONLY = TRUE in cfg to disable the heartbeat and only
-         // poll on async callbacks — useful for testing whether transceive is working.
+         // poll on async callbacks ï¿½ useful for testing whether transceive is working.
          if Assigned(ro) and (ro is THamLibDirect) then
             begin
             THamLibDirect(ro).DrainUrgentQueue;
@@ -873,7 +922,7 @@ begin
                lastHeartbeatTick := GetTickCount;
                end;
 
-            // RIT/XIT slow poll — every 5000ms independently of the main heartbeat.
+            // RIT/XIT slow poll ï¿½ every 5000ms independently of the main heartbeat.
             // rig_get_rit/xit trigger $07 D0 side-effects in HamLib's Icom driver
             // which dismiss front-panel menus; polling infrequently keeps them usable.
             if GetTickCount - lastRITXITTick >= 5000 then
@@ -920,7 +969,7 @@ begin
          rig.CurrentStatus.VFO[VFOB].Band := GetTR4WBandFromNetworkBand(ro.band[nrVFOB]);
 
          // Sync CW speed from radio ? program (active radio only, when CWSpeedSync enabled)
-         // Only the active radio should update CodeSpeed — in SO2R, the inactive radio
+         // Only the active radio should update CodeSpeed ï¿½ in SO2R, the inactive radio
          // may have a different speed and would otherwise fight the active radio.
          if rig^.CWSpeedSync and (ro.CWSpeed > 0) and (ro.CWSpeed <> CodeSpeed)
             and (rig = ActiveRadioPtr) then
@@ -930,7 +979,7 @@ begin
             DisplayCodeSpeed;  // Refreshes display and persists to SpeedMemory
             end;
 
-         // HamLib Direct skips this — SendPollRequests already logs individual values.
+         // HamLib Direct skips this ï¿½ SendPollRequests already logs individual values.
          if TR4W_HAMLIB_DEBUG and not (ro is THamLibDirect) then
             logger.Info('[pNetworkRadio:%s] pre-UpdateStatus: VFOA=%d VFOB=%d split=%s VFOStatus=%d',
                [rig^.RadioName,
@@ -3111,7 +3160,7 @@ begin
                BandMapCursorFrequency := rig.FilteredStatus.Freq;
                BandMapBand := ActiveBand;
                BandMapMode := ActiveMode;
-               BandMapNeedsRefresh := True; // coalesced via 250ms timer — avoids flash on every VFO poll
+               BandMapNeedsRefresh := True; // coalesced via 250ms timer ï¿½ avoids flash on every VFO poll
             end;
       end
    else
@@ -3139,7 +3188,7 @@ begin
                BandMapMode := rig.FilteredStatus.Mode;
                VisibleDupeSheetChanged := True;
                BandMapCursorFrequency := rig.FilteredStatus.Freq;
-               BandMapNeedsRefresh := True; // coalesced via 250ms timer — avoids flash on every VFO poll
+               BandMapNeedsRefresh := True; // coalesced via 250ms timer ï¿½ avoids flash on every VFO poll
             end;
 
          //GAV End of added
@@ -3762,7 +3811,7 @@ procedure GetVFOInfoForYaesuFTX1(buf: PChar; var VFO: VFOStatusType;
    FrequencyAdder: integer);
    // FTX-1F/FTX-1R IF response layout (30 bytes total, Issue #817):
    //   Pos 1-2:   "IF"
-   //   Pos 3-7:   P1  VFO/memory channel (5 bytes — 2 longer than FTDX10's 3-byte P1)
+   //   Pos 3-7:   P1  VFO/memory channel (5 bytes ï¿½ 2 longer than FTDX10's 3-byte P1)
    //   Pos 8-16:  P2  VFO frequency Hz (9 bytes)
    //   Pos 17:    P3  Clarifier direction (+/-)
    //   Pos 18-21: P3  Clarifier offset 0000-9990 Hz (4 bytes)
@@ -4187,7 +4236,7 @@ begin
    if which = 0 then
       begin
          rig.CurrentStatus.VFO[VFOA].Mode := mode;
-         rig.CurrentStatus.VFO[VFOA].ExtendedMode := em;  // was VFOB — copy-paste bug
+         rig.CurrentStatus.VFO[VFOA].ExtendedMode := em;  // was VFOB ï¿½ copy-paste bug
          rig.CurrentStatus.Mode := mode;
          rig.CurrentStatus.ExtendedMode := em;
       end


### PR DESCRIPTION
## Summary

Fixes three compounding defects in Icom network disconnect handling that surfaced during IC-7760 testing. The user-visible symptom was: turn the radio off → ~15 s before the magenta "radio lost" indicator appeared → ~1 s later the indicator switched back to normal color (as if reconnected) → never actually recovered when the radio was turned back on.

Each defect alone is small. Together they made the radio appear connected when it was unreachable AND prevented automatic recovery when it returned.

## Defects fixed

### 1. Alert color flashed back to normal during reconnect

`TIcomRadio.GetIsConnected` returns `True` for any non-`Disconnected` transport state — that's deliberate so the polling thread doesn't interrupt the multi-step Icom handshake (`WaitingForHere` → `WaitingForReady` → `WaitingForLogin` → `Authenticated` → `StreamRequested` → `Connected`) by spamming `Connect()`. But `TIcomRadio` did **not** override `GetIsOperational`, so it inherited the base default of `True` unconditionally.

When the polling thread fired its 1-second-after-disconnect reconnect, the transport went `Disconnected → WaitingForHere`, the polling thread immediately took the "connected" branch, and `uRadioPolling.pas:781` unconditionally cleared the alert color (`SetRadioAlertState(False)`). Operator saw magenta flash off even though the radio was unreachable.

**Fix:** `TIcomRadio.GetIsOperational` now returns `True` only when `FNetworkTransport.State = icsConnected`. `uRadioPolling.pas:781` changed from `SetRadioAlertState(False)` to `SetRadioAlertState(not ro.IsOperational)`.

### 2. No recovery from a stuck handshake

The transport sends one `$0003` (AYH — "Are You Here") packet on `Connect()` and then sits in `WaitingForHere` forever if no `$0004` reply arrives. That's exactly what happens when `Connect()` fires while the radio is off. When the radio came back online, TR4W stayed silent because:

- The transport had given up on resending AYH (only sent once per `Connect()`)
- The polling thread's `IsConnected = True` (loose check, see #1) kept it in the connected branch instead of the else-branch that would have called `Connect()` again

**Fix:** new stuck-handshake detector at the top of `pNetworkRadio`'s connected branch. When `IsConnected = True && IsOperational = False` persists for >8000 ms, force a `Disconnect` so the next iteration's else-branch fires `Connect()` with a fresh AYH. Cycle repeats every ~9 s until the radio responds.

Gated on a new virtual `TNetRadioBase.GetCanRecycleOnStuckHandshake` that defaults `False`. `TIcomRadio` overrides to `True` for the network path. Flex (whose `IsOperational` tracks slice validity, not handshake state) and K4 / HamLib Direct (TCP-based, get disconnect detection from `socket.Connected`) all keep the default `False` so the detector is a no-op for them.

### 3. Disconnect detection took 15 seconds

`ICOM_PING_DEAD_TIMEOUT_MS` was `15000`. Radio sends pings every 100 ms, so 150 missed pings before declaring the link lost. Felt sluggish to the operator turning the radio off.

**Fix:** lowered to `3000`. 30 missed pings is unambiguous; transient sub-3-second network glitches still won't trigger a false reconnect cycle.

## Why Icom needs this and K4 doesn't

K4 is **TCP**. When you power off a K4 the OS sees the FIN/RST and `socket.Connected` becomes `False` essentially immediately — TCP carries connection state. The K4 polling path needs no application-level ping watchdog and gets disconnect detection for free.

Icom is **UDP** (`TIdUDPServer` instances for control and CI-V sockets per `uIcomNetworkTransport.pas:67-68`). UDP is connectionless — there's no socket-level disconnect event the OS can deliver. The only signal is the absence of the radio's expected ping packets. Hence the explicit timeout.

## Cross-radio impact (verified)

| Radio | Alert color | Stuck-recycle | Detection speed |
|---|---|---|---|
| **Icom (network)** | New: keyed off strict `IsOperational` | New: recycles after 8 s if mid-handshake | Was 15 s, now 3 s |
| Icom (serial) | No change (handshake is instant) | No-op (`CanRecycle = False` for serial) | N/A |
| K4 | No change (`IsOperational = True` from base → `not True = False`, identical to old `SetRadioAlertState(False)`) | No-op (`CanRecycle = False`) | TCP-driven, unchanged |
| FlexRadio | No change (already used `IsOperational` correctly via line ~944) | **Intentional no-op** — Flex's `IsOperational = FSlice0Valid` drops when SmartSDR closes; recycling TCP wouldn't fix that | TCP-driven, unchanged |
| HamLib Direct | No change | No-op | Unchanged |

## Files

| File | Change |
|---|---|
| `src/uNetRadioBase.pas` | New virtual `GetCanRecycleOnStuckHandshake` (default False); paired property |
| `src/uRadioIcomBase.pas` | `GetIsOperational` override (strict, true only when `State = icsConnected`); `GetCanRecycleOnStuckHandshake` override (true for network) |
| `src/uRadioPolling.pas` | Alert color line 781 keyed on `IsOperational`; new stuck-handshake detector at top of connected branch, gated on `CanRecycleOnStuckHandshake` |
| `src/uIcomNetworkTypes.pas` | `ICOM_PING_DEAD_TIMEOUT_MS` 15000 → 3000 |

## Test plan

Verified live on IC-7760:

- [x] **Disconnect detection time**: turning the radio off shows magenta in ~3 s (was ~15 s).
- [x] **Magenta stays magenta**: no false-positive flash back to normal color during reconnect attempts.
- [x] **Recovery on radio power-up**: with the radio off, log shows the polling thread recycling every ~9 s (`handshake stuck (IsConnected but not IsOperational) for >8000 ms; forcing Disconnect for retry`); when the radio is turned back on, the next reconnect attempt completes the handshake within ~7 ms and the alert clears.

Recommend smoke-testing on:
- [x] **K4 (network)** — confirm no behavior change. Power-off should still show magenta within 1–2 s (TCP-driven). Reconnect on power-up unchanged.
- [ ] **K4 (serial)** — confirm no behavior change.
- [ ] **FlexRadio (with SmartSDR open and active)** — confirm the in-progress fix doesn't trigger spurious recycles. Closing SmartSDR while TR4W is connected should still alert without forcing TCP reconnects.
- [ ] **HamLib Direct (any radio)** — confirm the polling loop is unaffected.

## Known limitations / not in scope

- The stuck-handshake recycle uses a fixed 8 s timeout and 1 s reconnect delay (~9 s cycle). Could be made configurable, but fixed values seemed reasonable for a first pass.
- The 3 s ping timeout is hard-coded in `uIcomNetworkTypes.pas`. If operators on flaky WiFi report false disconnects, we could promote it to a config statement.
- No new config statements added for this fix — pure behavior change.
