### PR TITLE
Bump Version.pas to 4.147.18 (CI test for all-languages workflow path)

### DIFF
--- a/tr4w/src/Version.pas
+++ b/tr4w/src/Version.pas
@@ -25,7 +25,7 @@ const
 
 
 
-TR4W_CURRENTVERSION_NUMBER            = '4.147.17';  // NY4I     New Release
+TR4W_CURRENTVERSION_NUMBER            = '4.147.18';  // NY4I     CI test for all-languages workflow path
 
 
 


### PR DESCRIPTION
Bump for testing the new `-all` tag suffix path added in #927. After merge, tag `v4.147.18-all` to trigger the all-languages CI build.