### PR TITLE
Issue #908: bandmap not corrupted by inactive-radio status

### DIFF
--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -4466,8 +4466,41 @@ end;
 
 procedure DisplayBandMap;
 begin
-  if not BandMapEnable then Exit;
-  if not tWindowsExist(tw_BANDMAPWINDOW_INDEX) then Exit;
+  // Diagnostic: trace every entry into DisplayBandMap so we can see who
+  // is calling and what state the gates are in.  Useful for tracking
+  // down "bandmap clears unexpectedly" symptoms (issue: bandmap-startup-clear).
+  // Booleans rendered as 0/1 via Ord() to avoid pulling SysUtils.BoolToStr
+  // through this unit's tangled uses chain.
+  logger.Trace('[DisplayBandMap] enter: ' +
+               'BandMapEnable=%d, BandMapWindowExists=%d, ' +
+               'BandMapPreventRefresh=%d, ' +
+               'BandMapBand=%d, BandMapMode=%d, ' +
+               'BandMapAllBands=%d, BandMapAllModes=%d, ' +
+               'BandMapDupeDisplay=%d, BandMapDisplayCQ=%d, ' +
+               'BandMapMultsOnly=%d, WARCBandsEnabled=%d, VHFBandsEnabled=%d, ' +
+               'FCount=%d',
+    [Ord(BandMapEnable),
+     Ord(tWindowsExist(tw_BANDMAPWINDOW_INDEX)),
+     Ord(BandMapPreventRefresh),
+     Ord(BandMapBand), Ord(BandMapMode),
+     Ord(BandMapAllBands),
+     Ord(BandMapAllModes),
+     Ord(BandMapDupeDisplay),
+     Ord(BandMapDisplayCQ),
+     Ord(BandMapMultsOnly),
+     Ord(WARCBandsEnabled),
+     Ord(VHFBandsEnabled),
+     SpotsList.Count]);
+  if not BandMapEnable then
+    begin
+    logger.Trace('[DisplayBandMap] exit: BandMapEnable=False');
+    Exit;
+    end;
+  if not tWindowsExist(tw_BANDMAPWINDOW_INDEX) then
+    begin
+    logger.Trace('[DisplayBandMap] exit: bandmap window does not exist');
+    Exit;
+    end;
 //  if  BandMapPreventRefresh then  Exit;             // GAV  4.45.6
   SpotsList.Display;
   end;
@@ -4897,8 +4930,20 @@ begin
                          //                  going to assume that it is appropriate for the band
                          //                  map on this band to be displayed!
 
-                         if (TwoRadioState <> TwoRadiosDisabled) and BandMapEnable and RadioOnTheMove[radioone] then
+                         // Guard: don't follow the inactive radio if it has not yet
+                         // reported a real band/mode (NoBand/NoMode are uninitialized
+                         // sentinels). Same defect as uRadioPolling.pas inactive branch.
+                         if (TwoRadioState <> TwoRadiosDisabled) and BandMapEnable and
+                            RadioOnTheMove[radioone] and
+                            (FilteredStatus.Band <> NoBand) and
+                            (FilteredStatus.Mode <> NoMode) then
                             begin
+                               logger.Trace('[BMWriter LOGWIND:4935 inactive-FS] ' +
+                                            'BandMapBand:=FS.Band=%d, BandMapMode:=FS.Mode=%d, FS.Freq=%d, ' +
+                                            'TwoRadioState=%d, RadioOnTheMove[1]=%d',
+                                            [Ord(FilteredStatus.Band), Ord(FilteredStatus.Mode),
+                                             FilteredStatus.Freq, Ord(TwoRadioState),
+                                             Ord(RadioOnTheMove[radioone])]);
                                BandMapBand := FilteredStatus.Band;
                                BandMapMode := FilteredStatus.Mode;
                                BandMapCursorFrequency := FilteredStatus.Freq;

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -3134,10 +3134,22 @@ begin
             logger.debug('ProcessFilteredStatus:Radio %s] rig.FilteredStatus.Band = NoBand', [rig.RadioName]);
             logger.debug('ProcessFilteredStatus:Radio %s] rig.FilteredStatus.freq = %d', [rig.RadioName,rig.FilteredStatus.Freq]);
             end;
