### PR TITLE
Uninit-locals fixes (CW-by-CAT + bandmap), TS-890 LAN keepalive + handshake, build zip step

### DIFF
--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -75,6 +75,50 @@ if ($result -eq 0) {
         Write-Host "  Size: $($exeInfo.Length) bytes" -ForegroundColor White
         Write-Host "  Modified: $($exeInfo.LastWriteTime)" -ForegroundColor White
         Write-Host ""
+
+        # ---------------------------------------------------------------
+        # Step 3: Zip the exe for distribution.
+        # The version + branch + timestamp filename means whack-a-mole test
+        # cycles with off-site testers never end up with two ambiguous
+        # "tr4w.exe" attachments sitting in the inbox.
+        # ---------------------------------------------------------------
+        $DIST_DIR = "C:\TR4W\tr4w\target\dist"
+        New-Item -ItemType Directory -Force -Path $DIST_DIR | Out-Null
+
+        # Extract version from Version.pas (e.g. 4.147.15)
+        $versionLine = Select-String -Path "C:\TR4W\tr4w\src\Version.pas" `
+                                     -Pattern "TR4W_CURRENTVERSION_NUMBER\s*=\s*'([^']+)'" `
+                                     | Select-Object -First 1
+        if ($versionLine -and $versionLine.Matches[0].Groups[1].Value) {
+            $version = $versionLine.Matches[0].Groups[1].Value
+        } else {
+            $version = "unknown"
+        }
+
+        # Current git branch (slash-safe for filenames)
+        $branchRaw = (git -C "C:\TR4W" rev-parse --abbrev-ref HEAD 2>$null)
+        if ($LASTEXITCODE -ne 0 -or -not $branchRaw) {
+            $branch = "nobranch"
+        } else {
+            $branch = $branchRaw.Trim() -replace '[/\\:*?"<>|]', '-'
+        }
+
+        $stamp   = Get-Date -Format "yyyyMMdd-HHmmss"
+        $zipName = "tr4w-$version-$branch-$stamp.zip"
+        $zipPath = Join-Path $DIST_DIR $zipName
+
+        Write-Host "=== Packaging EXE ===" -ForegroundColor Cyan
+        Write-Host "Archive: $zipPath" -ForegroundColor Yellow
+
+        Compress-Archive -Path "$EXE_DIR\tr4w.exe" -DestinationPath $zipPath -Force
+        if (Test-Path $zipPath) {
+            $zipInfo = Get-Item $zipPath
+            Write-Host "  Size: $($zipInfo.Length) bytes" -ForegroundColor White
+            Write-Host ""
+        } else {
+            Write-Host "  ZIP STEP FAILED -- archive not created" -ForegroundColor Red
+            Write-Host ""
+        }
     }
 } else {
     Write-Host "=== BUILD FAILED ===" -ForegroundColor Red

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -2338,6 +2338,18 @@ begin
       begin
       exit;   // No need to be here if radio does not support CWBYCAT and not active
       end;
+   // Delphi 7 does NOT initialize stack-allocated locals. Without these two
+   // explicit defaults, `charProcessed` and `sendNow` carried whatever bytes
+   // happened to be on the stack from prior calls. If `charProcessed`
+   // was non-zero on entry, the `if not charProcessed` guard near the bottom
+   // of the rtKenwood block would short-circuit and the letter would never
+   // be appended to CWByCATBuffer -- so by the time the terminator arrived
+   // the buffer was empty, the assembly path ran on a zero-length string,
+   // and no KY command was emitted. Per-char debug output ("Adding (N)...")
+   // appeared because that log happens BEFORE the buffer append.
+   charProcessed := False;
+   sendNow       := False;
+
    // scWK_Reset;    // n4af 4.46.3  // ny4i This would not be necessary as this code is in the radio object. It is ONLY used by CWByCAT.
    localMsg := Msg;
 

--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -4616,6 +4616,15 @@ begin
 
 
   CurCursorPosData := GetBMSelItemData;
+  // Delphi 7 does not zero stack-allocated locals. Without this default,
+  // CurrentCursorPos was only assigned inside the band/mode/entry loops
+  // when an entry matched CurCursorPosData -- and was then passed to
+  // tLB_SETCURSEL unconditionally at the bottom of the procedure. If no
+  // entry matched (bandmap repopulated, prior selection expired, dupe
+  // filter toggled, frequency walked off) the listbox cursor landed on
+  // whatever was on the stack. -1 is the LB_SETCURSEL convention for
+  // "no selection".
+  CurrentCursorPos := -1;
 
   //  if not DoNotAddToBandMap then
   begin

--- a/tr4w/src/uRadioKenwoodTS890.pas
+++ b/tr4w/src/uRadioKenwoodTS890.pas
@@ -37,6 +37,7 @@ type
       ksNone,
       ksWaitingForCN,    // Sent ##CN;, awaiting ##CN1
       ksWaitingForID,    // Sent ##ID0...;, awaiting ##ID1
+      ksWaitingForTI,    // Got ##ID1, awaiting ##UE/##TI to finish handshake
       ksAuthenticated,   // Auth complete; normal Kenwood CAT
       ksAuthFailed       // Auth was rejected; connection unusable
    );
