### PR TITLE
Auto-sync server log + 3830 Score report + Edit Cabrillo Summary + label widening + ADIF CONTEST_ID fix

### DIFF
--- a/docs/NETWORK_LOG_AUTO_SYNC.md
+++ b/docs/NETWORK_LOG_AUTO_SYNC.md
@@ -1,0 +1,82 @@
+# Feature request: optional auto-synchronize on log mismatch
+
+## Context
+
+When a TR4W client (re)connects to TR4WServer and the local log's CRC32 differs
+from the server's, the "Difference in logs" dialog appears and waits for the
+operator to choose Synchronize / Exit / Clear all logs in network.
+
+In real multi-op operation this dialog fires every time a client reconnects
+after even a brief disconnect (network blip, laptop sleep, manual server
+restart) — because the server kept logging new QSOs while the client was
+offline, so the CRC necessarily differs. Operators report always clicking
+Synchronize, every time, which makes the dialog more obstacle than safeguard.
+
+This is **a TR4W client-side change**. The server cannot drive this decision
+because:
+
+- `TLogFileInformation` is a fixed 19-byte packed record with no spare field
+  to carry an "auto-sync" hint.
+- Even if a hint existed, the action (overwriting the local log with the
+  server's) happens on the client; the server cannot perform it remotely.
+
+## What exists today
+
+- Trigger: `uNet.pas:838-862` `ProcessServerLogInfo`. The relevant comparison
+  is `if s^.liLocalCRC32 <> s^.liSeverCRC32 then IdenticalLogs := False;` —
+  contest is displayed in the dialog but is not part of the trigger.
+- Dialog: `CreateModalDialog(220, 110, tr4whandle, @LogCompareDlgProc,
+  integer(s))` on mismatch. The dialog's Synchronize button pulls the full
+  `SERVERLOG.TRW` from the server's sync port (`PORT + 1`).
+
+## Proposed change
+
+Add an INI key under the TR4W network section, e.g.:
+
+```ini
+[NETWORK]
+AUTO SYNCHRONIZE ON CONNECT = 1
+```
+
+In `ProcessServerLogInfo`, when `IdenticalLogs = False` and the new flag is
+true, invoke the same code path the Synchronize button triggers and skip
+`CreateModalDialog` entirely. Default to `0` (current behavior — show the
+dialog) so this is opt-in for the operator who already knows they always
+click Synchronize.
+
+Suggested log line on auto-sync:
+`logger.Info('Auto-synchronizing local log from server (CRC mismatch: local %x, server %x)', [...])`
+so operators can confirm in `tr4w.log` that the sync happened.
+
+## Out of scope
+
+- Contest mismatch: not currently used in the trigger, intentionally left
+  alone. If contests differ, the existing dialog already shows it; auto-sync
+  would silently overwrite which may surprise an operator who connected to
+  the wrong server. If we ever want to be stricter, the natural check is
+  `if (s^.liLocalCRC32 <> s^.liSeverCRC32) and (LocalContest = s^.liContest)
+  then auto-sync else still show the dialog` — but probably not worth the
+  complexity until someone hits the wrong-server case.
+- Direction: this only handles "server is authoritative, pull from server."
+  TR4W's existing Synchronize button is one-directional in the same way;
+  any "merge local into server" feature would be a separate, much larger
+  change.
+
+## Related: Python TR4WServer
+
+The Python reimplementation of TR4WServer (in c:\projects\TR4WServer)
+mirrors the Delphi server's wire protocol exactly. It does not need any
+changes for this feature — the auto-sync logic is purely client-side. If
+the protocol ever does grow an auto-sync hint field, both servers would
+need a coordinated update.
+
+The Python server already implements:
+- Serial-number lockout (matches `tr4wserverUnit.pas` behavior — startup
+  scan of `NumberSent`, per-client `SM_SERIAL_NUMBER_CHANGED` push on
+  connect, increment on reservation).
+- Live per-station status table built from `TStationState` broadcasts
+  (Band / Freq / St / PTT / Qs / Callsign / Op).
+- `LOG RECORD SIZE` is configurable in `tr4wserver.ini` and validated
+  against the on-disk `SERVERLOG.TRW`, so a future TR4W release that
+  changes `SizeOf(ContestExchange)` produces a clear startup error rather
+  than silent corruption.

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3600,6 +3600,8 @@ begin
 
     menu_cabrillo: OpenStationInformationWindow(integer(@CreateCabrilloFile));
     menu_summary: OpenStationInformationWindow(integer(@SummarySheet));
+    menu_3830scores: ExportTo3830Scores;  // Issue: 3830 quick-submission report
+    menu_edit_cabrillo_summary: OpenStationInformationWindow(0);  // Issue #914
     menu_export_edi: OpenStationInformationWindow(integer(@ExportToEDI));
 
     menu_scorebyhour: ScoreByHour;

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -2299,6 +2299,8 @@ const
   menu_import_adif                      = 10018;
   menu_export_edi                       = 10019;
   menu_csv                              = 10020;
+  menu_3830scores                       = 10021;
+  menu_edit_cabrillo_summary            = 10022;  // Issue #914
   menu_options                          = 10100;
   menu_messages                         = 10101;
   menu_other_messages                   = 10102;

--- a/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
+++ b/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
@@ -184,6 +184,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Conexion a TR4WSERVER fallida. Compruebe valor SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Conectando a';
   TC_DISCONNECTEDFROM                   = '** Desconectado de ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Sincronizando log desde el servidor automaticamente.';
   TC_FAILEDTOCONNECTTO                  = 'Fallo al conectar a';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'SERVER y LOCAL logs son identicos.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/TR4W_CONSTS_SER.pas
+++ b/tr4w/src/lang/TR4W_CONSTS_SER.pas
@@ -209,6 +209,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Konekcija na TR4WSERVER nije uspela. Proveri ispravnost LOZINKE SERVERA!!';
   TC_CONNECTEDTO                        = 'Konektovan na ';
   TC_DISCONNECTEDFROM                   = '** Diskonektovan sa ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Konekcija nije uspela na ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Dnevnik na serveru i lokalni dnevnik identicni.';
   TC_NETWORK                            = 'Lokalna mreza : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_chn.pas
+++ b/tr4w/src/lang/tr4w_consts_chn.pas
@@ -189,6 +189,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Connect to TR4WSERVER failed. Check SERVER PASSWORD value!!';
   TC_CONNECTEDTO                        = 'Connected to ';
   TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Failed to connect to ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Server and local logs are identical.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_cze.pas
+++ b/tr4w/src/lang/tr4w_consts_cze.pas
@@ -205,6 +205,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Pøipojení k serveru TR4W neúspìšné. Ovìø heslo!';
   TC_CONNECTEDTO                        = 'Pøipojen k ';
   TC_DISCONNECTEDFROM                   = '** Odpojen od ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Porucha spojení s ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Deníky na serveru a aktuální deníky jsou identické.';
   TC_NETWORK                            = 'Sí     : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -200,6 +200,7 @@
   TC_CONNECTTOTR4WSERVERFAILED          = 'Connect to TR4WSERVER failed. Check SERVER PASSWORD value!!';
   TC_CONNECTEDTO                        = 'Connected to ';
   TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Failed to connect to ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Server and local logs are identical.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_ger.pas
+++ b/tr4w/src/lang/tr4w_consts_ger.pas
@@ -198,6 +198,7 @@
   TC_CONNECTTOTR4WSERVERFAILED          = 'Verbindung zum TR4WSERVER fehlgeschlagen. Check SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Verbunden mit ';
   TC_DISCONNECTEDFROM                   = '** Verbindung getrennt - ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Log automatisch vom Server synchronisieren.';
   TC_FAILEDTOCONNECTTO                  = 'Kann nicht verbinden mit ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Serverlog und lokale Logs sind identisch.';
   TC_NETWORK                            = 'Network : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_mng.pas
+++ b/tr4w/src/lang/tr4w_consts_mng.pas
@@ -190,6 +190,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'TR4WSERVER сервер лvv холбогдсонгvй. SERVER PASSWORDаа шалгана уу!!';
   TC_CONNECTEDTO                        = 'Холбогдлоо';
   TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Холболт амжилтгvй боллоо';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверийн ба локал логууд зов байна';
   TC_NETWORK                            = 'Сvлжээ : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_pol.pas
+++ b/tr4w/src/lang/tr4w_consts_pol.pas
@@ -186,6 +186,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Pó³aczenie z TR4WSERVER nie zosta³o nawi¹zane. SprawdŸ has³o dostêpowe do serwera!';
   TC_CONNECTEDTO                        = 'Po³¹czony z ';
   TC_DISCONNECTEDFROM                   = '** Rozlaczony z ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Nie uda³o siê po³¹czyæ z ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Logi serwerowy i lokalne s¹ identyczne.';
   TC_NETWORK                            = 'Sieæ : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_rom.pas
+++ b/tr4w/src/lang/tr4w_consts_rom.pas
@@ -206,6 +206,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Conectarea spre TR4WSERVER esuata. Verifica valoarea la SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Conectat la ';
   TC_DISCONNECTEDFROM                   = '** Deconectat de la ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Conectare esuata la ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Logul local si cel de la Server sunt identice.';
   TC_NETWORK                            = 'Reteaua : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_rus.pas
+++ b/tr4w/src/lang/tr4w_consts_rus.pas
@@ -206,6 +206,7 @@ const
   TC_CONNECTTOTR4WSERVERFAILED          = 'Соединение с TR4WSERVER не удалось. Проверьте значение команды SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'Соединено с ';
   TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Не удалось соединиться с ';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверный и локальный логи одинаковы.';
   TC_NETWORK                            = 'Сеть : %s %s:%d';

--- a/tr4w/src/lang/tr4w_consts_ukr.pas
+++ b/tr4w/src/lang/tr4w_consts_ukr.pas
@@ -207,6 +207,7 @@ TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Fr
   TC_CONNECTTOTR4WSERVERFAILED          = 'З`єднання з TR4WSERVER не вдалося. Перевірте значення команди SERVER PASSWORD!!';
   TC_CONNECTEDTO                        = 'З`єднано з';
   TC_DISCONNECTEDFROM                   = '** DISCONNECTED from ';
+  TC_AUTOSYNCHRONIZINGLOG               = 'Auto-synchronizing log from server.';
   TC_FAILEDTOCONNECTTO                  = 'Не вдалося з`єднатися з';
   TC_SERVERANDLOCALLOGSAREIDENTICAL     = 'Серверний та локальний логи однакові.';
   TC_NETWORK                            = 'Мережа: %s %s:%d';

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -121,6 +121,7 @@ procedure ExportToEDIByBand(Band: BandType);
 procedure ExportToADIF;
 procedure ExportToTRLogFormat;
 procedure ExportToCSV;   //n4af 04.30.3
+procedure ExportTo3830Scores;
 procedure PrintQSOsByCountry;
 function GenerateCountryMultiplierTotals: boolean;
 procedure QSOsByCountryByBand;
@@ -590,6 +591,183 @@ begin
   WriteScoreInformationToSummarySheet;
   CloseHandle(tReportFileWrite);
   FilePreview;
+end;
+
+procedure ExportTo3830Scores;
+// 3830Scores.com quick-submission report.  Layout adapts to contest rules:
+//   - Mode columns (CW Qs / Ph Qs / Dig Qs) appear only for modes that have
+//     at least one logged QSO.  Ph = USB+LSB+FM per spec.
+//   - Per-band Mults column appears iff MultByBand = TRUE (CQ-WW, etc).
+//   - Bottom Mults summary: per-mode breakdown if MultByMode = TRUE (FQP,
+//     NAQP); single 'Mults: N' otherwise.
+//   - All 8 standard 3830-form bands always rendered (160-2), even when
+//     zero.  Extra VHF/UHF rows appended only if they have QSOs.
+const
+   STD_BANDS        : array[0..7] of BandType =
+      (Band160, Band80, Band40, Band20, Band15, Band10, Band6, Band2);
+   STD_BAND_LABELS  : array[0..7] of string =
+      ('160', ' 80', ' 40', ' 20', ' 15', ' 10', '  6', '  2');
+var
+   buf                                   : string;
+   band                                  : BandType;
+   i                                     : integer;
+   m                                     : RemainingMultiplierType;
+   showCW, showPh, showDig               : boolean;
+   bandQsCW, bandQsPh, bandQsDig         : integer;
+   bandMults                             : integer;
+   sumCW, sumPh, sumDig, sumBandMults    : integer;
+   cwMults, phMults, digMults, totalMults: integer;
+   iniBuf                                : array[0..255] of Char;
+   operatorsStr, classStr, powerStr      : string;
+
+   function CalcBandMults(b: BandType): integer;
+   var
+      mm: RemainingMultiplierType;
+   begin
+      Result := 0;
+      // Note: FM QSOs are folded into Phone by LoadTotalCount (PostUnit ~986)
+      // before RawQSOTotals/MTotals are populated, so RawQSOTotals/MTotals
+      // are indexed by the CW..Both subrange of ModeType.  Don't reference
+      // FM here (compile error: 'Constant expression violates subrange bounds').
+      for mm := Low(RemainingMultiplierType) to High(RemainingMultiplierType) do
+         if MultByMode then
+            Result := Result +
+                      mo.MTotals[b, CW, mm] +
+                      mo.MTotals[b, Phone, mm] +
+                      mo.MTotals[b, Digital, mm]
+         else
+            Result := Result + mo.MTotals[b, Both, mm];
+   end;
+
+begin
+   if not CheckLog then Exit;
+   MakeReportFileName('3830Score.txt');
+   if not tOpenFileForWrite(tReportFileWrite, @ReportsFilename[1]) then Exit;
+
+   // RawQSOTotals[band, Phone] already includes FM (folded in by LoadTotalCount).
+   showCW  := RawQSOTotals[AllBands, CW] > 0;
+   showPh  := RawQSOTotals[AllBands, Phone] > 0;
+   showDig := RawQSOTotals[AllBands, Digital] > 0;
+
+   buf := SysUtils.Format('SOFTWARE: %s http://www.tr4w.net'#13#10#13#10,
+                          [TR4W_CURRENTVERSION]);
+   buf := buf + '3830Scores summary'#13#10#13#10;
+
+   // Metadata from the Cabrillo Summary fields the operator saved (read
+   // silently from tr4w.ini [REPORT] - no dialog popup).  Empty values
+   // emit blank lines so the operator types them directly on 3830's form.
+   if GetPrivateProfileString('REPORT', '_OPERATORS',
+         nil, iniBuf, SizeOf(iniBuf), TR4W_INI_FILENAME) > 0
+   then operatorsStr := string(iniBuf) else operatorsStr := '';
+   if GetPrivateProfileString('REPORT', '_CATEGORY-OPERATOR',
+         nil, iniBuf, SizeOf(iniBuf), TR4W_INI_FILENAME) > 0
+   then classStr := string(iniBuf) else classStr := '';
+   if GetPrivateProfileString('REPORT', '_CATEGORY-POWER',
+         nil, iniBuf, SizeOf(iniBuf), TR4W_INI_FILENAME) > 0
+   then powerStr := string(iniBuf) else powerStr := '';
+
+   buf := buf + SysUtils.Format('Call Used: %s'#13#10,        [string(MyCall)]);
+   buf := buf + SysUtils.Format('Operators: %s'#13#10,        [operatorsStr]);
+   buf := buf + SysUtils.Format('Class:     %s'#13#10,        [classStr]);
+   buf := buf + SysUtils.Format('Power:     %s'#13#10#13#10,  [powerStr]);
+
+   // Header row
+   buf := buf + '     ';
+   if showCW       then buf := buf + '    CW Qs';
+   if showPh       then buf := buf + '    Ph Qs';
+   if showDig      then buf := buf + '   Dig Qs';
+   if MultByBand   then buf := buf + '    Mults';
+   buf := buf + #13#10;
+
+   sumCW := 0; sumPh := 0; sumDig := 0; sumBandMults := 0;
+
+   // Standard 8 HF/Low-band rows (always shown, even when zero)
+   for i := Low(STD_BANDS) to High(STD_BANDS) do
+   begin
+      band      := STD_BANDS[i];
+      bandQsCW  := RawQSOTotals[band, CW];
+      bandQsPh  := RawQSOTotals[band, Phone];
+      bandQsDig := RawQSOTotals[band, Digital];
+
+      buf := buf + SysUtils.Format('%4s ', [STD_BAND_LABELS[i]]);
+      if showCW  then buf := buf + SysUtils.Format('%9d', [bandQsCW]);
+      if showPh  then buf := buf + SysUtils.Format('%9d', [bandQsPh]);
+      if showDig then buf := buf + SysUtils.Format('%9d', [bandQsDig]);
+      if MultByBand then
+         begin
+         bandMults := CalcBandMults(band);
+         buf := buf + SysUtils.Format('%9d', [bandMults]);
+         sumBandMults := sumBandMults + bandMults;
+         end;
+      buf := buf + #13#10#13#10;   // blank line between rows for readability
+
+      sumCW  := sumCW  + bandQsCW;
+      sumPh  := sumPh  + bandQsPh;
+      sumDig := sumDig + bandQsDig;
+   end;
+
+   // Extra VHF/UHF rows beyond 2m, only if they have QSOs
+   for band := Band222 to Band24G do
+      begin
+      bandQsCW  := RawQSOTotals[band, CW];
+      bandQsPh  := RawQSOTotals[band, Phone];
+      bandQsDig := RawQSOTotals[band, Digital];
+      if (bandQsCW + bandQsPh + bandQsDig) = 0 then Continue;
+
+      buf := buf + SysUtils.Format('%4s ', [BandStringsArray[band]]);
+      if showCW  then buf := buf + SysUtils.Format('%9d', [bandQsCW]);
+      if showPh  then buf := buf + SysUtils.Format('%9d', [bandQsPh]);
+      if showDig then buf := buf + SysUtils.Format('%9d', [bandQsDig]);
+      if MultByBand then
+         begin
+         bandMults := CalcBandMults(band);
+         buf := buf + SysUtils.Format('%9d', [bandMults]);
+         sumBandMults := sumBandMults + bandMults;
+         end;
+      buf := buf + #13#10#13#10;   // blank line between rows for readability
+
+      sumCW  := sumCW  + bandQsCW;
+      sumPh  := sumPh  + bandQsPh;
+      sumDig := sumDig + bandQsDig;
+      end;
+
+   // Total row
+   buf := buf + 'Total';
+   if showCW     then buf := buf + SysUtils.Format('%9d', [sumCW]);
+   if showPh     then buf := buf + SysUtils.Format('%9d', [sumPh]);
+   if showDig    then buf := buf + SysUtils.Format('%9d', [sumDig]);
+   if MultByBand then buf := buf + SysUtils.Format('%9d', [sumBandMults]);
+   buf := buf + #13#10#13#10;
+
+   // Mults summary
+   if MultByMode then
+      begin
+      cwMults := 0; phMults := 0; digMults := 0;
+      for m := Low(RemainingMultiplierType) to High(RemainingMultiplierType) do
+         begin
+         cwMults  := cwMults  + mo.MTotals[AllBands, CW, m];
+         phMults  := phMults  + mo.MTotals[AllBands, Phone, m];
+         digMults := digMults + mo.MTotals[AllBands, Digital, m];
+         end;
+      if showCW  then buf := buf + SysUtils.Format('CW Mults: %d'#13#10,  [cwMults]);
+      if showPh  then buf := buf + SysUtils.Format('Ph Mults: %d'#13#10,  [phMults]);
+      if showDig then buf := buf + SysUtils.Format('Dig Mults: %d'#13#10, [digMults]);
+      totalMults := cwMults + phMults + digMults;
+      buf := buf + SysUtils.Format('Total Mults: %d'#13#10, [totalMults]);
+      end
+   else
+      begin
+      totalMults := 0;
+      for m := Low(RemainingMultiplierType) to High(RemainingMultiplierType) do
+         totalMults := totalMults + mo.MTotals[AllBands, Both, m];
+      buf := buf + SysUtils.Format('Mults: %d'#13#10, [totalMults]);
+      end;
+
+   buf := buf + SysUtils.Format('Total Score: %d'#13#10, [TotalScore]);
+
+   sWriteFileFromString(tReportFileWrite, buf);
+   CloseHandle(tReportFileWrite);
+   FilePreview;
 end;
 
 procedure WriteTitleBlockToSummarySheet;

--- a/tr4w/src/uADIF.pas
+++ b/tr4w/src/uADIF.pas
@@ -1291,10 +1291,22 @@ begin
    if roverFullCall <> '' then
       Result := Result + EmitADIFField('APP_TR4W_ROVERCALL', roverFullCall);
 
-   // CONTEST_ID, unless POTA/GENERALQSO (legacy behaviour)
+   // CONTEST_ID, unless POTA/GENERALQSO (legacy behaviour).
+   // Mirror the fallback used by LOGSUBS2.PAS:2782, uGetScores.pas:435 and 564:
+   // if ContestsArray[].ADIFName is empty (true for 156 of TR4W's contests),
+   // fall back to the parallel ContestTypeSA[] string, which IS the standard
+   // ADIF Contest_ID for the major contests (e.g. 'CQ-WPX-SSB', 'CQ-WW-CW',
+   // 'ARRL-DX-CW').  This was the behaviour before Issue #887's extraction;
+   // it did not survive the move into uADIF.pas.
    if not (rec.ceContest in [POTA, GENERALQSO]) then
-      Result := Result + EmitADIFField('CONTEST_ID',
-         string(ContestsArray[rec.ceContest].ADIFName));
+      begin
+      if Length(ContestsArray[rec.ceContest].ADIFName) = 0 then
+         Result := Result + EmitADIFField('CONTEST_ID',
+            string(ContestTypeSA[rec.ceContest]))
+      else
+         Result := Result + EmitADIFField('CONTEST_ID',
+            string(ContestsArray[rec.ceContest].ADIFName));
+      end;
 
    // MODE / SUBMODE
    Result := Result + EmitADIFField('MODE', modeStr);

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -329,6 +329,7 @@ const
    CommandsArraySize = 416 {RadioOneCWSpeedSync} + 1 {RadioTwoCWSpeedSync}     // 4.91.3
    + 1 {RadioOneCWByCAT} + 1 {RadioTwoCWByCAT} //ny4i // 4.44.5
    + 9 {UDPBroadcast Variables} + 4 {New UDP Broadcasst Ports}
+   + 1 {ServerAutoSynchronizeLogOnConnect - Issue #912}
       //ny4i 4.44.9  - Issue 82 added one more UDP variable   Issue 304 Added UDPBroadcastScore
    + 1 {WSJTXUDPPort}
    + 1 {Radio TCP Server Port}
@@ -760,6 +761,7 @@ const
  (crCommand: 'SERIAL 6 PORT ADDRESS';         crAddress: nil;                             crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 0),
  (crCommand: 'SERIAL PORT DEBUG';             crAddress: @CPUKeyer.SerialPortDebug;       crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 0),
  (crCommand: 'SERVER ADDRESS';                crAddress: @ServerAddress;                  crMin:0;  crMax:255;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfAll; crType: ctString; crNetwork: 1),
+ (crCommand: 'SERVER AUTO SYNCHRONIZE LOG ON CONNECT'; crAddress: @ServerAutoSynchronizeLogOnConnect; crMin:0; crMax:0; crS: csNew; crA: 0; crC:0; crP:0; crJ: 0; crKind: ckNormal; cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),  // Issue #912
  (crCommand: 'SERVER PASSWORD';               crAddress: @ServerPassword;                 crMin:0;  crMax:10;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfAll; crType: ctPassword; crNetwork: 1),  // Was ctString -- bring under the masking-in-Settings logic (Issue #783)
  (crCommand: 'SERVER PORT';                   crAddress: @ServerPort;                     crMin:0;  crMax:MAXWORD; crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfAll; crType: ctInteger; crNetwork: 1),
  (crCommand: 'SHIFT KEY ENABLE';              crAddress: @ShiftKeyEnable;                 crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:1 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),     // 4.105.6

--- a/tr4w/src/uCbrSum.pas
+++ b/tr4w/src/uCbrSum.pas
@@ -201,7 +201,7 @@ begin
           tCreateStaticWindow(@CabrilloTagSArray[TempTag].ctrTag[1], LeftStyle, 10, Top, 160, TagHeight, hwnddlg, integer(TempTag) + 100);
           if ErmakSpecification and (TempTag = ctOperators) then
           begin
-            tCreateButtonWindow(WS_EX_STATICEDGE, 'Выбрать ...', WS_TABSTOP or WS_CHILD or WS_VISIBLE, 173, Top, 190, TagHeight, hwnddlg, 3);
+            tCreateButtonWindow(WS_EX_STATICEDGE, 'пїЅпїЅпїЅпїЅпїЅпїЅпїЅ ...', WS_TABSTOP or WS_CHILD or WS_VISIBLE, 173, Top, 190, TagHeight, hwnddlg, 3);
             Continue;
           end;
 
@@ -273,7 +273,15 @@ begin
     WM_COMMAND:
       begin
         case wParam of
-            1: asm call CabrilloSummaryProc; end;
+            1:
+              // Issue #914: when opened standalone (Tools -> Edit Cabrillo
+              // Summary), no callback is provided (lParam was 0).  Treat OK
+              // the same as Cancel - the WM_CLOSE/ExitAndClose path saves
+              // all ctrSave fields to tr4w.ini [REPORT] before closing.
+              if CabrilloSummaryProc = nil then
+                goto ExitAndClose
+              else
+                asm call CabrilloSummaryProc; end;
           2: goto ExitAndClose;
           3:
           //DialogBox(hInstance, MAKEINTRESOURCE(50), hwnddlg, @ErmakDlgProc);

--- a/tr4w/src/uGetServerLog.pas
+++ b/tr4w/src/uGetServerLog.pas
@@ -52,6 +52,14 @@ var
   ServerLogListView                     : HWND;
   LogSyncThreadID                       : Cardinal;
   showresverlogcontent                  : boolean = True;
+  HeadlessSyncMode                      : boolean = False;  // Issue #912 - run sync without any dialog UI
+
+const
+  // Issue #912: SendMessage from RunSyncThread (worker) to the UI thread to
+  // drive the post-download replace.  Cannot do this from the worker because
+  // LoadinLog (called by ReplaceLogByServerLog) accesses ListView controls,
+  // and Win32 controls require all messages from their creating thread.
+  WM_USER_HEADLESS_SYNC_REPLACE = WM_USER + 200;
 
 implementation
 uses MainUnit;
@@ -181,7 +189,8 @@ begin
        end;
       sWriteFile(NewServerLogHandle, SyncNetBuffer[Offset], i - Offset);
       TotalBytes := TotalBytes + i - Offset;
-      tSetDlgItemIntFalse(GetServerLogWnd, 108, TotalBytes);
+      if not HeadlessSyncMode then
+        tSetDlgItemIntFalse(GetServerLogWnd, 108, TotalBytes);
     end;
     if i <> 0 then
       goto 1;
@@ -193,15 +202,19 @@ begin
   begin
     if (LogSize <> TotalBytes) or ((TotalBytes - SizeOfTLogHeader) mod SizeOf(ContestExchange) <> 0) then
     begin
-      showwarning(TC_FAILEDTORECEIVESERVERLOG);
+      if HeadlessSyncMode then
+        logger.Error('Auto-sync: failed to receive server log (size=%d, expected=%d)', [TotalBytes, LogSize])
+      else
+        showwarning(TC_FAILEDTORECEIVESERVERLOG);
       goto e;
     end;
-    if showresverlogcontent then
+    if (not HeadlessSyncMode) and showresverlogcontent then
       SendMessage(ServerLogListView, LVM_SETITEMCOUNT, TotalBytes div SizeOf(ContestExchange), 0);
     Windows.SetFilePointer(NewServerLogHandle, SizeOfTLogHeader, nil, FILE_BEGIN);
 
     IndexInServerLogListView := 0;
-    tSetWindowRedraw(ServerLogListView, False);
+    if not HeadlessSyncMode then
+      tSetWindowRedraw(ServerLogListView, False);
     2:
     Windows.ReadFile(NewServerLogHandle, TempRXData, SizeOf(ContestExchange), lpNumberOfBytesWritten, nil);
     if lpNumberOfBytesWritten = SizeOf(ContestExchange) then
@@ -212,19 +225,51 @@ begin
         (not TempRXData.ceQSO_Deleted)) and
         (TempRXData.ceQSO_Skiped = False) then inc(TotalQ);
 
-      if TotalRecords mod 10 = 0 then
-        tSetDlgItemIntFalse(GetServerLogWnd, 101, TotalRecords);
-      if showresverlogcontent then
-        tAddContestExchangeToLog(TempRXData, ServerLogListView, IndexInServerLogListView);
+      if not HeadlessSyncMode then
+        begin
+        if TotalRecords mod 10 = 0 then
+          tSetDlgItemIntFalse(GetServerLogWnd, 101, TotalRecords);
+        if showresverlogcontent then
+          tAddContestExchangeToLog(TempRXData, ServerLogListView, IndexInServerLogListView);
+        end;
       goto 2;
     end;
-    tSetWindowRedraw(ServerLogListView, True);
+    if not HeadlessSyncMode then
+      tSetWindowRedraw(ServerLogListView, True);
   end;
-  tSetDlgItemIntFalse(GetServerLogWnd, 101, TotalRecords);
-  tSetDlgItemIntFalse(GetServerLogWnd, 109, TotalQ);
-  if TotalQ > 0 then EnableWindowTrue(GetServerLogWnd, 107);
+  if not HeadlessSyncMode then
+    begin
+    tSetDlgItemIntFalse(GetServerLogWnd, 101, TotalRecords);
+    tSetDlgItemIntFalse(GetServerLogWnd, 109, TotalQ);
+    if TotalQ > 0 then EnableWindowTrue(GetServerLogWnd, 107);
+    end;
   e:
   LogSyncThreadID := 0;
+  // Issue #912: headless mode drives the replace from the UI thread via
+  // SendMessage.  LoadinLog (called by ReplaceLogByServerLog) accesses
+  // Win32 ListView controls, which require their creating thread.
+  // SendMessage blocks here until the UI handler returns, which is fine -
+  // the worker thread is about to exit anyway.
+  if HeadlessSyncMode then
+    begin
+    if TotalQ > 0 then
+      begin
+      logger.Info('Auto-sync: download complete (%d records, %d QSOs).  Marshalling replace to UI thread.',
+                  [TotalRecords, TotalQ]);
+      SendMessage(tr4whandle, WM_USER_HEADLESS_SYNC_REPLACE, 0, 0);
+      end
+    else
+      begin
+      logger.Warn('Auto-sync: download produced %d records and %d QSOs - skipping replace.',
+                  [TotalRecords, TotalQ]);
+      if NewServerLogHandle <> INVALID_HANDLE_VALUE then
+        begin
+        CloseHandle(NewServerLogHandle);
+        NewServerLogHandle := INVALID_HANDLE_VALUE;
+        end;
+      HeadlessSyncMode := False;
+      end;
+    end;
 end;
 
 end.

--- a/tr4w/src/uMenu.pas
+++ b/tr4w/src/uMenu.pas
@@ -133,7 +133,7 @@ const
   RC_REPEAT_POTA_HK                     = #9'Ctrl+T';
 
 
-    T_MENU_ARRAY_SIZE                     = 179 {$IF MMTTYMODE} + 1{$IFEND}{$IF LANG = 'RUS'} + 3{$IFEND} + 2 {RC_RESET_RADIO_PORTS, separator, Repeat POTA Parks} + 2 {HamScore Resync (Tools) + HamScore Status (Windows menu), Issue #783};
+    T_MENU_ARRAY_SIZE                     = 179 {$IF MMTTYMODE} + 1{$IFEND}{$IF LANG = 'RUS'} + 3{$IFEND} + 2 {RC_RESET_RADIO_PORTS, separator, Repeat POTA Parks} + 2 {HamScore Resync (Tools) + HamScore Status (Windows menu), Issue #783} + 1 {3830 Score under File-Reports} + 1 {Edit Cabrillo Summary under Tools, Issue #914};
   T_MENU_ARRAY                          : array[0..T_MENU_ARRAY_SIZE] of MenuRecord = (
     (mrText: RC_FILE; mrId: MAXWORD),
  //{
@@ -165,6 +165,7 @@ const
     (mrText: RC_QSOBYCOUNTRY; mrId: menu_qsobycountry),
     (mrText: RC_SCOREBYHOUR; mrId: menu_scorebyhour),
     (mrText: RC_SUMMARY; mrId: menu_summary),
+    (mrText: '3830 Score'; mrId: menu_3830scores),
   //}
     (mrText: nil; mrId: MAXWORD - 2),
     (mrText: '-'; mrId: 0),
@@ -368,6 +369,7 @@ const
     (mrText: 'Download POTA Parks'; mrId: menu_download_pota_parks),  // issue #864
     (mrText: 'Repeat POTA Parks (2nd Op)' + RC_REPEAT_POTA_HK; mrId: menu_repeat_pota_parks),
     (mrText: 'HamScore: Resync log from scratch'; mrId: menu_hamscore_resync),  // Issue #783
+    (mrText: 'Edit Cabrillo Summary...'; mrId: menu_edit_cabrillo_summary),     // Issue #914
  //}
     (mrText: '-'; mrId: 0),
     (mrText: RC_3830; mrId: menu_3830_scores_posting),

--- a/tr4w/src/uNet.pas
+++ b/tr4w/src/uNet.pas
@@ -158,6 +158,7 @@ var
   ServerAddress                         : str31 = 'LOCALHOST';
   ServerPassword                        : Str20 = 'TR4WSERVER';
   ServerPort                            : integer = 1061;
+  ServerAutoSynchronizeLogOnConnect     : boolean = False;  // Issue #912
   NetSocket                             : Cardinal;
   LogSyncSocket                         : Cardinal;
   ConnectedwithServer                   : boolean;
@@ -855,8 +856,44 @@ begin
 //    if tUSQE <> 0 then IdenticalLogs := False;
 
     if not IdenticalLogs then
+      begin
+      // Issue #912: if SERVER AUTO SYNCHRONIZE LOG ON CONNECT is set, skip
+      // the "Difference in logs" dialog AND the GetServerLog dialog entirely
+      // and run the sync headlessly in a worker thread.  The replace happens
+      // on the UI thread via SendMessage (see WM_USER_HEADLESS_SYNC_REPLACE
+      // in tr4w.dpr) so LoadinLog's ListView access is thread-safe.
+      //
+      // Safety: only auto-sync when contests match (or server has no contest
+      // yet); otherwise fall through to the existing dialog so the operator
+      // sees the wrong-server warning.
+      if ServerAutoSynchronizeLogOnConnect and
+         ((s^.liContest = Contest) or (s^.liContest = DUMMYCONTEST)) then
+         begin
+         logger.Info('Auto-synchronizing local log from server (CRC mismatch: local %x, server %x)',
+                     [s^.liLocalCRC32, s^.liSeverCRC32]);
+         QuickDisplay(TC_AUTOSYNCHRONIZINGLOG);
+         NewServerLogHandle := CreateFile(TR4W_SYN_FILENAME,
+                                          GENERIC_READ or GENERIC_WRITE,
+                                          FILE_SHARE_READ or FILE_SHARE_WRITE,
+                                          nil, CREATE_ALWAYS,
+                                          FILE_ATTRIBUTE_ARCHIVE, 0);
+         if NewServerLogHandle = INVALID_HANDLE_VALUE then
+            begin
+            logger.Error('Auto-sync: could not create %s', [TR4W_SYN_FILENAME]);
+            // Fall through to the existing dialog so the operator can react.
+            CreateModalDialog(220, 110, tr4whandle, @LogCompareDlgProc, integer(s));
+            end
+         else
+            begin
+            HeadlessSyncMode := True;
+            if LogSyncThreadID = 0 then
+               tCreateThread(@RunSyncThread, LogSyncThreadID);
+            end;
+         end
+      else
 //      DialogBoxParam(hInstance, MAKEINTRESOURCE(75), tr4whandle, @LogCompareDlgProc, integer(s))
-      CreateModalDialog(220, 110, tr4whandle, @LogCompareDlgProc, integer(s))
+         CreateModalDialog(220, 110, tr4whandle, @LogCompareDlgProc, integer(s));
+      end
     else
       QuickDisplay(TC_SERVERANDLOCALLOGSAREIDENTICAL);
 

--- a/tr4w/src/uNewContest.pas
+++ b/tr4w/src/uNewContest.pas
@@ -141,9 +141,15 @@ begin
       begin
         NewContestDlgWndHandle := hwnddlg;
 
-        CreateStatic(RC_CAPTION, 5, 5, 280, hwnddlg, 445);
+        // Issue #915: shrink left column by 30 px to give the right-side
+        // CATEGORY-* labels room.  CATEGORY-TRANSMITTER (the longest label)
+        // was being clipped on the left because the label area was too
+        // narrow for right-aligned text.  Listbox entries are typically
+        // ~25-30 chars (e.g. "[2025 FLORIDA QSO PARTY NY4I]") which still
+        // fit comfortably at width 250.
+        CreateStatic(RC_CAPTION, 5, 5, 250, hwnddlg, 445);
          {LISTBOX}
-        CreateListBox(5, 35, 280, 370, hwnddlg, NC_LISTBOX);
+        CreateListBox(5, 35, 250, 370, hwnddlg, NC_LISTBOX);
 
         GetPrivateProfileString(_COMMANDS, LATEST_CONFIG_FILE, nil, TR4W_LATESTCFG_FILENAME, SizeOf(FileNameType), TR4W_INI_FILENAME);
         if TR4W_LATESTCFG_FILENAME[0] <> #0 then
@@ -155,7 +161,7 @@ begin
 
         {BUTTON LATEST CONFIG}
             TempCardinal := tWM_SETFONT(
-              CreateWindowEx(0, ButtonPChar, nil, BS_MULTILINE or WS_CHILD or BS_TEXT or WS_VISIBLE {or WS_TABSTOP}, 5, 415, 280, 50 {nHeight}, hwnddlg, NC_BUTTON_LATEST_CONFIG, hInstance, nil),
+              CreateWindowEx(0, ButtonPChar, nil, BS_MULTILINE or WS_CHILD or BS_TEXT or WS_VISIBLE {or WS_TABSTOP}, 5, 415, 250, 50 {nHeight}, hwnddlg, NC_BUTTON_LATEST_CONFIG, hInstance, nil),
               MSSansSerifFont);
 
             Windows.CopyMemory(@TempBuffer1, @TR4W_LATESTCFG_FILENAME, SizeOf(FileNameType));
@@ -169,9 +175,11 @@ begin
           end;
         end;
 
-        tCreateStaticWindow('MY CALL', WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 300, 5, 125 + 20, h, hwnddlg, 0);
+        // Issue #915: labels shifted left + widened to fit CATEGORY-TRANSMITTER
+        // at right-align.  x was 300, w was 125+20 (=145).  Now x=270, w=155+20.
+        tCreateStaticWindow('MY CALL', WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 270, 5, 155 + 20, h, hwnddlg, 0);
 
-        tCreateStaticWindow('CONTEST', WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 300, 33, 125 + 20, h, hwnddlg, 0);
+        tCreateStaticWindow('CONTEST', WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 270, 33, 155 + 20, h, hwnddlg, 0);
         tWM_SETFONT(CreateWindow(StaticPChar, nil, SS_SUNKEN or SS_center or WS_CHILD or WS_VISIBLE, 305, 95, 300, 40, hwnddlg, 106, hInstance, nil), MSSansSerifFont);
 
         {MY CALL}
@@ -203,7 +211,10 @@ begin
         for TempCardinal := 1 to CSAS do
         begin
           Top := 120 + TempCardinal * (h + 6);
-          InitialCommandsHWNDArray[TempCardinal, 1] := tCreateStaticWindow(InitialCommandsSA2[TempCardinal], WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 300, Top, 128 + 20, h, hwnddlg, 0);
+          // Issue #915: CATEGORY-* labels shifted left + widened so the
+          // longest one (CATEGORY-TRANSMITTER) fits at right-align without
+          // clipping.  Was: x=300, w=128+20 (=148).  Now: x=270, w=158+20.
+          InitialCommandsHWNDArray[TempCardinal, 1] := tCreateStaticWindow(InitialCommandsSA2[TempCardinal], WS_CHILD or SS_NOTIFY or SS_RIGHT or SS_NOPREFIX or WS_VISIBLE, 270, Top, 158 + 20, h, hwnddlg, 0);
           if TempCardinal < 4 then
             InitialCommandsHWNDArray[TempCardinal, 2] := tCreateEditWindow(WS_EX_STATICEDGE, nil, WS_TABSTOP or WS_CHILD or ES_UPPERCASE, 435 + 20, Top, 173 - 20, h, hwnddlg, 0)
           else

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -223,6 +223,22 @@ begin
 
     WM_DISPLAYCHANGE: if wParam <= 8 then tEightBitsPerPixel := True else tEightBitsPerPixel := False;
 
+    // Issue #912: headless server-log auto-sync.  RunSyncThread (worker)
+    // SendMessages here once the download is complete; we close the temp
+    // file handle and call ReplaceLogByServerLog on the UI thread so
+    // LoadinLog's ListView access is safe.
+    WM_USER_HEADLESS_SYNC_REPLACE:
+      begin
+        if NewServerLogHandle <> INVALID_HANDLE_VALUE then
+          begin
+          CloseHandle(NewServerLogHandle);
+          NewServerLogHandle := INVALID_HANDLE_VALUE;
+          end;
+        ReplaceLogByServerLog(True);
+        logger.Info('Auto-sync: local log replaced with server log.');
+        HeadlessSyncMode := False;
+      end;
+
 //    WM_MOUSEWHEEL: SetStackPointerOnMouseWheel(SHORT(HiWord(Cardinal(wParam))));
     WM_TRAYBALLON:
       begin


### PR DESCRIPTION
> ## NOTE TO HOWIE - ONE-TIME ACTION AFTER PULL
>
> After you pull this merge, run this once on your clone to silence cty.dat from \`git status\`:
>
> \`\`\`
> git -C /c/TR4W update-index --skip-worktree tr4w/target/cty.dat
> \`\`\`
>
> Why: cty.dat is rewritten by TR4W at runtime so it always shows as modified.  This PR's gitignore change blocks \`git add\` of cty.dat (so nobody accidentally commits a runtime-modified copy), but already-tracked files still appear in \`git status\` as modified.  The \`--skip-worktree\` flag is per-clone (each developer sets it once on their own machine) and tells your local git to ignore changes to that specific file.  If you ever genuinely need to update the master copy, \`git add -f tr4w/target/cty.dat\` is the escape.
>
> The CHANGES + RELEASE_NOTES commit that added the gitignore update (\`932d89d\` on master) explains this too.

---

## Summary

Four commits across three GitHub issues plus a drive-by ADIF fix.  Two commits chosen for rollback granularity per discussion - shared menu/file infrastructure between 3830 Score and #914 keeps them together; #915 is purely independent and gets its own commit.

### What's in each commit

1. **\`d3e08c5\` Restore CONTEST_ID fallback to ContestTypeSA in ADIF export**
   When \`ContestsArray[Contest].ADIFName\` is empty (true for 156 contests including all CQ-WW / CQ-WPX / ARRL-DX), the ADIF export was emitting no CONTEST_ID at all.  Now falls back to \`ContestTypeSA[Contest]\` like the three other code sites that already do this (\`LOGSUBS2.PAS:2782\`, \`uGetScores.pas:435\`, \`uGetScores.pas:564\`).  Single-line fix covers all 156 contests.  This fallback existed before Issue #887's extraction of the ADIF export from PostUnit/MainUnit into uADIF.pas - it didn't survive the move.

2. **\`3cf72ee\` Fixes #912 - SERVER AUTO SYNCHRONIZE LOG ON CONNECT**
   New boolean config flag (default FALSE).  When TRUE, reconnecting to TR4WServer with a CRC-mismatched log auto-syncs from the server's copy in the background instead of popping the \"Difference in logs\" modal.  Headless implementation: worker thread does the download, marshals to UI thread via SendMessage (\`WM_USER_HEADLESS_SYNC_REPLACE\`) for \`LoadinLog\`'s ListView access.  Safety guard: contest mismatch still falls through to the existing dialog so the wrong-server case still warns.

3. **\`d26d664\` Add 3830 Score report + Fixes #914 Edit Cabrillo Summary access**

   **3830 Score report**: new menu item File -> Reports -> 3830 Score generates \`<logname>_3830Score.txt\` matching the 3830scores.com submission form layout.  Output adapts to contest properties:
   - QSO table: per-band rows (always 160/80/40/20/15/10/6/2 + VHF rows if non-zero); mode columns appear only for modes with QSOs
   - Per-band Mults column iff \`MultByBand = TRUE\` (CQ-WW style)
   - Bottom Mults summary: per-mode lines + Total if \`MultByMode = TRUE\` (FQP/NAQP style); single \`Mults: N\` otherwise
   - Metadata header (Call Used / Operators / Class / Power) read silently from \`tr4w.ini [REPORT]\`; no dialog popup

   **Fixes #914 Edit Cabrillo Summary**: new Tools -> Edit Cabrillo Summary... menu opens the existing dialog standalone (passes \`lParam=0\` so the callback is nil; OK then takes the existing save-and-close path).  Operator can edit \`[REPORT]\` fields post-contest-setup without going through Cabrillo file generation.  Surfaced by the 3830 report's need for those values.

4. **\`c696477\` Fixes #915 - Widen CATEGORY-* labels in New Contest dialog**
   \`CATEGORY-OPERATOR\` and \`CATEGORY-TRANSMITTER\` were clipped on the left because the right-aligned label column was too narrow.  Shrunk the left listbox column by 30 px (280 -> 250), widened the right-side labels by the same 30 px (x=300 -> 270, width 148 -> 178).  Right edges of labels unchanged; dropdown positions unchanged.

## Files

| File | Touched by |
|---|---|
| \`src/uADIF.pas\` | ADIF CONTEST_ID fallback |
| \`src/uNet.pas\`, \`src/uCFG.pas\`, \`src/uGetServerLog.pas\`, \`tr4w.dpr\`, 11 lang files, \`docs/NETWORK_LOG_AUTO_SYNC.md\` | #912 |
| \`src/trdos/PostUnit.PAS\` | 3830 Score report |
| \`src/uCbrSum.pas\` | #914 nil-callback handling |
| \`src/uMenu.pas\`, \`src/VC.pas\`, \`src/MainUnit.pas\` | 3830 + #914 menu wiring |
| \`src/uNewContest.pas\` | #915 |

## Test plan

- [x] ADIF CONTEST_ID - exported CQ-WPX-SSB log, verified \`<CONTEST_ID:10>CQ-WPX-SSB\` present in each record
- [x] #912 SERVER AUTO SYNCHRONIZE - tested with TR4WServer stop/restart; sync happens headlessly, no modal
- [x] 3830 Score report - tested with CQ-WPX-SSB log; metadata block, band table, single-Mults total all correct
- [x] #914 Edit Cabrillo Summary - opens dialog, edits persist to \`tr4w.ini\`, no Cabrillo file generated
- [x] #915 label widening - visual confirmation in New Contest dialog
- [ ] @n4af smoke test on K3 SO2R setup before merging

## Issues this PR closes on merge

- Fixes #912
- Fixes #914
- Fixes #915