### PR TITLE
HamScore/UDP: TRACE log + canonical sent/rx exchanges; X-QSO All-column fix

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -5525,8 +5525,12 @@ begin
             inc(TimeSpentByBand[TempRXData.Band]);
             // PreviousBand := TempRXData.Band;
           end;
+          // Issue #750 follow-up: this increment was previously OUTSIDE
+          // the X-QSO guard, so the score grid's "All" column counted
+          // X-QSO records even though every per-band/per-mode counter
+          // skipped them. Moved inside so the totals are consistent.
+          inc(QSOTotals[AllBands, Both]);
         end;
-        inc(QSOTotals[AllBands, Both]);
       end;
     // else
     // asm nop end;

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -153,7 +153,8 @@ uses
   MainUnit,
   uRadioPolling,
   uYCCCSO2R,
-  uHamScore;        // Issue #783 -- HamScoreOnLog hook
+  uHamScore,        // Issue #783 -- HamScoreOnLog hook
+  uExchangeBuilder; // Canonical SentExchange builder for UDP broadcast
 procedure CreateAndSendPacketSpot(PacketSpotCall: CallString; PacketSpotFreq: LONGINT);
 
 begin
@@ -3083,15 +3084,13 @@ begin
       else
          sExchange := RXData.ExchString;
       end;}
-   case ActiveExchange of
-      NameAndDomesticOrDXQTHExchange:
-         sExchange := RXData.Name;
-      ClassDomesticOrDXQTHExchange:
-         sExchange := RXData.ceClass;
-      else
-         sExchange := RXData.ExchString;
-      end;
-
+   // Canonical received exchange, per contest, rebuilt from typed fields
+   // so the operator-typed order doesn't leak into consumers. The prior
+   // ActiveExchange dispatch only handled 2 cases and fell back to the
+   // raw operator string; the shared builder covers more contests
+   // (WPX/WAE, CQ WW/IARU, CQ 160, ARRL DX, All Asian, CWT, CWOpen, RTC,
+   // Field Day, Winter FD) with the same logic the RTC POST uses.
+   sExchange := BuildRxExchangeText(RxData);
 
    Result := Result + #9 + '<exchange1>' + sExchange + '</exchange1>' + sLineBreak;
    Result := Result +
@@ -3123,7 +3122,10 @@ begin
             #9 + '<IsClaimedQso>' + Format('%d',[IfThen(RxData.ceQSO_Skiped or RxData.ceXQSO,0,1)]) + '</IsClaimedQso>' + sLineBreak +
             #9 + '<oldtimestamp>' + sTimestamp + '</oldtimestamp>' + sLineBreak +
             #9 + '<oldcall>' + RXData.Callsign + '</oldcall>' + sLineBreak +
-            #9 + '<SentExchange>' + Trim(RxData.ExchString) + '</SentExchange>' + sLineBreak +
+            // SentExchange built from CQExchange template, not the
+            // received string. Pre-fix this echoed RxData.ExchString,
+            // which is wrong for any contest. See uExchangeBuilder.
+            #9 + '<SentExchange>' + BuildSentExchangeText(RxData) + '</SentExchange>' + sLineBreak +
 
       '</' + sRecType + '>'+ sLineBreak ;
 

