### PR TITLE
Parameterized local build + per-language DCU caching + installer mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,12 @@
 # Runs the same chain as Howie's local: FullBuild.ps1 -> UPX --lzma -> NSIS installer.
 # Single source of truth = src/Version.pas; passes /DVERSION to NSIS.
 #
-# Requires (one-time setup on win-ci runner):
-#   - Delphi 7 at C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE   [installed]
-#   - NSIS at C:\Program Files (x86)\NSIS\makensis.exe                    [installed]
-#   - Indy at C:\Indy\Indy\Lib\{Core,System,Protocols}                    [installed]
-#   - UPX in PATH (upx.exe --lzma)                                        [installed: C:\utils\upx.exe]
-#
-# Requires (one-time, in this repo) — already done on the ci/release-workflow branch:
-#   - tr4w/build/full.nsi: TR4WVERSION now holds the FULL version ('4.x.y') and is wrapped
-#     in !ifndef so CI can override via /DTR4WVERSION. The hardcoded "4." prefixes that
-#     used to be in Name/OutFile lines have been dropped (filename pattern changes from
-#     tr4w_setup_4_VERSION.exe to tr4w_setup_VERSION.exe — note for any external scripts).
+# Runner setup (one-time on self-hosted win-ci runner):
+#   - Delphi 7 (DCC32.EXE) -- default install path C:\Program Files (x86)\Borland\Delphi7\Bin\.
+#     Override per-runner by setting repo variable DELPHI7_BIN.
+#   - NSIS (makensis.exe)  -- default C:\Program Files (x86)\NSIS\. Override with NSIS_BIN.
+#   - Indy 10 lib          -- default C:\Indy\Indy\Lib\. Override with INDY_ROOT.
+#   - UPX                  -- must be in PATH (upx.exe --lzma).
 #
 # How releases work:
 #   git tag v4.123.7 && git push --tags    ->    workflow runs    ->    installer artifact
@@ -30,11 +25,16 @@ concurrency:
   group: tr4w-release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # Toolchain locations. Override via repo Settings -> Variables -> Actions
+  # to point at non-default installs without editing this file.
+  DELPHI7_BIN: ${{ vars.DELPHI7_BIN || 'C:\Program Files (x86)\Borland\Delphi7\Bin' }}
+  NSIS_BIN:    ${{ vars.NSIS_BIN    || 'C:\Program Files (x86)\NSIS' }}
+  INDY_ROOT:   ${{ vars.INDY_ROOT   || 'C:\Indy\Indy\Lib' }}
+
 jobs:
   build:
     name: Build TR4W installer
-    # Adjust the second label if your win-ci runner uses a different tag
-    # (e.g. 'windows11-build-runner'). Get current labels via repo Settings -> Actions -> Runners.
     runs-on: [self-hosted, win-ci]
     timeout-minutes: 30
 
@@ -42,28 +42,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v5
 
-      - name: Bridge workspace to C:\TR4W (FullBuild.ps1 expects hardcoded paths)
-        shell: powershell
-        run: |
-          # Remove any prior junction or leftover dir from a previous run
-          if (Test-Path C:\TR4W) {
-            $item = Get-Item C:\TR4W -Force
-            if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-              cmd /c rmdir C:\TR4W
-            } else {
-              throw "C:\TR4W exists as a real directory on this runner - refusing to delete. Investigate before re-running."
-            }
-          }
-          New-Item -ItemType Junction -Path C:\TR4W -Target $env:GITHUB_WORKSPACE | Out-Null
-          if (-not (Test-Path C:\TR4W\tr4w\FullBuild.ps1)) {
-            throw "Junction setup failed: C:\TR4W\tr4w\FullBuild.ps1 not visible after junction"
-          }
-
       - name: Extract version from src/Version.pas
         id: ver
         shell: powershell
         run: |
-          $line = Select-String -Path C:\TR4W\tr4w\src\Version.pas `
+          $line = Select-String -Path "$env:GITHUB_WORKSPACE\tr4w\src\Version.pas" `
                                 -Pattern "TR4W_CURRENTVERSION_NUMBER\s*=\s*'([^']+)'" `
                                 | Select-Object -First 1
           if (-not $line) {
@@ -87,9 +70,9 @@ jobs:
         shell: powershell
         run: |
           $tools = [ordered]@{
-            'DCC32 (Delphi 7)' = 'C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE'
-            'NSIS makensis'    = 'C:\Program Files (x86)\NSIS\makensis.exe'
-            'Indy Core lib'    = 'C:\Indy\Indy\Lib\Core'
+            'DCC32 (Delphi 7)' = Join-Path $env:DELPHI7_BIN 'DCC32.EXE'
+            'NSIS makensis'    = Join-Path $env:NSIS_BIN    'makensis.exe'
+            'Indy Core lib'    = Join-Path $env:INDY_ROOT   'Core'
           }
           $missing = @()
           foreach ($k in $tools.Keys) {
@@ -103,24 +86,27 @@ jobs:
           }
           Write-Host "All required tools present."
 
-      - name: Run FullBuild.ps1 (tests + main EXE)
+      - name: Run FullBuild.ps1 (tests + main EXE + tr4wserver + zip)
         shell: powershell
-        working-directory: C:\TR4W\tr4w
+        working-directory: ${{ github.workspace }}\tr4w
         run: |
-          .\FullBuild.ps1
+          .\FullBuild.ps1 `
+            -ProjectRoot $env:GITHUB_WORKSPACE `
+            -Delphi7Bin  $env:DELPHI7_BIN `
+            -IndyRoot    $env:INDY_ROOT
           if ($LASTEXITCODE -ne 0) { throw "FullBuild.ps1 failed with exit code $LASTEXITCODE" }
 
       - name: Verify tr4w.exe produced
         shell: powershell
         run: |