@@ -56,6 +57,10 @@ type TKenwoodTS890Radio = class(TNetRadioBase)
       procedure ParseFAOrFBResponse(const sMessage: string; whichVFO: TVFO);
       procedure ParseOMResponse(const sMessage: string);
       procedure ParseKSResponse(const sMessage: string);
+      procedure ParseTBResponse(const sMessage: string);
+      procedure ParseFTResponse(const sMessage: string);
+      procedure ParseRTResponse(const sMessage: string);
+      procedure ParseXTResponse(const sMessage: string);
 
    public
       NetworkUsername: ShortString;   // Set by LOGRADIO before Connect; "Admin ID" on the radio
@@ -129,11 +134,17 @@ begin
    NetworkUsername := '';
    NetworkPassword := '';
 
-   // TS-890 uses AI2 for full push updates of frequency, mode, split etc.
-   // No periodic polling needed once authenticated.
-   requiresPolling := False;
+   // TS-890 uses AI2 for state push, but the LAN protocol REQUIRES
+   // periodic traffic from the client. Per the LAN HOWTO:
+   //   "The TS-890 will close the TCP connection if it does not receive
+   //    any data for 10 seconds. ... send the PS; command every 5 seconds"
+   // (This is what Kenwood's own ARCP software does.)
+   // So we poll PS; at 5-second intervals purely as a keepalive heartbeat;
+   // the response is discarded. Without this, the radio drops us ~10s
+   // after auth completes and any AI2 push state stops arriving.
+   requiresPolling := True;
    autoUpdateCommand := 'AI2;';
-   pollingInterval := 0;
+   pollingInterval := 5000;
 end;
 
 Destructor TKenwoodTS890Radio.Destroy;
@@ -220,10 +231,13 @@ begin
       begin
       if AnsiStartsStr('##ID1', sMessage) then
          begin