-         if (rig.BandMemory <> rig.FilteredStatus.Band) or
-            (rig.ModeMemory <> rig.FilteredStatus.Mode) then
+         logger.Trace('[ProcessFilteredStatus] rig=%s, ' +
+                      'BandMemory=%d, FS.Band=%d, ' +
+                      'ModeMemory=%d, FS.Mode=%d, ' +
+                      'FS.Freq=%d, ActiveBand(before)=%d, ActiveMode(before)=%d',
+                      [rig.RadioName, Ord(rig.BandMemory), Ord(rig.FilteredStatus.Band),
+                       Ord(rig.ModeMemory), Ord(rig.FilteredStatus.Mode),
+                       rig.FilteredStatus.Freq, Ord(ActiveBand), Ord(ActiveMode)]);
+         // Guard: NoBand/NoMode are sentinels meaning "not yet reported by radio".
+         // Never propagate them into ActiveBand/ActiveMode; they would corrupt the
+         // bandmap, dupe sheet, and multiplier displays until the next valid poll.
+         if (rig.FilteredStatus.Band <> NoBand) and
+            (rig.FilteredStatus.Mode <> NoMode) and
+            ((rig.BandMemory <> rig.FilteredStatus.Band) or
+             (rig.ModeMemory <> rig.FilteredStatus.Mode)) then
             begin
-               ActiveBand := rig.FilteredStatus.Band;   // After reset port, filteredstatus.band is NoBand which is the issue     - FS.freq is set correctly so find out what sets filteredStatus up
+               ActiveBand := rig.FilteredStatus.Band;
                ActiveMode := rig.FilteredStatus.Mode;
                DisplayBandMode(ActiveBand, ActiveMode, False);
                VisibleDupeSheetChanged := True;
@@ -3180,8 +3192,21 @@ begin
 
          //GAV added this section. Changes BandmapBand & Bandmap Mode to follow inactive radio when inactive radio is tuned
 
-         if ((dif > 0) and ((rig.FilteredStatus.Freq <> BandMapCursorFrequency)
-            or (BandMapMode <> ActiveMode)) and (rig.FilteredStatus.Freq <> 0)) then
+         // Issue #908: gate the "follow inactive radio" feature on TwoRadioMode.
+         // The legacy LOGWIND.PAS path checked TwoRadioState <> TwoRadiosDisabled;
+         // this Gav-added polling path forgot the SO2R gate, so an inactive radio
+         // could mutate the bandmap even with TWO RADIO MODE=FALSE.
+         //
+         // Guard: also skip if the inactive radio has not yet reported real
+         // band/mode (NoBand/NoMode are uninitialized sentinels), which would
+         // otherwise blank the active radio's bandmap on first poll.
+         if TwoRadioMode and
+            (rig.FilteredStatus.Band <> NoBand) and
+            (rig.FilteredStatus.Mode <> NoMode) and
+            (dif > 0) and
+            ((rig.FilteredStatus.Freq <> BandMapCursorFrequency) or
+             (BandMapMode <> ActiveMode)) and
+            (rig.FilteredStatus.Freq <> 0) then
             // Gav 4.47.4 #015
             begin
                BandmapBand := rig.FilteredStatus.Band;

--- a/tr4w/src/uSpots.pas
+++ b/tr4w/src/uSpots.pas
@@ -220,16 +220,27 @@ var
   CurrentCursorPos: integer;
   //    CurCursorPosData                     : integer;
   NumberEntriesDisplayed: integer;
+  // Diagnostic counters -- per-filter rejection tallies (issue: bandmap-startup-clear).
+  // Total of all reject* + rejNoNext + NumberEntriesDisplayed should equal FCount.
+  rejDupeNext, rejBand, rejMode, rejDupeFlag, rejCQ, rejWARC, rejMultsOnly, rejVHF: Integer;
 begin
   bottom := 0;
   top := 1;
   centrefound := False; // 4.79.3