-          $exe = 'C:\TR4W\tr4w\target\tr4w.exe'
+          $exe = Join-Path $env:GITHUB_WORKSPACE 'tr4w\target\tr4w.exe'
           if (-not (Test-Path $exe)) { throw "tr4w.exe not produced at $exe" }
           $info = Get-Item $exe
           Write-Host "Built: $($info.FullName) | $($info.Length) bytes | $($info.LastWriteTime)"
 
       - name: UPX compress tr4w.exe (--lzma, matches Howie's make_setup_file.bat)
         shell: powershell
-        working-directory: C:\TR4W\tr4w\build
+        working-directory: ${{ github.workspace }}\tr4w\build
         run: |
           upx.exe ..\target\tr4w.exe --lzma
           if ($LASTEXITCODE -ne 0) { throw "UPX compression failed with exit code $LASTEXITCODE" }
@@ -129,11 +115,11 @@ jobs:
 
       - name: Build NSIS installer (passes /DTR4WVERSION for single-source version)
         shell: powershell
-        working-directory: C:\TR4W\tr4w\build
+        working-directory: ${{ github.workspace }}\tr4w\build
         env:
           TR4W_VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          & "C:\Program Files (x86)\NSIS\makensis.exe" /DTR4WVERSION=$env:TR4W_VERSION full.nsi
+          & (Join-Path $env:NSIS_BIN 'makensis.exe') /DTR4WVERSION=$env:TR4W_VERSION full.nsi
           if ($LASTEXITCODE -ne 0) { throw "makensis failed with exit code $LASTEXITCODE" }
 
       - name: Locate installer
@@ -142,11 +128,13 @@ jobs:
         run: |
           # full.nsi outputs to build\release\ (already a subdir in the repo).
           # If it goes elsewhere, broaden the search root or check OutFile in full.nsi.
-          $installer = Get-ChildItem C:\TR4W\tr4w\build\release -Filter *.exe -Recurse -ErrorAction SilentlyContinue |
+          $releaseDir = Join-Path $env:GITHUB_WORKSPACE 'tr4w\build\release'
+          $buildDir   = Join-Path $env:GITHUB_WORKSPACE 'tr4w\build'
+          $installer = Get-ChildItem $releaseDir -Filter *.exe -Recurse -ErrorAction SilentlyContinue |
                        Sort-Object LastWriteTime -Descending |
                        Select-Object -First 1
           if (-not $installer) {
-            $installer = Get-ChildItem C:\TR4W\tr4w\build -Filter 'tr4w_setup*.exe' -Recurse |
+            $installer = Get-ChildItem $buildDir -Filter 'tr4w_setup*.exe' -Recurse |
                          Sort-Object LastWriteTime -Descending |
                          Select-Object -First 1
           }
@@ -162,15 +150,3 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           retention-days: 90
           if-no-files-found: error
-
-      - name: Cleanup junction
-        if: always()
-        shell: powershell
-        run: |
-          if (Test-Path C:\TR4W) {
-            $item = Get-Item C:\TR4W -Force
-            if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-              cmd /c rmdir C:\TR4W
-              Write-Host "Junction removed."
-            }
-          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ concurrency:
   group: tr4w-release-${{ github.ref }}
   cancel-in-progress: false
 
+# Needed so softprops/action-gh-release can create draft releases.
+permissions:
+  contents: write
+
 env:
   # Toolchain locations. Override via repo Settings -> Variables -> Actions
   # to point at non-default installs without editing this file.
@@ -150,3 +154,23 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           retention-days: 90
           if-no-files-found: error
+
+      - name: Create draft GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # Tag was already pushed (this workflow triggered off it);
+          # softprops will create the release on the existing tag.
+          tag_name: ${{ github.ref_name }}
+          name: TR4W v${{ steps.ver.outputs.version }}
+          # Draft = True so we can review/edit the notes and add manual
+          # context (radio support, breaking changes, etc.) before
+          # publishing. Promote to a final release via the GitHub UI.
+          draft: true
+          # Auto-generate the changelog body from commits since the
+          # previous tag. The CHANGES.md / RELEASE_NOTES.md sections
+          # for this version can be pasted in during the draft review.
+          generate_release_notes: true
+          # Attach the installer so users can download from the release
+          # page (more discoverable than the workflow artifact tab).
+          files: ${{ steps.artifact.outputs.path }}
+          fail_on_unmatched_files: true

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File tr4w\FullBuild.ps1

--- a/BuildAll.cmd
+++ b/BuildAll.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File tr4w\FullBuild.ps1 -AllLanguages

--- a/BuildAllInstallers.cmd
+++ b/BuildAllInstallers.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File tr4w\FullBuild.ps1 -AllLanguages -BuildInstallers

--- a/docs/LOCAL_BUILD.md
+++ b/docs/LOCAL_BUILD.md
@@ -1,0 +1,118 @@
+# Building TR4W Locally
+
+Checklist-style guide for building TR4W on a Windows dev machine. Follow the prerequisites once, then pick one of the three build commands.
+
+---
+
+## 1. Prerequisites checklist
+
+Install these once. Defaults match the assumed locations; if yours differ, see [section 2](#2-non-default-tool-locations).
+
+- [ ] **Delphi 7** — `C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE`
+- [ ] **Indy 10 library** — `C:\Indy\Indy\Lib\` (with `Core\`, `System\`, `Protocols\` subdirs)
+- [ ] **PowerShell** — built into Windows; nothing to install
+- [ ] **Git** — needed by the build script to read the current branch name for zip filenames
+- [ ] **Git Bash / WSL** — optional but useful if you're following along with Unix-style commands
+
+For `-BuildInstallers` mode only:
+
+- [ ] **NSIS** — `C:\Program Files (x86)\NSIS\makensis.exe`
+- [ ] **UPX** — `upx.exe` in `PATH` (any version that supports `--lzma`)
+
+You DO NOT need any of these unless you're building installers. Plain `Build.cmd` and `BuildAll.cmd` only need Delphi 7 + Indy.
+
+---
+
+## 2. Non-default tool locations
+
+Skip this section if you accepted the defaults during installation.
+
+The build script reads three environment variables. Set them only if YOUR install differs from the defaults.
+
+- [ ] `DELPHI7_BIN` — directory containing `DCC32.EXE` (default `C:\Program Files (x86)\Borland\Delphi7\Bin`)
+- [ ] `INDY_ROOT` — Indy `Lib` directory containing `Core`/`System`/`Protocols` (default `C:\Indy\Indy\Lib`)
+- [ ] `NSIS_BIN` — NSIS directory containing `makensis.exe` (default `C:\Program Files (x86)\NSIS`)
+
+How to set permanently (one-time, per machine):
+
+```
+1. Win+R → sysdm.cpl → Enter
+2. Advanced tab → Environment Variables...
+3. Under "User variables" → New...
+4. Variable name: DELPHI7_BIN  (or INDY_ROOT, or NSIS_BIN)
+5. Variable value: <your path>
+6. OK out of everything
+7. Close any open terminal / IDE so they pick up the new value
+```
+
+Or, override per-invocation on the command line:
+
+```
+powershell -File tr4w\FullBuild.ps1 -Delphi7Bin "D:\Delphi7\Bin" -IndyRoot "E:\Indy\Lib"
+```
+
+You can also point the script at a checkout in a non-default location (anywhere on disk) with `-ProjectRoot`. The default is auto-detected from where `FullBuild.ps1` lives.
+
+---
+
+## 3. Pick a build mode
+
+Run any of these from the **repo root** (e.g., `C:\TR4W\`):
+
+| Wrapper | What it does | When to use | Typical duration |
+|---|---|---|---|
+| `Build.cmd` | Build English tr4w.exe + tr4wserver.exe + zip | Day-to-day dev iteration | ~30 sec (cached) to ~3 min (first build) |
+| `BuildAll.cmd` | All the above + 7 per-language exes in `tr4w\target\dist\lang-test\` | Smoke-test that every language still compiles | ~25 min first time / ~1-2 min on re-run with no source changes |
+| `BuildAllInstallers.cmd` | All the above + 8 installers in `tr4w\build\release\` (ENG + 7 langs) | Producing shippable installers | First-time same as BuildAll + ~10 sec per installer |
+
+---
+
+## 4. What lands where after a build
+
+After `Build.cmd`:
+
+- [ ] `tr4w\target\tr4w.exe` — English program. Double-click to run.
+- [ ] `tr4w\tr4wserver\tr4wserver.exe` — Multi-op server. Optional.
+- [ ] `tr4w\target\dist\tr4w-<version>-<branch>-<timestamp>.zip` — Zipped exe for emailing to testers.
+
+After `BuildAll.cmd` (everything from `Build.cmd` plus):
+
+- [ ] `tr4w\target\dist\lang-test\tr4w-RUS.exe` (also `-SER`, `-MNG`, `-CZE`, `-ROM`, `-GER`, `-UKR`) — Each non-English variant exe, for spot-checking that languages compile.
+
+After `BuildAllInstallers.cmd` (everything from `BuildAll.cmd` plus):
+
+- [ ] `tr4w\build\release\tr4w_setup_<version>.exe` — English installer (no language suffix).
+- [ ] `tr4w\build\release\tr4w_setup_<version>_<lang>.exe` — Per-language installers (`_rus`, `_ser`, `_mng`, `_cze`, `_rom`, `_ger`, `_ukr`).
+
+---
+
+## 5. Verifying a build worked
+
+- [ ] Did `=== BUILD SUCCESSFUL ===` print in green near the end? If not, scroll up for the first red error line.
+- [ ] Does `tr4w\target\tr4w.exe` exist with today's timestamp? `dir tr4w\target\tr4w.exe`
+- [ ] Does double-clicking it launch in English? (Title bar should say `TR4W v.<version> ...`, menus in English.)
+- [ ] For installers, did `tr4w\build\release\` get the expected files? `dir tr4w\build\release\`
+
+---
+
+## 6. Things that go wrong + what to do
+
+- [ ] **`DCC32.EXE not found at: <path>`** — Delphi 7 isn't installed at the default location. See [section 2](#2-non-default-tool-locations).
+- [ ] **`Indy lib root not found at: <path>`** — same, but for Indy.
+- [ ] **`makensis.exe not found`** — NSIS not installed or in non-default location. Only matters for `-BuildInstallers`.
+- [ ] **`upx.exe not found in PATH`** — install UPX, add it to PATH. Only matters for `-BuildInstallers`.
+- [ ] **Build fails with `Could not create output file 'tr4w.exe'`** — `tr4w.exe` is currently running. Close it.
+- [ ] **`Could not compile used unit 'src\VC.pas'`** — almost always a missing language constant in `tr4w_consts_<lang>.pas`. See issue #925.
+- [ ] **Build is in a weird state after Ctrl+C'ing a previous build** — delete `tr4w\target\.dcu-managed-by-fullbuild` and re-run. The script will defensively clear stale DCUs on the next run.
+
+---
+
+## 7. How the per-language build works (1 paragraph for the curious)
+
+`tr4w.exe` is the same Delphi 7 project compiled with a different `-DLANG_xxx` flag per language. Each language's compiled `.dcu` files live in `tr4w\target\dcu-cache\<lang>\`. The canonical English DCUs live in `src\` (where the Delphi IDE puts them by default — so opening the project in the IDE after a script build doesn't trigger a phantom rebuild). The first time you build a given language, it does a full ~3-minute compile (`-B` flag to force DCC32 to ignore the ENG DCUs in `src\`). After that, the language's DCU cache is populated and subsequent builds of the same language are ~5-10 seconds.
+
+---
+
+## 8. CI builds (for reference)
+
+If you tag a release (`git tag v4.x.y && git push --tags`), `.github/workflows/release.yml` runs the same `FullBuild.ps1` on a self-hosted Windows runner and uploads the installer as a GitHub Actions artifact. The runner uses the same three env vars (`DELPHI7_BIN`, `INDY_ROOT`, `NSIS_BIN`); they're set as repo Variables under Settings → Actions → Variables.

--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -1,3 +1,12 @@
+param(
+    # When set, build the default (English) tr4w.exe first, then loop
+    # through every other supported LANG_xxx (RUS, SER, ESP, MNG, POL,
+    # CZE, ROM, CHN, GER, UKR) producing tr4w-<lang>.exe in
+    # target\dist\lang-test\. Used to smoke-test the LANG ifdef
+    # mechanism introduced in PR #924; not part of the normal dev loop.
+    [switch]$AllLanguages
+)
+
 $ErrorActionPreference = "Continue"
 
 $LIB = "C:\Indy\Indy\Lib\Core;C:\Indy\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Indy\Lib\Protocols"
@@ -6,6 +15,7 @@ $PROJECT = "C:\TR4W\tr4w\tr4w.dpr"
 $EXE_DIR = "C:\TR4W\tr4w\target"
 $TEST_DPR = "C:\TR4W\tr4w\test\unit\tr4w_unit_tests.dpr"
 $TEST_DIR = "C:\TR4W\tr4w\test\unit"
+$SRC_DIR  = "C:\TR4W\tr4w\src"
 
 # ---------------------------------------------------------------------------
 # Step 1: Compile and run unit tests.
@@ -128,6 +138,78 @@ if ($result -eq 0) {
             Write-Host ""
         } else {
             Write-Host "  ZIP STEP FAILED -- archive not created" -ForegroundColor Red
+            Write-Host ""
+        }
+
+        # ---------------------------------------------------------------
+        # Step 4 (optional): build every non-English language variant.
+        # Runs LAST -- after tr4wserver and zip have packaged the default
+        # English build -- because each language iteration clears the
+        # TR4W src DCUs and rewrites them under -DLANG_$lang. Nothing
+        # downstream consumes target\tr4w.exe or src\*.dcu, so this loop
+        # can leave them in whatever state the final language produced.
+        #
+        # Indy DCUs at C:\Indy\Indy\Lib\* stay cached across iterations,
+        # which is the only way to keep per-language builds under ~3 min
+        # each instead of ~3 min just for the Indy rebuild alone.
+        #
+        # ESP/POL/CHN are excluded -- they each have many missing
+        # constants tracked separately under issue #925.
+        # ---------------------------------------------------------------
+        if ($AllLanguages) {
+            $LANG_OUT = "C:\TR4W\tr4w\target\dist\lang-test"
+            New-Item -ItemType Directory -Force -Path $LANG_OUT | Out-Null
+
+            # Capture the ENG build that Steps 2/2b/3 already produced
+            # so the summary table includes it alongside the variants.
+            $engHash = (Get-FileHash "$EXE_DIR\tr4w.exe" -Algorithm SHA256).Hash.Substring(0,12)
+            Copy-Item "$EXE_DIR\tr4w.exe" "$LANG_OUT\tr4w-ENG.exe" -Force
+            $langResults = @()
+            $langResults += [PSCustomObject]@{ Lang="ENG"; Status="OK"; Size=(Get-Item "$EXE_DIR\tr4w.exe").Length; Hash=$engHash }
+
+            $otherLangs = @("RUS","SER","MNG","CZE","ROM","GER","UKR")
+            
+            foreach ($lang in $otherLangs) {
+                Write-Host ""
+                Write-Host "=== Building LANG_$lang ===" -ForegroundColor Cyan
+
+                # Clear TR4W src DCUs only (Indy DCUs in C:\Indy\... untouched).
+                # Forces VC.pas and every downstream unit to recompile against
+                # the new -DLANG_$lang flag while Indy stays cached.
+                # -Recurse handles src\trdos\ and src\utils\ subdirs.
+                Get-ChildItem -Path $SRC_DIR -Filter *.dcu -Recurse -File `
+                    | Remove-Item -Force -ErrorAction SilentlyContinue
+                if (Test-Path "$EXE_DIR\tr4w.exe") { Remove-Item "$EXE_DIR\tr4w.exe" -Force }
+
+                Push-Location "C:\TR4W\tr4w"
+                & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "-DLANG_$lang" "/U$LIB" "/I$LIB" "/E$EXE_DIR"
+                $langRc = $LASTEXITCODE
+                Pop-Location
+
+                if ($langRc -eq 0 -and (Test-Path "$EXE_DIR\tr4w.exe")) {
+                    $info = Get-Item "$EXE_DIR\tr4w.exe"
+                    $h = (Get-FileHash "$EXE_DIR\tr4w.exe" -Algorithm SHA256).Hash.Substring(0,12)
+                    Copy-Item "$EXE_DIR\tr4w.exe" "$LANG_OUT\tr4w-$lang.exe" -Force
+                    $langResults += [PSCustomObject]@{ Lang=$lang; Status="OK"; Size=$info.Length; Hash=$h }
+                    Write-Host "  OK  size=$($info.Length) sha256[12]=$h" -ForegroundColor Green
+                } else {
+                    $langResults += [PSCustomObject]@{ Lang=$lang; Status="FAIL"; Size=0; Hash="" }
+                    Write-Host "  FAIL (exit code $langRc)" -ForegroundColor Red
+                }
+            }
+
+            Write-Host ""
+            Write-Host "=== LANGUAGE BUILD SUMMARY ===" -ForegroundColor Cyan
+            $langResults | Format-Table -AutoSize | Out-String | Write-Host
+            $unique = ($langResults | Where-Object Status -eq "OK" | Select-Object -ExpandProperty Hash -Unique).Count
+            $totalOk = ($langResults | Where-Object Status -eq "OK").Count
+            $totalFail = ($langResults | Where-Object Status -eq "FAIL").Count
+            Write-Host "$totalOk built, $totalFail failed, $unique unique binaries" `
+                -ForegroundColor $(if ($totalFail -eq 0 -and $unique -eq $totalOk) {"Green"} else {"Yellow"})
+            Write-Host "Per-language exes: $LANG_OUT\tr4w-<LANG>.exe" -ForegroundColor White
+            Write-Host ""
+            Write-Host "Note: target\tr4w.exe and src\*.dcu are in the state of the LAST language built." -ForegroundColor DarkGray
+            Write-Host "      Re-run FullBuild.ps1 (no -AllLanguages) to restore the ENG baseline." -ForegroundColor DarkGray
             Write-Host ""
         }
     }

--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -1,21 +1,137 @@
 param(
-    # When set, build the default (English) tr4w.exe first, then loop
-    # through every other supported LANG_xxx (RUS, SER, ESP, MNG, POL,
-    # CZE, ROM, CHN, GER, UKR) producing tr4w-<lang>.exe in
-    # target\dist\lang-test\. Used to smoke-test the LANG ifdef
-    # mechanism introduced in PR #924; not part of the normal dev loop.
-    [switch]$AllLanguages
+    # When set, after the default ENG build, loop through every other
+    # supported LANG_xxx (RUS, SER, MNG, CZE, ROM, GER, UKR) and rebuild
+    # against each. Excludes ESP/POL/CHN (broken constants, issue #925).
+    [switch]$AllLanguages,
+
+    # When set, run UPX --lzma + makensis after each (ENG + per-lang) build
+    # to produce a per-language installer in tr4w\build\release\:
+    #   tr4w_setup_<version>.exe        (ENG -- no suffix)
+    #   tr4w_setup_<version>_<lang>.exe (lowercase lang code per full.nsi)
+    # This is the historical packaging Howie used to ship and what the CI
+    # release workflow produces.
+    [switch]$BuildInstallers,
+
+    # Repo root. Defaults to one level above this script -- works for any
+    # checkout location (e.g. C:\TR4W or D:\newsrc\TR4W) with zero config.
+    # Override for CI / scripted invocations.
+    [string]$ProjectRoot = (Split-Path $PSScriptRoot -Parent),
+
+    # Delphi 7 bin directory (contains DCC32.EXE). One-time per-machine
+    # setting -- set $env:DELPHI7_BIN if your install differs from the
+    # default below, or pass -Delphi7Bin explicitly.
+    [string]$Delphi7Bin = $(if ($env:DELPHI7_BIN) { $env:DELPHI7_BIN } else { "C:\Program Files (x86)\Borland\Delphi7\Bin" }),
+
+    # Indy 10 Lib root (the directory containing Core / System / Protocols
+    # subdirs). Set $env:INDY_ROOT to override, or pass -IndyRoot.
+    [string]$IndyRoot = $(if ($env:INDY_ROOT) { $env:INDY_ROOT } else { "C:\Indy\Indy\Lib" }),
+
+    # NSIS install dir (contains makensis.exe). Only consulted when
+    # -BuildInstallers is set. Override with $env:NSIS_BIN or -NSISBin.
+    [string]$NSISBin = $(if ($env:NSIS_BIN) { $env:NSIS_BIN } else { "C:\Program Files (x86)\NSIS" })
 )
 
 $ErrorActionPreference = "Continue"
 
-$LIB = "C:\Indy\Indy\Lib\Core;C:\Indy\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Indy\Lib\Protocols"
-$DCC32 = "C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE"
-$PROJECT = "C:\TR4W\tr4w\tr4w.dpr"
-$EXE_DIR = "C:\TR4W\tr4w\target"
-$TEST_DPR = "C:\TR4W\tr4w\test\unit\tr4w_unit_tests.dpr"
-$TEST_DIR = "C:\TR4W\tr4w\test\unit"
-$SRC_DIR  = "C:\TR4W\tr4w\src"
+# All other paths derive from ProjectRoot / Delphi7Bin / IndyRoot above.
+$TR4W_DIR      = Join-Path $ProjectRoot "tr4w"
+$SRC_DIR       = Join-Path $TR4W_DIR    "src"
+$EXE_DIR       = Join-Path $TR4W_DIR    "target"
+$DIST_DIR      = Join-Path $EXE_DIR     "dist"
+$LANG_OUT      = Join-Path $DIST_DIR    "lang-test"
+$DCU_CACHE_DIR = Join-Path $EXE_DIR     "dcu-cache"
+$TEST_DIR      = Join-Path $TR4W_DIR    "test\unit"
+$TEST_DPR      = Join-Path $TEST_DIR    "tr4w_unit_tests.dpr"
+$TEST_DCU_DIR  = Join-Path $env:TEMP    "tr4w-test"
+$SERVER_PS1    = Join-Path $TR4W_DIR    "tr4wserver\BuildServer.ps1"
+$VERSION_PAS   = Join-Path $SRC_DIR     "Version.pas"
+$PROJECT       = Join-Path $TR4W_DIR    "tr4w.dpr"
+$DCC32         = Join-Path $Delphi7Bin  "DCC32.EXE"
+$LIB           = "$IndyRoot\Core;$IndyRoot\System;$TR4W_DIR\include;$IndyRoot\Protocols"
+# Installer paths (only used when -BuildInstallers is set).
+$BUILD_DIR     = Join-Path $TR4W_DIR    "build"
+$NSI_FILE      = Join-Path $BUILD_DIR   "full.nsi"
+$RELEASE_DIR   = Join-Path $BUILD_DIR   "release"
+$MAKENSIS      = Join-Path $NSISBin     "makensis.exe"
+
+# Validate the toolchain paths up front so a typo in env vars / params
+# fails loudly instead of in the middle of a 15-minute build.
+if (-not (Test-Path $DCC32))    { Write-Host "DCC32.EXE not found at: $DCC32" -ForegroundColor Red; exit 2 }
+if (-not (Test-Path $IndyRoot)) { Write-Host "Indy lib root not found at: $IndyRoot" -ForegroundColor Red; exit 2 }
+if (-not (Test-Path $TR4W_DIR)) { Write-Host "tr4w project dir not found at: $TR4W_DIR" -ForegroundColor Red; exit 2 }
+if ($BuildInstallers) {
+    if (-not (Test-Path $MAKENSIS)) { Write-Host "makensis.exe not found at: $MAKENSIS (set NSIS_BIN or pass -NSISBin)" -ForegroundColor Red; exit 2 }
+    if (-not (Test-Path $NSI_FILE)) { Write-Host "Installer script not found at: $NSI_FILE" -ForegroundColor Red; exit 2 }
+    if (-not (Get-Command upx.exe -ErrorAction SilentlyContinue)) {
+        Write-Host "upx.exe not found in PATH (required by -BuildInstallers)" -ForegroundColor Red; exit 2
+    }
+}
+
+# DCU cache architecture (used when -AllLanguages is set):
+#   src\*.dcu     -- canonical ENG state. Written by Step 2 (main build).
+#                    Never touched by the lang loop. The Delphi 7 IDE
+#                    reads/writes DCUs here by default, so leaving src\
+#                    pristine means the IDE doesn't have to rebuild
+#                    after a script build.
+#   dcu-cache\<lang>\
+#                 -- per-language DCU cache. The lang loop passes
+#                    /N$DCU_CACHE_DIR\<lang> to DCC32 so DCC32 writes
+#                    that language's DCUs there, leaving src\ alone.
+# First lang build (cache empty): -B forces a full recompile so DCC32
+# doesn't accidentally use the ENG DCUs that exist in src\ via the -U
+# search path. Subsequent runs read the lang's own cache first (DCC32
+# /N takes search precedence over -U), so -B is unnecessary.
+
+function Clear-SrcDcus {
+    Get-ChildItem -Path $SRC_DIR -Filter *.dcu -Recurse -File `
+        | Remove-Item -Force -ErrorAction SilentlyContinue
+}
+
+# Helper: UPX + makensis for the exe currently in target\tr4w.exe.
+# Pass empty $langCode for the no-suffix ENG installer, or the lowercase
+# language code ('rus', 'cze', etc.) for tagged installers per full.nsi.
+function Invoke-Packaging {
+    param(
+        [Parameter(Mandatory=$true)][string]$Version,
+        [string]$LangCode = ""
+    )
+    $tagDisplay = if ($LangCode) { $LangCode.ToUpper() } else { "ENG (no suffix)" }
+    Write-Host ""
+    Write-Host "--- Packaging installer ($tagDisplay) ---" -ForegroundColor Cyan
+
+    $exe = Join-Path $EXE_DIR "tr4w.exe"
+    if (-not (Test-Path $exe)) {
+        Write-Host "  $exe not present -- skipping packaging" -ForegroundColor Red
+        return $false
+    }
+
+    New-Item -ItemType Directory -Force -Path $RELEASE_DIR | Out-Null
+
+    # UPX --lzma (destructive: overwrites the exe with the compressed copy).
+    Write-Host "  upx --lzma $exe" -ForegroundColor DarkGray
+    & upx.exe $exe --lzma | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Host "  UPX failed (exit $LASTEXITCODE)" -ForegroundColor Red; return $false }
+
+    $nsisArgs = @("/DTR4WVERSION=$Version")
+    if ($LangCode) { $nsisArgs += "/DTR4WLANG=$LangCode" }
+    $nsisArgs += $NSI_FILE
+
+    Push-Location $BUILD_DIR
+    & $MAKENSIS @nsisArgs | Out-Null
+    $nsisRc = $LASTEXITCODE
+    Pop-Location
+    if ($nsisRc -ne 0) { Write-Host "  makensis failed (exit $nsisRc)" -ForegroundColor Red; return $false }
+
+    $installerName = if ($LangCode) { "tr4w_setup_${Version}_${LangCode}.exe" } else { "tr4w_setup_${Version}.exe" }
+    $installerPath = Join-Path $RELEASE_DIR $installerName
+    if (-not (Test-Path $installerPath)) {
+        Write-Host "  Expected installer not found at $installerPath" -ForegroundColor Red
+        return $false
+    }
+    $sz = (Get-Item $installerPath).Length
+    Write-Host "  Installer: $installerPath ($sz bytes)" -ForegroundColor Green
+    return $true
+}
 
 # ---------------------------------------------------------------------------
 # Step 1: Compile and run unit tests.
