### PR TITLE
Issue #910: TR4WSERVER disconnect uses toast + title update, not modal dialog

### DIFF
--- a/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
+++ b/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
@@ -183,6 +183,7 @@ const
   TC_CONNECTINGTO                       = 'Conectando a ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Conexion a TR4WSERVER fallida. Compruebe valor SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Conectando a';
+  TC_DISCONNECTEDFROM                   = '** Desconectado de ';
   TC_FAILEDTOCONNECTTO                  = 'Fallo al conectar a';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'SERVER y LOCAL logs son identicos.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/TR4W_CONSTS_SER.pas
+++ b/tr4w/src/lang/TR4W_CONSTS_SER.pas
@@ -208,6 +208,7 @@ const
   TC_CONNECTINGTO                       = 'Konektujem se na ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Konekcija na TR4WSERVER nije uspela. Proveri ispravnost LOZINKE SERVERA!!';
   TC_CONNECTEDTO                        = 'Konektovan na ';
+  TC_DISCONNECTEDFROM                   = '** Diskonektovan sa ';
   TC_FAILEDTOCONNECTTO                  = 'Konekcija nije uspela na ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Dnevnik na serveru i lokalni dnevnik identicni.';
   TC_NETWORK                            = 'Lokalna mreza : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_chn.pas
+++ b/tr4w/src/lang/tr4w_consts_chn.pas
@@ -188,6 +188,7 @@ const
   TC_CONNECTINGTO                       = 'Connecting to ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Connect to TR4WSERVER failed. Check SERVER PASSWORD value!!';
   TC_CONNECTEDTO                        = 'Connected to ';
+  TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
   TC_FAILEDTOCONNECTTO                  = 'Failed to connect to ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Server and local logs are identical.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_cze.pas
+++ b/tr4w/src/lang/tr4w_consts_cze.pas
@@ -204,6 +204,7 @@ const
   TC_CONNECTINGTO                       = 'Pøipojuje se k ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Pøipojení k serveru TR4W neúspìšné. Ovìø heslo!';
   TC_CONNECTEDTO                        = 'Pøipojen k ';
+  TC_DISCONNECTEDFROM                   = '** Odpojen od ';
   TC_FAILEDTOCONNECTTO                  = 'Porucha spojení s ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Deníky na serveru a aktuální deníky jsou identické.';
   TC_NETWORK                            = 'Sí     : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -199,6 +199,7 @@
   TC_CONNECTINGTO                       = 'Connecting to ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Connect to TR4WSERVER failed. Check SERVER PASSWORD value!!';
   TC_CONNECTEDTO                        = 'Connected to ';
+  TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
   TC_FAILEDTOCONNECTTO                  = 'Failed to connect to ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Server and local logs are identical.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_ger.pas
+++ b/tr4w/src/lang/tr4w_consts_ger.pas
@@ -197,6 +197,7 @@
   TC_CONNECTINGTO                       = 'Verbinde mit ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Verbindung zum TR4WSERVER fehlgeschlagen. Check SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Verbunden mit ';
+  TC_DISCONNECTEDFROM                   = '** Verbindung getrennt - ';
   TC_FAILEDTOCONNECTTO                  = 'Kann nicht verbinden mit ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Serverlog und lokale Logs sind identisch.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_mng.pas
+++ b/tr4w/src/lang/tr4w_consts_mng.pas
@@ -189,6 +189,7 @@ const
   TC_CONNECTINGTO                       = 'Холбогдож байна';
   TC_CONNECTTOTR4WSERVERFAILED          = 'TR4WSERVER сервер лvv холбогдсонгvй. SERVER PASSWORDаа шалгана уу!!';
   TC_CONNECTEDTO                        = 'Холбогдлоо';
+  TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
   TC_FAILEDTOCONNECTTO                  = 'Холболт амжилтгvй боллоо';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверийн ба локал логууд зов байна';
   TC_NETWORK                            = 'Сvлжээ : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_pol.pas
+++ b/tr4w/src/lang/tr4w_consts_pol.pas
@@ -185,6 +185,7 @@ const
   TC_CONNECTINGTO                       = '£¹czê z ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Pó³aczenie z TR4WSERVER nie zosta³o nawi¹zane. SprawdŸ has³o dostêpowe do serwera!';
   TC_CONNECTEDTO                        = 'Po³¹czony z ';
+  TC_DISCONNECTEDFROM                   = '** Rozlaczony z ';
   TC_FAILEDTOCONNECTTO                  = 'Nie uda³o siê po³¹czyæ z ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Logi serwerowy i lokalne s¹ identyczne.';
   TC_NETWORK                            = 'Sieæ : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_rom.pas
+++ b/tr4w/src/lang/tr4w_consts_rom.pas
@@ -205,6 +205,7 @@ const
   TC_CONNECTINGTO                       = 'Conectez pe ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Conectarea spre TR4WSERVER esuata. Verifica valoarea la SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Conectat la ';
+  TC_DISCONNECTEDFROM                   = '** Deconectat de la ';
   TC_FAILEDTOCONNECTTO                  = 'Conectare esuata la ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Logul local si cel de la Server sunt identice.';
   TC_NETWORK                            = 'Reteaua : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_rus.pas
+++ b/tr4w/src/lang/tr4w_consts_rus.pas
@@ -205,6 +205,7 @@ const
   TC_CONNECTINGTO                       = 'Соединение с ';
   TC_CONNECTTOTR4WSERVERFAILED          = 'Соединение с TR4WSERVER не удалось. Проверьте значение команды SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Соединено с ';
