### PR TITLE
VC.pas: derive LANG const from -DLANG_xxx compiler flags

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -144,21 +144,33 @@ const
   MORSERUNNER                           = False;
   ICOM_LONG_MODECOMMAND                 = True ;
 
+// LANG is selected by passing -DLANG_xxx to DCC32 (e.g. -DLANG_RUS).
+// Default is ENG when no LANG_xxx is defined, so local builds work unchanged.
+{$IFDEF LANG_ENG}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_RUS}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_SER}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_ESP}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_MNG}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_POL}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_CZE}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_ROM}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_CHN}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_GER}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFDEF LANG_UKR}{$DEFINE _LANG_SET}{$ENDIF}
+{$IFNDEF _LANG_SET}{$DEFINE LANG_ENG}{$ENDIF}
+
 const
-         LANG                                  = 'ENG';
-//        LANG                                  = 'RUS';
-//      LANG                                  = 'MNG';
-//        LANG                                  = 'CZE';
-//        LANG                                  = 'SER';
-//         LANG                                  = 'ROM';
-//      LANG                                  = 'GER';
-//        LANG                                  = 'UKR';
-// not implemented
-
-
-//       LANG                                  = 'ESP';
-//       LANG                                  = 'CHN';
-//       LANG                                  = 'POL';
+{$IFDEF LANG_ENG}  LANG = 'ENG';{$ENDIF}
+{$IFDEF LANG_RUS}  LANG = 'RUS';{$ENDIF}
+{$IFDEF LANG_SER}  LANG = 'SER';{$ENDIF}
+{$IFDEF LANG_ESP}  LANG = 'ESP';{$ENDIF}
+{$IFDEF LANG_MNG}  LANG = 'MNG';{$ENDIF}
+{$IFDEF LANG_POL}  LANG = 'POL';{$ENDIF}
+{$IFDEF LANG_CZE}  LANG = 'CZE';{$ENDIF}
+{$IFDEF LANG_ROM}  LANG = 'ROM';{$ENDIF}
+{$IFDEF LANG_CHN}  LANG = 'CHN';{$ENDIF}
+{$IFDEF LANG_GER}  LANG = 'GER';{$ENDIF}
+{$IFDEF LANG_UKR}  LANG = 'UKR';{$ENDIF}
 {$IF LANG = 'ENG'}{$INCLUDE lang\tr4w_consts_eng.pas}{$IFEND}
 {$IF LANG = 'RUS'}{$INCLUDE lang\tr4w_consts_rus.pas} {$IFEND}
 {$IF LANG = 'SER'}{$INCLUDE lang\tr4w_consts_ser.pas}{$IFEND}

--- a/tr4w/src/lang/tr4w_consts_rus.pas
+++ b/tr4w/src/lang/tr4w_consts_rus.pas
@@ -217,7 +217,7 @@ const
 
   TC_FAILEDTOCONNECTTOGETSCORESORG      = 'Не удалось соединиться с сервером';
   TC_NOANSWERFROMSERVER                 = 'Нет ответа от сервера';
-//  TC_UPLOADEDSUCCESSFULLY               = 'Загружено успешно.';
+    TC_UPLOADEDSUCCESSFULLY               = 'Загружено успешно.';
 //  TC_FAILEDTOLOAD                       = 'НЕ УДАЛОСЬ ЗАГРУЗИТЬ. Смотрите GETSCORESANSWER.HTML для уточнения.';
 
   {UBANDMAP}


### PR DESCRIPTION
## Summary

Replace the hand-edited `const LANG = 'ENG';` in `VC.pas` with `{$IFDEF LANG_xxx}` dispatch so DCC32 can pick the language via a `-D` flag.

Defaults to `LANG_ENG` if no `LANG_xxx` is defined, so:
- Local builds (FullBuild.ps1, BatchCompile.cmd, IDE) keep working unchanged.
- CI can pass `-DLANG_RUS`, `-DLANG_SER`, etc. per matrix job in a future PR.

## Why this approach

`LANG` is a string `const` evaluated by `{$IF LANG = 'RUS'}` directives (string compare). DCC32's `-D` flag defines boolean conditional symbols and cannot redefine a string-valued const. The IFDEF cascade in this PR sets the const based on which flag is defined, so every existing `{$IF LANG = 'RUS'}` directive across the codebase (~50 sites in 17 files) continues to work unchanged.

**Only `tr4w/src/VC.pas` is restructured.** One additional translation-restore touch in `tr4w_consts_rus.pas` (see below).

## Latent bug exposed and fixed in this PR

The `-DLANG_RUS` test build failed on the first attempt with:

```
src\uGetScores.pas(186) Error: Undeclared identifier: 'TC_UPLOADEDSUCCESSFULLY'
```

`TC_UPLOADEDSUCCESSFULLY` is referenced unconditionally at `uGetScores.pas:186` (the "score upload succeeded" code path) but had been commented out in `tr4w_consts_rus.pas:220`. Nobody noticed because `LANG` was hardcoded to `'ENG'` in master — Russian was never actually compiled.

This PR restores the Russian translation (one-line uncomment). Audit of other commented-out constants in `tr4w_consts_rus.pas` confirmed no other unconditionally-referenced identifiers are affected.

Same class of issue exists in `tr4w_consts_ukr.pas` for `TC_UPLOADEDSUCCESSFULLY` and `TC_TELNET` — left for a follow-up PR when UKR enters the CI matrix.

## Validation

Test-built on win-ci from this branch with full rebuild (`-B`):

|  | ENG | RUS | Δ |
|---|---|---|---|
| lines compiled | 463,541 | 463,517 | -24 |
| compile time | 328s | 328s | same |
| code bytes | 1,518,180 | 1,520,576 | +2,396 |
| data bytes | 411,893 | 411,945 | +52 |
| **exe size** | **1,833,984** | **1,855,488** | **+21,504** |

The exe size delta (~21KB) proves it's a true differentiated build — different Russian strings compiled in, different `.res` file embedded, RUS-only `{$IF LANG = 'RUS'}` code blocks in `uTelnet`, `MainUnit`, etc. now active.

## What this PR does NOT do

- No CI matrix changes. `release.yml` continues to build ENG only. A future PR adds `strategy.matrix.lang` to the release workflow and passes `-DLANG_xxx` to DCC32 per job.
- No changes to NSIS installer (`full.nsi`) — already accepts `/DTR4WLANG=xxx` for per-language installer naming.
- No changes to the 50+ `{$IF LANG = 'XXX'}` directive sites in 17 other files. They continue to work via the const value.
- UKR translation gap not fixed here.

## Test plan

- [x] Default build on win-ci with no `-D` flag → ENG behavior preserved
- [x] `-DLANG_RUS` build on win-ci → compiles clean, produces a differentiated EXE
- [ ] Manual: launch the default-built EXE locally, confirm UI strings are English (regression check vs current master)
- [ ] Manual: launch the `-DLANG_RUS` EXE, confirm Russian UI renders correctly (not just compiled — actually displays)