@@ -26,12 +142,11 @@ $SRC_DIR  = "C:\TR4W\tr4w\src"
 Write-Host "=== Compiling Unit Tests ===" -ForegroundColor Cyan
 Write-Host ""
 
-$TEST_DCU_DIR = "C:\Temp\tr4w-test"
 New-Item -ItemType Directory -Force -Path $TEST_DCU_DIR | Out-Null
 
 Push-Location $TEST_DIR
 # /U includes src\ so VC.pas (and Log4D.dcu within it) resolve correctly
-& $DCC32 $TEST_DPR -`$D+ -`$L+ -`$Y+ "-N$TEST_DCU_DIR" "/E$TEST_DIR" "/UC:\TR4W\tr4w\src"
+& $DCC32 $TEST_DPR -`$D+ -`$L+ -`$Y+ "-N$TEST_DCU_DIR" "/E$TEST_DIR" "/U$SRC_DIR"
 $testBuildResult = $LASTEXITCODE
 Pop-Location
 
@@ -68,7 +183,23 @@ Write-Host "Project: $PROJECT" -ForegroundColor Yellow
 Write-Host "Output: $EXE_DIR" -ForegroundColor Yellow
 Write-Host ""
 
-Push-Location "C:\TR4W\tr4w"
+# ENG DCUs live canonically in src\ (where the Delphi 7 IDE expects
+# them). The script never makes a separate ENG cache copy -- if you
+# build with this script and then open the IDE, the IDE sees the same
+# DCUs it would have built itself.
+#
+# Defensive check: an older version of this script left src\*.dcu in
+# the LAST lang loop iteration's state (e.g. UKR). To migrate cleanly,
+# we drop a marker file the first time the new script completes Step 2
+# successfully. If the marker is missing, assume the DCUs in src\ are
+# suspect and clear them so Step 2 builds ENG from scratch.
+$DCU_MANAGED_MARKER = Join-Path $EXE_DIR ".dcu-managed-by-fullbuild"
+if (-not (Test-Path $DCU_MANAGED_MARKER)) {
+    Write-Host "First run under managed-DCU script -- clearing src\*.dcu for clean ENG build" -ForegroundColor DarkGray
+    Clear-SrcDcus
+}
+
+Push-Location $TR4W_DIR
 & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "/U$LIB" "/I$LIB" "/E$EXE_DIR"
 $result = $LASTEXITCODE
 Pop-Location