+  TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
   TC_FAILEDTOCONNECTTO                  = 'Не удалось соединиться с ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверный и локальный логи одинаковы.';
   TC_NETWORK                            = 'Сеть : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_ukr.pas
+++ b/tr4w/src/lang/tr4w_consts_ukr.pas
@@ -206,6 +206,7 @@ TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Fr
   TC_CONNECTINGTO                       = 'З`єднання з';
   TC_CONNECTTOTR4WSERVERFAILED          = 'З`єднання з TR4WSERVER не вдалося. Перевірте значення команди SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'З`єднано з';
+  TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
   TC_FAILEDTOCONNECTTO                  = 'Не вдалося з`єднатися з';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверний та локальний логи однакові.';
   TC_NETWORK                            = 'Мережа: %s %s:%d';

--- a/tr4w/src/uNet.pas
+++ b/tr4w/src/uNet.pas
@@ -254,8 +254,13 @@ begin
           NetDisconnect;
           Windows.ZeroMemory(@StatusArray, SizeOf(StatusArray));
           for i := 1 to 26 do DisplayClientStatus(i);
+          // Issue #910: replaced modal dialog (showwarning) with non-blocking
+          // QuickDisplay toast + title-bar update.  Auto-reconnect is handled
+          // by the existing WM_TIMER path which calls TryConnectToNetwork
+          // every tNetStatusUpdateInterval ms while NetSocket = 0.
+          ShowConnectionStatus(TC_DISCONNECTEDFROM);
           Format(wsprintfBuffer, TC_CONNECTIONTOTR4WSERVERLOST, @ServerAddress[1], ServerPort);
-          showwarning(wsprintfBuffer);
+          QuickDisplay(wsprintfBuffer);
           Exit;
         end;
 


### PR DESCRIPTION
## Summary

1. **No more modal dialog when the TR4WSERVER connection drops.** Previously, a `MessageBox` blocked the call window, exchange window, and every other input until the operator clicked OK. Now it's a transient `QuickDisplay` toast - logging keeps working.

2. **The Network window title bar shows the state at a glance.** "`Network : ** DISCONNECTED from LOCALHOST:1061`" appears immediately on loss, then cycles to "Connecting to..." / "Failed to connect to..." during retry, and back to "Connected to..." on success. Auto-reconnect was already in place; only the notification UX needed fixing.

Fixes #910.

## Code change

`uNet.pas:252-260` (WM_SOCK_NET handler, recv returned <= 0):

```diff
   if i <= 0 then
   begin
     NetDisconnect;
     Windows.ZeroMemory(@StatusArray, SizeOf(StatusArray));
     for i := 1 to 26 do DisplayClientStatus(i);
+    // Issue #910: replaced modal dialog (showwarning) with non-blocking
+    // QuickDisplay toast + title-bar update.  Auto-reconnect is handled
+    // by the existing WM_TIMER path which calls TryConnectToNetwork
+    // every tNetStatusUpdateInterval ms while NetSocket = 0.
+    ShowConnectionStatus(TC_DISCONNECTEDFROM);
     Format(wsprintfBuffer, TC_CONNECTIONTOTR4WSERVERLOST, @ServerAddress[1], ServerPort);
-    showwarning(wsprintfBuffer);
+    QuickDisplay(wsprintfBuffer);
     Exit;
   end;
```

## Language constant

New `TC_DISCONNECTEDFROM` added to all 11 language files. The English value is `'** DISCONNECTED from '` (asterisks serve as the visual cue since Win32 standard title bars cannot be colored without custom-painting the non-client area). Non-Latin scripts (Russian/Ukrainian/Mongolian/Chinese) get the English string as a placeholder; native-speaker translations to follow.

Files inserted via byte-level patching (PowerShell + raw bytes) to preserve original ANSI codepages and CRLF line endings. Initial attempt via the editing tool re-saved files with normalized encoding and produced thousands of spurious diff lines per file - that commit was reverted before push. The script-based insertion produced clean `+1 -0` diffs per language file.

## Auto-reconnect (unchanged - already works)

`uNet.pas:229-246` WM_TIMER handler:

```pascal
if NetSocket <> 0 then
  ...
else
  TryConnectToNetwork;
```

Every `tNetStatusUpdateInterval` (5000 ms) the timer fires; if disconnected, retry. On success, `ConnectThread` already calls `ShowConnectionStatus(TC_CONNECTEDTO)` which restores the title text.

## Deferred (not in this PR)

- Colored status banner inside the Network dialog (above the listview). Would let us show a true red "DISCONNECTED - retrying" banner instead of relying on title text. Skipped to keep this PR small; can be a follow-up issue.
- Translations for the 4 non-Latin language files (currently English placeholder). Needs native speakers.
- There is a second `showwarning(TC_CONNECTTOTR4WSERVERFAILED)` modal at `uNet.pas:653` for password-failure on connect. Out of scope here; could get the same treatment.

## Test plan

- [x] Reproduce: stop TR4WSERVER while TR4W is connected. Verify the modal dialog NO LONGER appears.
- [x] Title bar updates to "Network : ** DISCONNECTED from LOCALHOST:1061" within ~1 second.
- [x] QuickDisplay toast shows in the status row.
- [x] Logging in the call window still works while server is down (no blocking).
- [x] Restart TR4WSERVER - title returns to "Network : Connected to LOCALHOST:1061" automatically within ~5 seconds.
- [ ] Multiple disconnect/reconnect cycles within one session (smoke).
- [ ] Other language builds compile (eng confirmed, others not built but constant present).