--- a/tr4w/src/uExchangeBuilder.pas
+++ b/tr4w/src/uExchangeBuilder.pas
@@ -1,0 +1,181 @@
+unit uExchangeBuilder;
+
+(*
+  Shared exchange string builders for RTC / HamScore / N1MM-style UDP
+  ContactInfo broadcasts.
+
+  The TR4W exchange parser is intentionally forgiving about field order --
+  for a grid contest you can type either "EL88 1234" or "1234 EL88" and
+  parse both correctly into NumberReceived / QTHString.  But scoring
+  consumers (HamScore RTC, external loggers) want a canonical form so
+  that the same QSO doesn't appear two different ways depending on what
+  the operator typed.
+
+  These helpers rebuild the SentExchange and RxExchange strings from the
+  ContestExchange record's typed fields, per contest type, in the
+  scoring-canonical order.  Output is plain text; XML escaping is the
+  caller's job.
+
+  Future: when the radio/contest factory grows an "RTC exchange template"
+  field per contest, these dispatchers move there and the case statement
+  disappears.
+*)
+
+interface
+
+uses
+  VC;
+
+// Plain-text builders (no XML escaping).
+function BuildSentExchangeText(const RXData: ContestExchange): string;
+function BuildRxExchangeText  (const RXData: ContestExchange): string;
+
+implementation
+
+uses
+  SysUtils, StrUtils,
+  LogCW;     // CQExchange template global
+
+// Collapse runs of whitespace (space + tab) to a single space and trim
+// both ends.  Used after substituting into the CQExchange template so
+// the template's leading space and any double spaces from optional
+// fields don't survive.
+function CollapseWhitespace(const s: string): string;
+var
+   i: Integer;
+   prevSpace: Boolean;
+begin
+   Result := '';
+   prevSpace := True;
+   for i := 1 to Length(s) do
+      begin
+      if (s[i] = ' ') or (s[i] = #9) then
+         begin
+         if not prevSpace then
+            begin
+            Result := Result + ' ';
+            prevSpace := True;
+            end;
+         end
+      else
+         begin
+         Result := Result + s[i];
+         prevSpace := False;
+         end;
+      end;
+   while (Length(Result) > 0) and (Result[Length(Result)] = ' ') do
+      SetLength(Result, Length(Result) - 1);
+end;
+
+// 599 on CW/Digital, 59 on Phone/FM -- used when RSTReceived = 0 because
+// the operator accepted the parser default and it never picked up an
+// explicit value.
+function DefaultRST(mode: ModeType): string;
+begin
+   case mode of
+      CW, Digital: Result := '599';
+   else
+      Result := '59';
+   end;
+end;
+
+function RSTReceivedString(const RXData: ContestExchange): string;
+begin
+   if RXData.RSTReceived > 0 then
+      Result := IntToStr(RXData.RSTReceived)
+   else
+      Result := DefaultRST(RXData.Mode);
+end;
+
+function BuildSentExchangeText(const RXData: ContestExchange): string;
+var
+   tpl: string;
+begin
+   tpl := string(CQExchange);
+   if tpl = '' then
+      begin
+      // No template configured -- fall back to whatever the operator
+      // typed.  Still echoes the received exchange, but no worse than
+      // pre-fix behaviour and avoids fabricating data we don't have.
+      Result := Trim(string(RXData.ExchString));
+      Exit;
+      end;
+
+   // '#' -> our sent serial number for this QSO.
+   tpl := StringReplace(tpl, '#',   IntToStr(RXData.NumberSent), [rfReplaceAll]);
+   // CW shorthand '5NN' -> '599' (T = N in CW).  RTC consumers want
+   // canonical numeric RST, not keyer shorthand.
+   tpl := StringReplace(tpl, '5NN', '599',                       [rfReplaceAll, rfIgnoreCase]);
+
+   Result := CollapseWhitespace(tpl);
+end;
+
+function BuildRxExchangeText(const RXData: ContestExchange): string;
+var
+   rst, serial, age, zone, qth, pwr, nm, cls: string;
+begin
+   rst    := RSTReceivedString(RXData);
+   serial := IntToStr(RXData.NumberReceived);
+   age    := IntToStr(RXData.Age);
+   zone   := IntToStr(RXData.Zone);
+   qth    := Trim(string(RXData.QTHString));
+   pwr    := Trim(string(RXData.Power));
+   nm     := Trim(string(RXData.Name));
+   cls    := Trim(string(RXData.ceClass));
+
+   case RXData.ceContest of
+      // RST + serial
+      CQWPXCW, CQWPXSSB, DARCWAEDCCW:
+         Result := rst + ' ' + serial;
+
+      // RST + zone
+      CQWWCW, CQWWSSB, IARU:
+         Result := rst + ' ' + zone;
+
+      // RST + state/section literal
+      CQ160CW:
+         Result := rst + ' ' + qth;
+
+      // ARRL DX: US side sends RST+state, DX side sends RST+power.
+      // TR4W's parser puts state in QTHString and power in Power; pick
+      // whichever the worked station actually sent.
+      ARRLDXCW, ARRLDXSSB:
+         if qth <> '' then
+            Result := rst + ' ' + qth
+         else
+            Result := rst + ' ' + pwr;
+
+      // RST + age
+      ALLASIANCW, ALLASIANSSB:
+         Result := rst + ' ' + age;
+
+      // CWT: Name + (member# or QTH) -- both go through QTHString.
+      CWOPS:
+         Result := nm + ' ' + qth;
+
+      // CWOpen: serial + Name
+      CWOPEN:
+         Result := serial + ' ' + nm;
+
+      // RTC (Real-Time Contest, Issue #902): serial + grid.
+      // Parser uses RSTQSONumberAndGridSquareExchange (which accepts RST
+      // optionally) but the actual on-air exchange is just serial + grid.
+      RTC:
+         Result := serial + ' ' + qth;
+
+      // ARRL Field Day / Winter Field Day: class + section.
+      // Both contests use ClassDomesticOrDXQTHExchange; class lands in
+      // ceClass (e.g. "2A"), section in QTHString (e.g. "FL" or "DX").
+      ARRLFIELDDAY, WINTERFIELDDAY:
+         Result := cls + ' ' + qth;
+
+   else
+      // Unknown contest -- emit the raw operator-typed string.  Same as
+      // pre-fix behaviour; no worse, and avoids fabricating fields.
+      Result := Trim(string(RXData.ExchString));
+   end;
+
+   Result := CollapseWhitespace(Result);
+end;
+
+end.

--- a/tr4w/src/uHamScore.pas
+++ b/tr4w/src/uHamScore.pas
@@ -159,7 +159,8 @@ uses
   ZoneCont,          // GetContinentName, ContinentType
   TF,                // CreateButton, CreateStatic
   MainUnit,          // CloseTR4WWindow, DefTR4WProc, FrmSetFocus (impl/impl cycle is OK)
-  uGetScores;        // BuildDynamicResultsXml (added by this PR)
+  uGetScores,        // BuildDynamicResultsXml (added by this PR)
+  uExchangeBuilder;  // Shared SentExchange / RxExchange canonical builders
 
 const
   DEFAULT_CYCLE_MS = 120000;   // 2 minutes per RTC spec section 1.2
@@ -274,6 +275,19 @@ begin
      tSysTime.qtHour, tSysTime.qtMinute, tSysTime.qtSecond]));
 end;
 