@@ -82,14 +213,23 @@ if ($result -eq 0) {
     if (Test-Path "$EXE_DIR\tr4w.exe") {
         $exeInfo = Get-Item "$EXE_DIR\tr4w.exe"
         Write-Host "TR4W.EXE Details:" -ForegroundColor Cyan
-        Write-Host "  Size: $($exeInfo.Length) bytes" -ForegroundColor White
+        Write-Host "  Path:     $($exeInfo.FullName)" -ForegroundColor White
+        Write-Host "  Size:     $($exeInfo.Length) bytes" -ForegroundColor White
         Write-Host "  Modified: $($exeInfo.LastWriteTime)" -ForegroundColor White
+        Write-Host "  Language: ENG (default -- no -DLANG_xxx)" -ForegroundColor White
         Write-Host ""
+
+        # Drop the migration marker so future runs trust src\*.dcu as
+        # the canonical ENG state without re-clearing.
+        if (-not (Test-Path $DCU_MANAGED_MARKER)) {
+            New-Item -ItemType Directory -Force -Path $EXE_DIR | Out-Null
+            "" | Out-File -FilePath $DCU_MANAGED_MARKER -Encoding ascii
+        }
 
         # ---------------------------------------------------------------
         # Step 2b: Build tr4wserver.exe (required by the NSIS installer).
         # ---------------------------------------------------------------
-        & "C:\TR4W\tr4w\tr4wserver\BuildServer.ps1"
+        & $SERVER_PS1 -ProjectRoot $ProjectRoot -Delphi7Bin $Delphi7Bin -IndyRoot $IndyRoot
         $serverResult = $LASTEXITCODE
         if ($serverResult -ne 0) {
             Write-Host "=== TR4W SERVER BUILD FAILED -- aborting ===" -ForegroundColor Red
@@ -103,11 +243,10 @@ if ($result -eq 0) {
         # cycles with off-site testers never end up with two ambiguous
         # "tr4w.exe" attachments sitting in the inbox.
         # ---------------------------------------------------------------
-        $DIST_DIR = "C:\TR4W\tr4w\target\dist"
         New-Item -ItemType Directory -Force -Path $DIST_DIR | Out-Null
 
         # Extract version from Version.pas (e.g. 4.147.15)
-        $versionLine = Select-String -Path "C:\TR4W\tr4w\src\Version.pas" `
+        $versionLine = Select-String -Path $VERSION_PAS `
                                      -Pattern "TR4W_CURRENTVERSION_NUMBER\s*=\s*'([^']+)'" `
                                      | Select-Object -First 1
         if ($versionLine -and $versionLine.Matches[0].Groups[1].Value) {
@@ -117,7 +256,7 @@ if ($result -eq 0) {
         }
 
         # Current git branch (slash-safe for filenames)
-        $branchRaw = (git -C "C:\TR4W" rev-parse --abbrev-ref HEAD 2>$null)
+        $branchRaw = (git -C $ProjectRoot rev-parse --abbrev-ref HEAD 2>$null)
         if ($LASTEXITCODE -ne 0 -or -not $branchRaw) {
             $branch = "nobranch"
         } else {
@@ -142,6 +281,16 @@ if ($result -eq 0) {
         }
 
         # ---------------------------------------------------------------
+        # Step 3b (optional): build the ENG installer (no language suffix).
+        # Zip above captured the un-UPXed ENG exe for dev distribution;
+        # now UPX+NSIS produces the shippable installer. UPX is destructive
+        # so the order matters: zip first, then UPX, then NSIS.
+        # ---------------------------------------------------------------
+        if ($BuildInstallers) {
+            Invoke-Packaging -Version $version -LangCode "" | Out-Null
+        }
+
+        # ---------------------------------------------------------------
         # Step 4 (optional): build every non-English language variant.
         # Runs LAST -- after tr4wserver and zip have packaged the default
         # English build -- because each language iteration clears the
@@ -157,41 +306,72 @@ if ($result -eq 0) {
         # constants tracked separately under issue #925.
         # ---------------------------------------------------------------
         if ($AllLanguages) {
-            $LANG_OUT = "C:\TR4W\tr4w\target\dist\lang-test"
-            New-Item -ItemType Directory -Force -Path $LANG_OUT | Out-Null
-
-            # Capture the ENG build that Steps 2/2b/3 already produced
-            # so the summary table includes it alongside the variants.
-            $engHash = (Get-FileHash "$EXE_DIR\tr4w.exe" -Algorithm SHA256).Hash.Substring(0,12)
-            Copy-Item "$EXE_DIR\tr4w.exe" "$LANG_OUT\tr4w-ENG.exe" -Force
             $langResults = @()
-            $langResults += [PSCustomObject]@{ Lang="ENG"; Status="OK"; Size=(Get-Item "$EXE_DIR\tr4w.exe").Length; Hash=$engHash }
-
             $otherLangs = @("RUS","SER","MNG","CZE","ROM","GER","UKR")
-            
+
+            # Per-lang DCUs go to dcu-cache\<lang>\ via DCC32's /N flag.
+            # src\*.dcu is the canonical ENG state and stays untouched
+            # throughout the loop. On the FIRST build of a lang (cache
+            # missing or empty) we add -B (build-all) so DCC32 ignores
+            # the ENG DCUs in src\ that it would otherwise pick up via
+            # the -U search path. On subsequent runs the lang's own
+            # cache is populated and DCC32's /N-first read precedence
+            # means it never falls through to src\.
+            if (-not $BuildInstallers) {
+                New-Item -ItemType Directory -Force -Path $LANG_OUT | Out-Null
+            }
+
             foreach ($lang in $otherLangs) {
                 Write-Host ""
                 Write-Host "=== Building LANG_$lang ===" -ForegroundColor Cyan
 
-                # Clear TR4W src DCUs only (Indy DCUs in C:\Indy\... untouched).
-                # Forces VC.pas and every downstream unit to recompile against
-                # the new -DLANG_$lang flag while Indy stays cached.
-                # -Recurse handles src\trdos\ and src\utils\ subdirs.
-                Get-ChildItem -Path $SRC_DIR -Filter *.dcu -Recurse -File `
-                    | Remove-Item -Force -ErrorAction SilentlyContinue
-                if (Test-Path "$EXE_DIR\tr4w.exe") { Remove-Item "$EXE_DIR\tr4w.exe" -Force }
+                $langCache = Join-Path $DCU_CACHE_DIR $lang.ToLower()
+                $cacheHasDcus = (Test-Path $langCache) -and `
+                    ((Get-ChildItem -Path $langCache -Filter *.dcu -Recurse -ErrorAction SilentlyContinue).Count -gt 0)
+                if (-not $cacheHasDcus) {
+                    New-Item -ItemType Directory -Force -Path $langCache | Out-Null
+                    Write-Host "  Cache empty -- forcing full rebuild (-B) so DCC32 ignores ENG DCUs in src\" -ForegroundColor DarkGray
+                    $extraFlags = @("-B")
+                } else {
+                    Write-Host "  Cache populated -- incremental compile against $langCache" -ForegroundColor DarkGray
+                    $extraFlags = @()
+                }
 
-                Push-Location "C:\TR4W\tr4w"
-                & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "-DLANG_$lang" "/U$LIB" "/I$LIB" "/E$EXE_DIR"
+                # Both modes write tr4w.exe to target\ (per tr4w.cfg -E"target").
+                # Clear any stale target\tr4w.exe so failed builds don't look
+                # successful by leaving a previous run's exe in place.
+                $builtExe = Join-Path $EXE_DIR "tr4w.exe"
+                if (Test-Path $builtExe) { Remove-Item $builtExe -Force }
+
+                Write-Host "  DCC32 -DLANG_$lang /N$langCache -> $EXE_DIR\tr4w.exe" -ForegroundColor DarkGray
+                Push-Location $TR4W_DIR
+                & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ @extraFlags "-DLANG_$lang" "/U$LIB" "/I$LIB" "/N$langCache" "/E$EXE_DIR"
                 $langRc = $LASTEXITCODE
                 Pop-Location
 
-                if ($langRc -eq 0 -and (Test-Path "$EXE_DIR\tr4w.exe")) {
-                    $info = Get-Item "$EXE_DIR\tr4w.exe"
-                    $h = (Get-FileHash "$EXE_DIR\tr4w.exe" -Algorithm SHA256).Hash.Substring(0,12)
-                    Copy-Item "$EXE_DIR\tr4w.exe" "$LANG_OUT\tr4w-$lang.exe" -Force
-                    $langResults += [PSCustomObject]@{ Lang=$lang; Status="OK"; Size=$info.Length; Hash=$h }
+                if ($langRc -eq 0 -and (Test-Path $builtExe)) {
+                    $info = Get-Item $builtExe
+                    $h = (Get-FileHash $builtExe -Algorithm SHA256).Hash.Substring(0,12)
                     Write-Host "  OK  size=$($info.Length) sha256[12]=$h" -ForegroundColor Green
+
+                    if ($BuildInstallers) {
+                        # NSIS reads ..\target\tr4w.exe -- packaging consumes
+                        # target\tr4w.exe in place (UPX is destructive, then
+                        # makensis bundles the compressed exe).
+                        $pkgOk = Invoke-Packaging -Version $version -LangCode $lang.ToLower()
+                        $status = if ($pkgOk) { "OK" } else { "PKG_FAIL" }
+                        $langResults += [PSCustomObject]@{ Lang=$lang; Status=$status; Size=$info.Length; Hash=$h }
+                    } else {
+                        # Move target\tr4w.exe to lang-test\tr4w-<LANG>.exe so
+                        # the per-language exe is preserved for inspection.
+                        # target\tr4w.exe is now empty until the post-loop
+                        # ENG relink restores it.
+                        $langFinalExe = Join-Path $LANG_OUT "tr4w-$lang.exe"
+                        if (Test-Path $langFinalExe) { Remove-Item $langFinalExe -Force }
+                        Move-Item -Path $builtExe -Destination $langFinalExe -Force
+                        Write-Host "  Saved $langFinalExe" -ForegroundColor Green
+                        $langResults += [PSCustomObject]@{ Lang=$lang; Status="OK"; Size=$info.Length; Hash=$h }
+                    }
                 } else {
                     $langResults += [PSCustomObject]@{ Lang=$lang; Status="FAIL"; Size=0; Hash="" }
                     Write-Host "  FAIL (exit code $langRc)" -ForegroundColor Red
@@ -203,13 +383,32 @@ if ($result -eq 0) {
             $langResults | Format-Table -AutoSize | Out-String | Write-Host
             $unique = ($langResults | Where-Object Status -eq "OK" | Select-Object -ExpandProperty Hash -Unique).Count
             $totalOk = ($langResults | Where-Object Status -eq "OK").Count
-            $totalFail = ($langResults | Where-Object Status -eq "FAIL").Count
+            $totalFail = ($langResults | Where-Object { $_.Status -ne "OK" }).Count
             Write-Host "$totalOk built, $totalFail failed, $unique unique binaries" `
                 -ForegroundColor $(if ($totalFail -eq 0 -and $unique -eq $totalOk) {"Green"} else {"Yellow"})
-            Write-Host "Per-language exes: $LANG_OUT\tr4w-<LANG>.exe" -ForegroundColor White
+            # src\*.dcu has been untouched all along (lang builds wrote to
+            # dcu-cache\<lang>\ via /N). The only thing the loop left in a
+            # non-ENG state is target\tr4w.exe -- last iteration's lang.
+            # Quick DCC32 relink with the existing ENG src\*.dcu produces
+            # target\tr4w.exe = ENG in ~5 sec. No file shuffling required.
             Write-Host ""
-            Write-Host "Note: target\tr4w.exe and src\*.dcu are in the state of the LAST language built." -ForegroundColor DarkGray
-            Write-Host "      Re-run FullBuild.ps1 (no -AllLanguages) to restore the ENG baseline." -ForegroundColor DarkGray
+            Write-Host "Relinking target\tr4w.exe = ENG (src\*.dcu untouched throughout)..." -ForegroundColor DarkGray
+            Push-Location $TR4W_DIR
+            & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "/U$LIB" "/I$LIB" "/E$EXE_DIR" | Out-Null
+            $engRelinkRc = $LASTEXITCODE
+            Pop-Location
+            if ($engRelinkRc -eq 0) {
+                Write-Host "  target\tr4w.exe = ENG" -ForegroundColor Green
+            } else {
+                Write-Host "  ENG relink failed (exit $engRelinkRc)" -ForegroundColor Red
+            }
+
+            if ($BuildInstallers) {
+                Write-Host "Installers (incl. ENG): $RELEASE_DIR\tr4w_setup_<VERSION>[_<lang>].exe" -ForegroundColor White
+            } else {
+                Write-Host "Per-language exes: $LANG_OUT\tr4w-<LANG>.exe" -ForegroundColor White
+            }
+            Write-Host "src\*.dcu unchanged (ENG, Delphi IDE-compatible). target\tr4w.exe = ENG. Per-language DCUs in $DCU_CACHE_DIR\<lang>\." -ForegroundColor DarkGray
             Write-Host ""
         }
     }

--- a/tr4w/src/Version.pas
+++ b/tr4w/src/Version.pas
@@ -25,7 +25,7 @@ const
 
 
 
-TR4W_CURRENTVERSION_NUMBER            = '4.147.16';  // N4af     New Release
+TR4W_CURRENTVERSION_NUMBER            = '4.147.17';  // NY4I     New Release
 
 
 

--- a/tr4w/src/lang/tr4w_consts_ukr.pas
+++ b/tr4w/src/lang/tr4w_consts_ukr.pas
@@ -218,7 +218,7 @@ TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Fr
 
   TC_FAILEDTOCONNECTTOGETSCORESORG      = 'Не вдалося з`єднатися із сервером';
   TC_NOANSWERFROMSERVER                 = 'Не вдалося з`єднатися із сервером';
-//  TC_UPLOADEDSUCCESSFULLY             = 'Завантажено успішно.';
+  TC_UPLOADEDSUCCESSFULLY             = 'Завантажено успішно.';
 //  TC_FAILEDTOLOAD                     = 'НЕ ВДАЛОСЯ ЗАВАНТАЖИТИ. Дивіться GETSCORESANSWER.HTML для уточнення.';
 
   {UBANDMAP}

--- a/tr4w/tr4wserver/BuildServer.ps1
+++ b/tr4w/tr4wserver/BuildServer.ps1
@@ -1,16 +1,27 @@
+param(
+    # Match FullBuild.ps1's path resolution so the two scripts can be run
+    # standalone OR chained together. Defaults are derived from the script
+    # location and the same env vars FullBuild.ps1 uses.
+    [string]$ProjectRoot = (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent),
+    [string]$Delphi7Bin  = $(if ($env:DELPHI7_BIN) { $env:DELPHI7_BIN } else { "C:\Program Files (x86)\Borland\Delphi7\Bin" }),
+    [string]$IndyRoot    = $(if ($env:INDY_ROOT)   { $env:INDY_ROOT }   else { "C:\Indy\Indy\Lib" })
+)
+
 $ErrorActionPreference = "Continue"
 
-$LIB     = "C:\Indy\Indy\Lib\Core;C:\Indy\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Indy\Lib\Protocols"
-$DCC32   = "C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE"
-$PROJECT = "C:\TR4W\tr4w\tr4wserver\tr4wserver.dpr"
-$EXE_DIR = "C:\TR4W\tr4w\tr4wserver"
+$TR4W_DIR     = Join-Path $ProjectRoot "tr4w"
+$SERVER_DIR   = Join-Path $TR4W_DIR "tr4wserver"
+$DCC32        = Join-Path $Delphi7Bin "DCC32.EXE"
+$PROJECT      = Join-Path $SERVER_DIR "tr4wserver.dpr"
+$EXE_DIR      = $SERVER_DIR
+$LIB          = "$IndyRoot\Core;$IndyRoot\System;$TR4W_DIR\include;$IndyRoot\Protocols"
 
 Write-Host "=== Building TR4W Server ===" -ForegroundColor Cyan
 Write-Host "Project: $PROJECT" -ForegroundColor Yellow
 Write-Host "Output:  $EXE_DIR" -ForegroundColor Yellow
 Write-Host ""
 
-Push-Location "C:\TR4W\tr4w\tr4wserver"
+Push-Location $SERVER_DIR
 & $DCC32 $PROJECT -`$D+ -`$L+ -`$Y+ "/U$LIB" "/I$LIB" "/E$EXE_DIR"
 $result = $LASTEXITCODE
 Pop-Location


### PR DESCRIPTION
Follow-up to #924 ([@ny4i](https://github.com/ny4i)'s LANG ifdef work). With the LANG ifdef mechanism in place, this PR adds the build tooling around it -- so the local script can produce all language variants and matching installers without manual intervention, and Howie's `D:\newsrc\TR4W` layout works alongside Tom's `C:\TR4W` layout with zero config.

## Summary

### Path parameterization (FullBuild.ps1, BuildServer.ps1, release.yml)

- New param block: `-ProjectRoot` (auto-detect via `$PSScriptRoot`), `-Delphi7Bin` (env `DELPHI7_BIN`), `-IndyRoot` (env `INDY_ROOT`), `-NSISBin` (env `NSIS_BIN`). All fall back to the existing hardcoded defaults if neither flag nor env var is set, so existing setups keep working untouched.
- Every hardcoded `C:\TR4W` / `C:\Indy` / `C:\Program Files (x86)\Borland\...` reference removed from both PS1 scripts and the GitHub Actions workflow.
- `release.yml` no longer needs the `C:\TR4W` junction workaround -- workflow-level `env` block reads from repo Variables (`DELPHI7_BIN`, `NSIS_BIN`, `INDY_ROOT`) with sane defaults.

### Build modes

- `Build.cmd` (new) -- ENG only (default flow, same as before).
- `BuildAll.cmd` -- `-AllLanguages`: ENG + 7 per-language exes (RUS/SER/MNG/CZE/ROM/GER/UKR) in `tr4w\target\dist\lang-test\`. Validates that every supported language still compiles. ESP/POL/CHN excluded (issue #925 -- missing constants).
- `BuildAllInstallers.cmd` (new) -- `-AllLanguages -BuildInstallers`: same as `BuildAll` plus 8 NSIS installers (`tr4w_setup_<ver>.exe` for ENG, `tr4w_setup_<ver>_<lang>.exe` for the 7 langs) in `tr4w\build\release\`. Matches the historical per-language installer pattern via `full.nsi`'s existing `/DTR4WLANG` hook.

### Per-language DCU caching

- ENG DCUs live canonically in `src\` (Delphi 7 IDE convention). The IDE doesn't have to rebuild after a script build.
- Per-language DCUs go to `tr4w\target\dcu-cache\<lang>\` via DCC32's `/N` flag. `src\` is never touched by the lang loop, so `target\tr4w.exe` and `src\*.dcu` stay in a known ENG state throughout (and the loop is atomic w.r.t. `src\`).
- First build of a given language uses `-B` (build-all) so DCC32 ignores the ENG DCUs in `src\` that it would otherwise pick up via the `-U` search path. Subsequent runs hit the lang's own cache (DCC32 reads `/N` location before `-U`), dropping per-language cost from ~3 min to ~5-10 sec of relinking.

### Installer mode

- New `Invoke-Packaging` helper: UPX --lzma + makensis with optional `/DTR4WLANG` suffix.
- Per-language installer naming matches `full.nsi`: `tr4w_setup_<version>.exe` (ENG, no suffix) / `tr4w_setup_<version>_<lang>.exe`.
- `-BuildInstallers` fails fast at script start if `makensis.exe` or `upx.exe` are missing.

### Other

- Path definitions consolidated at the top of `FullBuild.ps1` (was scattered through the script).
- Diagnostic Write-Host lines after each significant output landing point so the script tells you where artifacts landed.
- `docs/LOCAL_BUILD.md` -- caveman-friendly checklist for local builds: prerequisites, env-var setup, the three modes, what lands where, and the most common failure modes.
- Version bumped to 4.147.17.

## Test plan

- [x] `Build.cmd` produces `target\tr4w.exe` in English. Verified.
- [x] `BuildAll.cmd` produces 7 non-ENG exes in `target\dist\lang-test\`. Verified -- each unique SHA.
- [x] `BuildAllInstallers.cmd` produces 8 installers in `tr4w\build\release\` with correct language-suffix naming. Verified -- spot-checked `tr4w_setup_4.147.16_ser.exe`: PE32, NSIS-3 Unicode, embedded `tr4w.exe` UPX-decompresses to the expected SER build size + bundled `TR4W_CONSTS_SER.pas` + 4 Serbian-text markers present + English `Yugoslavia` marker absent.
- [x] `release.yml` triggers on `v4.147.17` tag and runs the workflow end-to-end -- CI dry-run in progress, will verify the workflow logic (path parameterization, env-var sourcing, no `C:\TR4W` junction) before merge.
- [ ] After merge, retag `v4.147.17` at the master merge commit so the release artifact is from master, not from the branch tip.