-         FAuthState := ksAuthenticated;
-         logger.Info('[%s.HandleAuthMessage] Authenticated successfully',
+         // Per LAN HOWTO: after ##ID1 the radio also sends ##UE1; and
+         // ##TI1; (often batched on the same TCP segment). The radio is
+         // not ready for CAT until it has sent ##TI1; -- so don't fire
+         // InitializeAfterAuth yet; wait for ##TI in ksWaitingForTI.
+         FAuthState := ksWaitingForTI;
+         logger.Info('[%s.HandleAuthMessage] Credentials accepted; awaiting ##TI handshake',
                      [Self.rigLabel]);
-         InitializeAfterAuth;
          end
       else
          begin
@@ -231,6 +245,29 @@ begin
          logger.Error('[%s.HandleAuthMessage] AUTH FAILED -- radio responded: %s',
                       [Self.rigLabel, sMessage]);
          end;
+      Exit;
+      end;
+
+   if FAuthState = ksWaitingForTI then
+      begin
+      // ##UE1; arrives between ##ID and ##TI -- just log it and keep waiting.
+      if AnsiStartsStr('##UE', sMessage) then
+         begin
+         logger.Debug('[%s.HandleAuthMessage] Received %s; awaiting ##TI',
+                      [Self.rigLabel, sMessage]);
+         Exit;
+         end;
+      if AnsiStartsStr('##TI', sMessage) then
+         begin
+         FAuthState := ksAuthenticated;
+         logger.Info('[%s.HandleAuthMessage] Authenticated and CAT-ready (%s)',
+                     [Self.rigLabel, sMessage]);
+         InitializeAfterAuth;
+         Exit;
+         end;
+      // Other ## frames while waiting for TI -- log and keep waiting.
+      logger.Debug('[%s.HandleAuthMessage] Unexpected post-ID frame: %s',
+                   [Self.rigLabel, sMessage]);
       Exit;
       end;
 end;
@@ -300,6 +337,19 @@ begin
       ParseOMResponse(sMessage)
    else if AnsiStartsStr('KS', sMessage) then
       ParseKSResponse(sMessage)
+   else if AnsiStartsStr('TB', sMessage) then
+      ParseTBResponse(sMessage)
+   else if AnsiStartsStr('FT', sMessage) then
+      ParseFTResponse(sMessage)
+   else if AnsiStartsStr('RT', sMessage) then
+      ParseRTResponse(sMessage)
+   else if AnsiStartsStr('XT', sMessage) then
+      ParseXTResponse(sMessage)
+   else if AnsiStartsStr('PS', sMessage) then
+      // Keepalive heartbeat response (PS1; = power on). No state to track;
+      // the round-trip itself is what keeps the LAN connection from being
+      // dropped by the radio's 10-second idle timeout.
+      logger.Trace('[%s.ProcessMessage] Keepalive ack: %s', [Self.rigLabel, sMessage])
    else if AnsiStartsStr('ID', sMessage) then
       begin
       // ID024 = TS-890S. Anything else means we connected to the wrong radio.
@@ -311,8 +361,6 @@ begin
       end
    else
       begin
-      // Other replies (RT, XT, TB, FT, etc.) -- logged for now, parsed in
-      // follow-up work as we wire up more state into TNetRadioBase.
       logger.Trace('[%s.ProcessMessage] Unhandled reply: %s', [Self.rigLabel, sMessage]);
       end;
 end;
@@ -401,6 +449,45 @@ begin
       end;
 end;
 
+// Format: TB<0|1>;  -- 0 = split off, 1 = split on.
+// TS-890 Split is a global on/off flag separate from FR/FT VFO selection.
+procedure TKenwoodTS890Radio.ParseTBResponse(const sMessage: string);
+begin
+   if Length(sMessage) < 3 then Exit;
+   Self.localSplitEnabled := (sMessage[3] = '1');
+   logger.Trace('[%s.ParseTBResponse] Split = %s',
+                [Self.rigLabel, BoolToStr(Self.localSplitEnabled, True)]);
+end;
+
+// Format: FT<0|1>;  -- 0 = VFO A is TX, 1 = VFO B is TX.
+// We don't track an explicit TX VFO field today; surface it in the log so the
+// state is at least visible. Wire it into TNetRadioBase when split-VFO support
+// gets fleshed out.
+procedure TKenwoodTS890Radio.ParseFTResponse(const sMessage: string);
+begin
+   if Length(sMessage) < 3 then Exit;
+   logger.Trace('[%s.ParseFTResponse] TX VFO = %s',
+                [Self.rigLabel, IfThen(sMessage[3] = '1', 'B', 'A')]);
+end;
+
+// Format: RT<0|1>;  -- 0 = RIT off, 1 = RIT on.
+procedure TKenwoodTS890Radio.ParseRTResponse(const sMessage: string);
+begin
+   if Length(sMessage) < 3 then Exit;
+   Self.RITState := (sMessage[3] = '1');
+   logger.Trace('[%s.ParseRTResponse] RIT = %s',
+                [Self.rigLabel, BoolToStr(Self.RITState, True)]);
+end;
+
+// Format: XT<0|1>;  -- 0 = XIT off, 1 = XIT on.
+procedure TKenwoodTS890Radio.ParseXTResponse(const sMessage: string);
+begin
+   if Length(sMessage) < 3 then Exit;
+   Self.XITState := (sMessage[3] = '1');
+   logger.Trace('[%s.ParseXTResponse] XIT = %s',
+                [Self.rigLabel, BoolToStr(Self.XITState, True)]);
+end;
+
 // ============================================================================
 // Mode mapping (TS-890 PC Command Reference, OM command P2 values)
 // ============================================================================
@@ -458,9 +545,12 @@ end;
 procedure TKenwoodTS890Radio.PollRadioState;
 begin
    if FAuthState <> ksAuthenticated then Exit;
-   // AI2 pushes most state; periodic poll of TX status is enough to detect
-   // hung-PTT scenarios. Reuse the inherited behaviour by default.
-   inherited;
+   // LAN-only requirement: the TS-890 closes the TCP connection if it
+   // receives nothing from us for 10 seconds. ARCP and other Kenwood-
+   // documented clients send PS; every 5 seconds as a heartbeat. The
+   // response is just PS1; (power on) and is discarded. AI2 pushes
+   // everything else, so this is keepalive only -- no real polling.
+   Self.SendToRadio('PS;');
 end;
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Four independent improvements gathered onto one branch:

### 1. Fix uninitialized-locals bug in `RadioObject.SendCW` — Kenwood/Elecraft CW-by-CAT
`charProcessed` and `sendNow` were declared but never initialized at function entry. Delphi 7 does not zero stack-allocated locals, so they carried whatever was on the stack from prior calls. When `charProcessed` happened to be non-zero on entry, the `if not charProcessed` guard at the bottom of the rtKenwood case skipped the append, so individual letters never made it into `CWByCATBuffer`. By the time the terminator arrived the buffer was empty and no `KY` command went out. Symptom: per-char `[AddStringToBuffer] Adding (N) to CW Buffer` debug logs appear, then `Assembling CW message to send`, then nothing. Affects all Kenwood and Elecraft radios using CW-by-CAT. Surfaced testing RTC mode with a K4 over TCP.

### 2. Fix uninitialized `CurrentCursorPos` in bandmap repaint (`LOGWIND.PAS`)
Same signature as #1. Found via a code audit after the SendCW fix. `CurrentCursorPos` was only assigned inside the band/mode/entry loops when a row matched the previously-selected cursor entry, then passed unconditionally to `tLB_SETCURSEL` at the bottom of the procedure. When no row matched (entry expired, dupe filter toggled, frequency walked off, bandmap repopulated) the listbox cursor was set to stack garbage. Fix: initialise to `-1` (LB_SETCURSEL "no selection") right after the cursor-pointer read.

### 3. TS-890 LAN: `PS;` keepalive every 5s + wait for `##TI;` before init + parse TB/FT/RT/XT
Three fixes for the Kenwood TS-890 LAN protocol per the [open890 LAN-HOWTO](https://github.com/open890/kenwood-ts890/blob/main/LAN-HOWTO.md) and an audit against `simts890.c`:
- **`PS;` keepalive every 5 seconds.** The TS-890 closes its LAN TCP connection after 10 seconds of client silence. AI2 only pushes state outbound; the radio needs traffic *from* us. Kenwood's own ARCP sends `PS;` every 5 s. Match that with `requiresPolling=True`, `pollingInterval=5000`, `PollRadioState` sending `PS;`, and a `PS` dispatch case that no-ops the reply (the round-trip itself is the keepalive). Without this, the radio dropped us ~10 s after auth.
- **Wait for `##TI;` before sending CAT.** Per the HOWTO, after `##ID1;` the radio batches `##ID1;##UE1;##TI1;` and only considers itself CAT-ready after `##TI1;`. We were firing `InitializeAfterAuth` on `##ID1;`. New `ksWaitingForTI` auth state handles `##UE` (log + ignore) and `##TI` (promote to authenticated, run init).
- **Parse TB/FT/RT/XT responses.** These four queries were sent in the init burst but their responses landed in the `Unhandled reply` trace bucket. Now parsed: `TB` → `localSplitEnabled`, `RT` → `RITState`, `XT` → `XITState`. `FT` (TX VFO) logged for visibility until a per-radio TX-VFO field exists.

### 4. `FullBuild.ps1`: zip the exe into `target/dist/` on successful build
Drops `tr4w-<version>-<branch>-<YYYYMMDD-HHMMSS>.zip` next to `target/tr4w.exe`. Use case: iterative bug-hunting with off-site testers (radio bugs where the developer doesn't have the hardware locally) where three rounds of `tr4w.exe` attachments in an inbox get ambiguous. `target/dist/` is already covered by the existing `tr4w/target/*` gitignore.

## Commits

- `5b75b94` Fix uninitialized-locals bug in `RadioObject.SendCW`
- `51bfa67` Fix uninitialized `CurrentCursorPos` in bandmap repaint
- `21df4a1` TS-890 LAN: keepalive + `##TI` wait + TB/FT/RT/XT parsers
- `8ef238a` `FullBuild.ps1`: post-build zip step

## Test plan

- [x] `FullBuild.ps1` runs all 773 unit tests + main build green
- [x] Local CW-by-CAT verified working on K4/TCP — `KY <call>;` reaches the radio (was completely broken before fix #1)
- [ ] TS-890 LAN fixes (#3) tested with real hardware by N2SKH — the radio he was testing previously dropped ~20s after auth; with `PS;` keepalive the connection should stay up and state queries should populate VFO B / mode / split / RIT / XIT
- [ ] Bandmap repaint cursor (fix #2) tested on a live log — selection no longer jumps after a repaint when previous selection has aged out / filter changed
- [x] `target/dist/<versioned-zip>.zip` produced on each successful build, ignored by git