+// XML-escaping wrappers around the plain-text shared builders in
+// uExchangeBuilder.  Keeping the wrappers thin means LOGSUBS2 (UDP
+// broadcast) and uHamScore (RTC POST) emit identical canonical strings.
+function BuildSentExchange(const RXData: ContestExchange): AnsiString;
+begin
+   Result := XmlEscape(AnsiString(BuildSentExchangeText(RXData)));
+end;
+
+function BuildRxExchange(const RXData: ContestExchange): AnsiString;
+begin
+   Result := XmlEscape(AnsiString(BuildRxExchangeText(RXData)));
+end;
+
 // Render a <contactinfo> or <contactreplace> body for one QSO.
 // Used by HamScoreOnLog / HamScoreOnEdit on the main thread; the result
 // goes into TRTCContact.XmlBody and is held until CFM by the worker.
@@ -317,11 +331,13 @@ begin
     #9 + '<txfreq>' + AnsiString(IntToStr(txFreq)) + '</txfreq>' + sLineBreak +
     #9 + '<mode>' + MapModeForRTC(RXData) + '</mode>' + sLineBreak +
     #9 + '<call>' + XmlEscape(AnsiString(RXData.Callsign)) + '</call>' + sLineBreak +
-    #9 + '<SentExchange>' + XmlEscape(Trim(AnsiString(RXData.ExchString))) + '</SentExchange>' + sLineBreak +
-    #9 + '<RxExchange>'   + XmlEscape(Trim(AnsiString(RXData.ExchString))) + '</RxExchange>' + sLineBreak +
-    // RxExchange: TR4W does not store the received exchange string verbatim
-    // separate from the parsed fields; ExchString reflects what was typed.
-    // Spec tolerates a single exchange string; refine later if needed.
+    #9 + '<SentExchange>' + BuildSentExchange(RXData) + '</SentExchange>' + sLineBreak +
+    #9 + '<RxExchange>'   + BuildRxExchange(RXData)   + '</RxExchange>'   + sLineBreak +
+    // SentExchange: built from CQExchange template (LogCfg.pas) with '#'
+    // -> NumberSent and '5NN' -> '599'. RxExchange: rebuilt from parsed
+    // ContestExchange fields in canonical scoring order per contest so
+    // operator-typed order variations don't leak into the submission.
+    // Unsupported contests fall back to the raw operator-typed string.
     #9 + '<countryprefix>' + XmlEscape(AnsiString(RXData.QTH.CountryID)) + '</countryprefix>' + sLineBreak +
     #9 + '<wpxprefix>'     + XmlEscape(AnsiString(RXData.QTH.Prefix))    + '</wpxprefix>' + sLineBreak +
     #9 + '<continent>' + AnsiString(GetContinentName(RXData.QTH.Continent)) + '</continent>' + sLineBreak +