+  rejDupeNext := 0; rejBand := 0; rejMode := 0; rejDupeFlag := 0;
+  rejCQ := 0; rejWARC := 0; rejMultsOnly := 0; rejVHF := 0;
   //  inc(SpotsDisplayed);
   //  setwindowtext(OpModeWindowHandle,inttopchar(SpotsDisplayed));
   if BandMapListBox = 0 then
+    begin
+    logger.Trace('[SpotsList.Display] exit: BandMapListBox=0');
     Exit;
+    end;
   if BandMapPreventRefresh then
+    begin
+    logger.Trace('[SpotsList.Display] exit: BandMapPreventRefresh=True');
     Exit; // Gav 4.45.6
+    end;
   TDXSpotsList.UpdateSpotsMultiplierStatus;
   CurrentCursorPos := tLB_GETCURSEL(BandMapListBox); //0;
   setlength(FiltSpotIndex, FCount);
@@ -238,28 +249,52 @@ begin
   for i := 0 to FCount - 1 do
   begin
     if (FList^[i].FCall = FList^[i + 1].FCall) then
+      begin
+      Inc(rejDupeNext);
       continue;
+      end;
     if not BandMapAllBands then
       if FList^[i].FBand <> BandmapBand then
+        begin
+        Inc(rejBand);
         Continue; //Gav  ActiveBand changed to BandmapBand
+        end;
     if not BandMapAllModes then
       if FList^[i].FMode <> BandmapMode then
+        begin
+        Inc(rejMode);
         Continue; //Gav  ActiveMode changed to BandmapMode
+        end;
     if not BandMapDupeDisplay then
       if FList^[i].FDupe then
+        begin
+        Inc(rejDupeFlag);
         Continue;
+        end;
     if not BandMapDisplayCQ then
       if FList^[i].FCQ then
+        begin
+        Inc(rejCQ);
         Continue;
+        end;
     if not WARCBandsEnabled then
       if FList^[i].FWARCBand then
+        begin
+        Inc(rejWARC);
         Continue;
+        end;
     if BandMapMultsOnly then
       if not ((FList^[i].FMult) or (FList^[i].FCQ)) then
+        begin
+        Inc(rejMultsOnly);
         Continue; //Gav added or FCQ to stop CQ spots being trapped by Mult only filter
+        end;
     if not VHFBandsEnabled then
       if (FList^[i].FBand > Band12) then
+        begin
+        Inc(rejVHF);
         Continue;
+        end;
 
     // SendMessage(BandMapListBox, LB_ADDSTRING, 0, integer(i));         //GAV original message send
 
@@ -270,6 +305,9 @@ begin
     inc(k);
 
   end;
+  logger.Trace('[SpotsList.Display] filter pass: FCount=%d, passed=%d, rejected by: NextDup=%d Band=%d Mode=%d DupeFlag=%d CQ=%d WARC=%d MultsOnly=%d VHF=%d',
+    [FCount, NumberEntriesDisplayed, rejDupeNext, rejBand, rejMode, rejDupeFlag,
+     rejCQ, rejWARC, rejMultsOnly, rejVHF]);
 
   //Gav   Start of added section to limit and centre bandmap on vfo, using pointers to Flist stored in FiltSpotIndex arrray
 
@@ -340,6 +378,8 @@ begin
     SendMessage(BandMapListBox, LB_ADDSTRING, 0, FiltSpotIndex[k]);
   tLB_SETCURSEL(BandMapListBox, CurrentCursorPos);
   tSetWindowRedraw(BandMapListBox, True);
+  logger.Trace('[SpotsList.Display] listbox populated: bottom=%d, top=%d, items_added=%d, CurrentCursorPos=%d, BandMapDisplayLimit=%d',
+    [bottom, top, top - bottom + 1, CurrentCursorPos, BandMapDisplayLimit]);
   // WM_SETREDRAW(True) causes the list box to queue an erase+paint, which
   // produces a visible flash. Cancel the pending erase, then repaint
   // immediately without erasing — owner-draw items fill their own background.


### PR DESCRIPTION
## Summary

1. **Second radio doesn't mess with the bandmap unless SO2R is actually on.** Previously, even with `TWO RADIO MODE = FALSE`, the inactive radio's polling thread could still rewrite `BandMapBand`/`BandMapMode`. Now it can't.

