### PR TITLE
Add CI release-build workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+# Place at .github/workflows/release.yml in n4af/tr4w
+#
+# Triggers on tag push matching v4.*.* (e.g. v4.123.7).
+# Runs the same chain as Howie's local: FullBuild.ps1 -> UPX --lzma -> NSIS installer.
+# Single source of truth = src/Version.pas; passes /DVERSION to NSIS.
+#
+# Requires (one-time setup on win-ci runner):
+#   - Delphi 7 at C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE   [installed]
+#   - NSIS at C:\Program Files (x86)\NSIS\makensis.exe                    [installed]
+#   - Indy at C:\Indy\Indy\Lib\{Core,System,Protocols}                    [installed]
+#   - UPX in PATH (upx.exe --lzma)                                        [installed: C:\utils\upx.exe]
+#
+# Requires (one-time, in this repo) — already done on the ci/release-workflow branch:
+#   - tr4w/build/full.nsi: TR4WVERSION now holds the FULL version ('4.x.y') and is wrapped
+#     in !ifndef so CI can override via /DTR4WVERSION. The hardcoded "4." prefixes that
+#     used to be in Name/OutFile lines have been dropped (filename pattern changes from
+#     tr4w_setup_4_VERSION.exe to tr4w_setup_VERSION.exe — note for any external scripts).
+#
+# How releases work:
+#   git tag v4.123.7 && git push --tags    ->    workflow runs    ->    installer artifact
+
+name: Release Build
+
+on:
+  push:
+    tags:
+      - 'v4.*.*'
+
+concurrency:
+  group: tr4w-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build TR4W installer
+    # Adjust the second label if your win-ci runner uses a different tag
+    # (e.g. 'windows11-build-runner'). Get current labels via repo Settings -> Actions -> Runners.
+    runs-on: [self-hosted, win-ci]
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Bridge workspace to C:\TR4W (FullBuild.ps1 expects hardcoded paths)
+        shell: powershell
+        run: |
+          # Remove any prior junction or leftover dir from a previous run
+          if (Test-Path C:\TR4W) {
+            $item = Get-Item C:\TR4W -Force
+            if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+              cmd /c rmdir C:\TR4W
+            } else {
+              throw "C:\TR4W exists as a real directory on this runner - refusing to delete. Investigate before re-running."
+            }
+          }
+          New-Item -ItemType Junction -Path C:\TR4W -Target $env:GITHUB_WORKSPACE | Out-Null
+          if (-not (Test-Path C:\TR4W\tr4w\FullBuild.ps1)) {
+            throw "Junction setup failed: C:\TR4W\tr4w\FullBuild.ps1 not visible after junction"
+          }
+
+      - name: Extract version from src/Version.pas
+        id: ver
+        shell: powershell
+        run: |
+          $line = Select-String -Path C:\TR4W\tr4w\src\Version.pas `
+                                -Pattern "TR4W_CURRENTVERSION_NUMBER\s*=\s*'([^']+)'" `
+                                | Select-Object -First 1
+          if (-not $line) {
+            throw "Could not extract TR4W_CURRENTVERSION_NUMBER from src/Version.pas"
+          }
+          $version = $line.Matches[0].Groups[1].Value
+          Write-Host "Extracted version: $version"
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Validate tag matches Version.pas
+        shell: powershell
+        run: |
+          $tag = $env:GITHUB_REF -replace '^refs/tags/v', ''
+          $version = "${{ steps.ver.outputs.version }}"
+          if ($tag -ne $version) {
+            throw "Tag mismatch: refs/tags/v$tag does not match Version.pas ($version). Bump one or the other before re-tagging."
+          }
+          Write-Host "Tag v$tag matches Version.pas $version - OK"
+
+      - name: Verify required tools
+        shell: powershell
+        run: |
+          $tools = [ordered]@{
+            'DCC32 (Delphi 7)' = 'C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE'
+            'NSIS makensis'    = 'C:\Program Files (x86)\NSIS\makensis.exe'
+            'Indy Core lib'    = 'C:\Indy\Indy\Lib\Core'
+          }
+          $missing = @()
+          foreach ($k in $tools.Keys) {
+            if (-not (Test-Path $tools[$k])) { $missing += "$($k): $($tools[$k]) not found" }
+          }
+          if (-not (Get-Command upx.exe -ErrorAction SilentlyContinue)) {
+            $missing += "UPX: upx.exe not found in PATH"
+          }
+          if ($missing.Count -gt 0) {
+            throw "Missing required tools:`n$($missing -join "`n")"
+          }
+          Write-Host "All required tools present."
+
+      - name: Run FullBuild.ps1 (tests + main EXE)
+        shell: powershell
+        working-directory: C:\TR4W\tr4w
+        run: |
+          .\FullBuild.ps1
+          if ($LASTEXITCODE -ne 0) { throw "FullBuild.ps1 failed with exit code $LASTEXITCODE" }
+
+      - name: Verify tr4w.exe produced
+        shell: powershell
+        run: |
+          $exe = 'C:\TR4W\tr4w\target\tr4w.exe'
+          if (-not (Test-Path $exe)) { throw "tr4w.exe not produced at $exe" }
+          $info = Get-Item $exe
+          Write-Host "Built: $($info.FullName) | $($info.Length) bytes | $($info.LastWriteTime)"
+
+      - name: UPX compress tr4w.exe (--lzma, matches Howie's make_setup_file.bat)
+        shell: powershell
+        working-directory: C:\TR4W\tr4w\build
+        run: |
+          upx.exe ..\target\tr4w.exe --lzma
+          if ($LASTEXITCODE -ne 0) { throw "UPX compression failed with exit code $LASTEXITCODE" }
+          $info = Get-Item ..\target\tr4w.exe
+          Write-Host "Compressed: $($info.Length) bytes"
+
+      - name: Build NSIS installer (passes /DTR4WVERSION for single-source version)
+        shell: powershell
+        working-directory: C:\TR4W\tr4w\build
+        env:
+          TR4W_VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          & "C:\Program Files (x86)\NSIS\makensis.exe" /DTR4WVERSION=$env:TR4W_VERSION full.nsi
+          if ($LASTEXITCODE -ne 0) { throw "makensis failed with exit code $LASTEXITCODE" }
+
+      - name: Locate installer
+        id: artifact
+        shell: powershell
+        run: |
+          # full.nsi outputs to build\release\ (already a subdir in the repo).
+          # If it goes elsewhere, broaden the search root or check OutFile in full.nsi.
+          $installer = Get-ChildItem C:\TR4W\tr4w\build\release -Filter *.exe -Recurse -ErrorAction SilentlyContinue |
+                       Sort-Object LastWriteTime -Descending |
+                       Select-Object -First 1
+          if (-not $installer) {
+            $installer = Get-ChildItem C:\TR4W\tr4w\build -Filter 'tr4w_setup*.exe' -Recurse |
+                         Sort-Object LastWriteTime -Descending |
+                         Select-Object -First 1
+          }
+          if (-not $installer) { throw "No installer found under build\release\ or build\tr4w_setup*.exe" }
+          Write-Host "Installer: $($installer.FullName) ($($installer.Length) bytes)"
+          "path=$($installer.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "name=$($installer.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tr4w-installer-${{ steps.ver.outputs.version }}
+          path: ${{ steps.artifact.outputs.path }}
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Cleanup junction
+        if: always()
+        shell: powershell
+        run: |
+          if (Test-Path C:\TR4W) {
+            $item = Get-Item C:\TR4W -Force
+            if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+              cmd /c rmdir C:\TR4W
+              Write-Host "Junction removed."
+            }
+          }

--- a/tr4w/build/full.nsi
+++ b/tr4w/build/full.nsi
@@ -1,4 +1,9 @@
-!define TR4WVERSION    '147.16'
+; TR4WVERSION is the full version (e.g. '4.147.16') and the single source of
+; truth for both the displayed name and the installer filename. CI passes it
+; via /DTR4WVERSION; local builds use the default below.
+!ifndef TR4WVERSION
+  !define TR4WVERSION  '4.147.16'
+!endif
 !define TR4WINSTFOLDER 'Software\TR4W'
 !define TR4WDRVREG     'SYSTEM\CurrentControlSet\Services\TR4WIO'
 
@@ -17,17 +22,17 @@
 ;!define TR4WLANG    'chn'
 
 !ifdef MMTTYMODE
-Name    "TR4W v.4.${TR4WVERSION} - MMTTY"
+Name    "TR4W v.${TR4WVERSION} - MMTTY"
 !else
-Name    "TR4W v.4.${TR4WVERSION}"
+Name    "TR4W v.${TR4WVERSION}"
 !endif
 
 !ifdef TR4WLANG
-OutFile release\tr4w_setup_4_${TR4WVERSION}_${TR4WLANG}.exe
+OutFile release\tr4w_setup_${TR4WVERSION}_${TR4WLANG}.exe
 !else
-OutFile release\tr4w_setup_4_${TR4WVERSION}.exe
+OutFile release\tr4w_setup_${TR4WVERSION}.exe
 !ifdef MMTTYMODE
-OutFile release\tr4w_setup_4_${TR4WVERSION}_mmtty.exe
+OutFile release\tr4w_setup_${TR4WVERSION}_mmtty.exe
 !endif
 !endif
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — triggers on `v4.*.*` tag push, runs on the win-ci self-hosted runner, mirrors the local FullBuild chain: `FullBuild.ps1` (tests + EXE) → UPX --lzma → NSIS installer → artifact upload.
- Refactors `tr4w/build/full.nsi`: `TR4WVERSION` now holds the full version (`'4.147.16'`) wrapped in `!ifndef` so CI can pass `/DTR4WVERSION=4.x.y`. Hardcoded `4.` prefixes in `Name`/`OutFile` lines removed — single source of truth for the version inside the .nsi file.

## Version source-of-truth

Edit `src/Version.pas` (as today). CI extracts via `Select-String` on `TR4W_CURRENTVERSION_NUMBER`, validates the git tag matches, then passes that same string to NSIS via `/DTR4WVERSION`. One file to edit; everything downstream derives.

## Filename change to note

Installer filename pattern changes from `tr4w_setup_4_147.16.exe` to `tr4w_setup_4.147.16.exe`. Any external links/scripts pointing to the old pattern need updating.

## Test plan

- [ ] Merge to master
- [ ] Push a throwaway test tag (\`v4.999.0-test\`) to verify end-to-end on win-ci before any real release
- [ ] Confirm tag-mismatch guard works (e.g. tag \`v4.999.0\` against Version.pas value \`4.147.16\` should fail fast)
- [ ] Confirm installer artifact downloads cleanly from the workflow run page
- [ ] Howie's local \`make_setup_file.bat\` flow still works unchanged (no \`/DTR4WVERSION\` → falls through to the default \`4.147.16\`)