@@ -591,6 +607,11 @@ begin
     http.ReadTimeout            := 30000;
 
     try
+      if FLogger.IsTraceEnabled then
+         begin
+         FLogger.Trace('[HamScore] POST %s user=%s payload=%s',
+            [FURL, effectiveUser, string(xml)]);
+         end;
       http.Post(FURL, body, resp);
       Result := http.ResponseCode;
       responseBody := resp.DataString;

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -111,6 +111,7 @@ uses
   exportto_trlog in 'src\exportto_trlog.pas',
   uWSJTX in 'src\uWSJTX.pas',
   uHamScore in 'src\uHamScore.pas',
+  uExchangeBuilder in 'src\uExchangeBuilder.pas',
   uGridLookup in 'src\uGridLookup.pas',
   Log4D in 'src\Log4D.pas',
   uNetRadioBase in 'src\uNetRadioBase.pas',


### PR DESCRIPTION
## Summary

- **TRACE log** of outgoing HamScore RTC POST payload (URL, user, full XML), guarded by `IsTraceEnabled`.
- **New `uExchangeBuilder.pas`** with shared `BuildSentExchangeText` / `BuildRxExchangeText` used by both the HamScore RTC POST (`uHamScore.pas`) and the N1MM-style UDP ContactInfo broadcast (`LOGSUBS2.PAS`). `SentExchange` is rebuilt from the contest's `CQExchange` template (`#`→`NumberSent`, `5NN`→`599`). `RxExchange` is rebuilt from parsed `ContestExchange` fields in scoring-canonical order so operator-typed order variations (`EL88 1234` vs `1234 EL88`) don't leak into submissions.
- **X-QSO `All` column fix** in `MainUnit.pas` `LoadinLog`: the `inc(QSOTotals[AllBands, Both])` was outside the `ceXQSO` guard, so the score grid's `All` column counted X-QSO records while every per-band/per-mode counter correctly excluded them. Moved inside the guard. Issue #750 follow-up.

### Contests with canonical RxExchange

| Contest | Canonical order |
|---|---|
| CQ WPX CW/SSB, WAE CW | RST + serial |
| CQ WW CW/SSB, IARU | RST + zone |
| CQ 160 CW | RST + state/section |
| ARRL DX CW/SSB | RST + state (US) or RST + power (DX) |
| All Asian CW/SSB | RST + age |
| CWT (CWOps) | Name + member#/QTH |
| CWOpen | serial + Name |
| RTC | serial + grid |
| ARRL FD, Winter FD | class + section |

Unknown contests fall back to the raw operator-typed string — no regression vs. prior behaviour.

### Bugs fixed
1. **`<SentExchange>` echoed the received string** in both the HamScore RTC POST and the UDP ContactInfo broadcast (it copied `RXData.ExchString`, the operator-typed received exchange). Now it's built from `CQExchange` template + `NumberSent`.
2. **`<RxExchange>` / `<exchange1>` reflected operator-typed order** (e.g. `EL88 1234` for an RTC QSO where the operator copied grid before serial). Now canonicalized per contest.
3. **Score grid `All` column included X-QSO records** while per-band columns correctly excluded them (Issue #750 follow-up).

## Test plan

- [x] Build succeeds (`FullBuild.ps1`), all 773 unit tests pass
- [x] User confirmed the X-QSO `All`-column fix works on real log
- [x] User confirmed RTC `<RxExchange>` shows `serial + grid` for a QSO typed in either order
- [ ] Verify `<SentExchange>` shows `599 N MyState` (or contest-appropriate) for a representative QSO in CQ WPX, CQ WW, ARRL DX
- [ ] Verify `<exchange1>` UDP broadcast canonicalization with an N1MM-compatible consumer (e.g. DXKeeper)
- [ ] TRACE log shows full XML payload when `DEBUG LOG LEVEL = TRACE`