2. **Don't trust a radio's reported band/mode until it has actually reported real values.** `NoBand` and `NoMode` are placeholders meaning "haven't heard from the radio yet" - they used to leak into the bandmap and active-radio globals; now they're filtered out at all three places that propagated them.

Fixes #908.

## Symptom

With a primary radio (e.g., K4 on 20m CW) configured as the active radio and an Icom (e.g., IC-7760 on 80m LSB) configured as a second radio:

1. Start TR4W with bandmap window open and saved spots from the prior session.
2. Spots flash on the bandmap for ~200 ms, then go blank.
3. Spots only reappear after double-clicking a DX cluster spot.

Symptom disappeared if the inactive Icom was powered off at startup.

## Root cause

Three call sites propagated `FilteredStatus.Band`/`Mode` into globals (`ActiveBand`/`ActiveMode`/`BandMapBand`/`BandMapMode`) without checking whether the radio had reported real values yet. The Gav-added "follow inactive radio when tuned" code at `uRadioPolling.pas:3138` additionally was missing the SO2R gate that the older `LOGWIND.PAS:4933` path already had.

When the inactive Icom's first poll cycle ran at startup, its `FilteredStatus.Band` was already populated (Band80, from a partial unsolicited frame) but `FilteredStatus.Mode` was still `NoMode`. The unguarded code wrote `BandMapBand := Band80, BandMapMode := NoMode`, which the bandmap filter rejected every spot against.

## Fix

| File | Change |
|---|---|
| `uRadioPolling.pas:3088` | Sentinel-value guard at active-radio polling - latent same-pattern bug already flagged by a TODO comment ("After reset port, filteredstatus.band is NoBand which is the issue"). |
| `uRadioPolling.pas:3138` | SO2R gate (`TwoRadioMode`) + sentinel-value guard. **The confirmed culprit.** |
| `LOGWIND.PAS:4933` | Sentinel-value guard at the legacy LogWind inactive-FS path. |

Per N4AF (email thread May 15): the "follow inactive radio when tuned" feature is the intended SO2R workflow ("changes bm entries to the new band - assuming it is the s&p radio that changed bands"), so the SO2R gate preserves that case while eliminating the unintended single-radio behavior. N4AF couldn't reproduce the issue because his INI has `BAND MAP ALL BANDS=TRUE`, which masks the symptom (the band filter accepts everything).

## Open follow-up questions (in #908)

1. **Should the bandmap follow the inactive radio at all in SO2R mode?** A future enhancement could add `BAND MAP FOLLOW INACTIVE RADIO` config knob defaulting `TRUE` (preserves Howie's workflow). Tracked in #908 for separate discussion.

2. **Second-bandmap feature.** N4AF said "i dont think it is worth the effort on 2 bm" - declined for now.

## Diagnostic logging added

TRACE-level only (no behavior change at default log levels):

- `[DisplayBandMap]` - entry state of all bandmap globals + SpotsList.Count
- `[SpotsList.Display]` - per-filter rejection counts (NextDup/Band/Mode/DupeFlag/CQ/WARC/MultsOnly/VHF) + listbox population stats
- `[ProcessFilteredStatus]` - polling thread state on every active-radio poll cycle
- `[BMWriter LOGWIND:4935 inactive-FS]` - fires when the legacy LogWind path mutates bandmap from inactive radio

Useful for future bandmap debugging.

## Test plan

- [x] Reproduce original symptom: K4 active on 20m CW, IC-7760 on 80m LSB, bandmap blanks at startup
- [x] Confirm trace logs identify the inactive-polling code path as the culprit
- [x] Apply fix, rebuild
- [x] Confirm bandmap stays populated with K4's 20m CW spots throughout startup (verified in tr4w.log)
- [x] Confirm `[BMWriter]` and inactive-radio `[ProcessFilteredStatus]` no longer trigger bandmap mutation
- [ ] Verify the "follow inactive radio when tuned" SO2R workflow still works for users with `TWO RADIO MODE = TRUE` (deferred to N4AF testing on K3 SO2R setup)