### PR TITLE
CI: Version.pas merge guard + run entire release pipeline on self-hosted win-ci

### DIFF
--- a/.github/scripts/Invoke-VirusTotalScan.ps1
+++ b/.github/scripts/Invoke-VirusTotalScan.ps1
@@ -1,0 +1,410 @@
+<#
+.SYNOPSIS
+   Shared VirusTotal scan logic -- the SINGLE source of truth used by BOTH the
+   CI release pipeline (.github/workflows/release.yml) and the local build
+   pre-flight (tr4w/FullBuild.ps1). There is no second VT implementation.
+
+.DESCRIPTION
+   Two ways to use this file:
+
+   1. DOT-SOURCE it (`. .\Invoke-VirusTotalScan.ps1`) to load the functions
+      without running anything. FullBuild.ps1 does this for its informational
+      local pre-flight: it calls Invoke-VirusTotalScan + ConvertTo-VtResult and
+      prints verdicts, never failing the build.
+
+   2. RUN it directly with -InstallerDir / -ReportPath to perform the CI
+      authoritative scan: scan every installer in the directory, write a
+      Markdown report, and exit non-zero if any installer meets/exceeds
+      -Threshold malicious detections.
+
+   The multipart upload uses curl.exe (ships with Windows 10 1803+), NOT
+   Invoke-RestMethod -Form. That keeps the script identical under Windows
+   PowerShell 5.1 (FullBuild runs under powershell.exe) and PowerShell 7 (the
+   CI step runs under pwsh) -- no -Form / no pwsh-7 dependency.
+
+   The VirusTotal API key is read from the VT_API_KEY environment variable in
+   CI mode (mapped from secrets.VIRUS_TOTAL_API_KEY); FullBuild passes its key
+   to Invoke-VirusTotalScan explicitly.
+
+.PARAMETER InstallerDir
+   CI mode: directory (searched recursively) for tr4w_setup_*.exe to scan.
+.PARAMETER ReportPath
+   CI mode: path to write the Markdown report to (overwritten if it exists).
+.PARAMETER Threshold
+   Malicious-engine detections at or above which a file is BLOCKED (CI fails).
+.PARAMETER RefName
+   Git ref name for the report header. Informational only.
+.PARAMETER CommitSha
+   Full commit SHA for the report header; truncated to 7 chars. Informational.
+.PARAMETER SelfTest
+   Run the network-free logic against built-in sample data and assert
+   invariants. No API key or network required.
+#>
+[CmdletBinding()]
+param(
+   [string]$InstallerDir,
+   [string]$ReportPath,
+   [int]$Threshold = 8,
+   [string]$RefName = '',
+   [string]$CommitSha = '',
+   [switch]$SelfTest
+)
+
+$ErrorActionPreference = 'Stop'
+
+# VirusTotal API v3 endpoints + the 32 MiB large-file upload boundary.
+$script:VtFilesUrl       = 'https://www.virustotal.com/api/v3/files'
+$script:VtUploadUrlUrl   = 'https://www.virustotal.com/api/v3/files/upload_url'
+$script:VtAnalysesUrl    = 'https://www.virustotal.com/api/v3/analyses'
+$script:VtGuiFileUrl     = 'https://www.virustotal.com/gui/file'
+$script:VtLargeFileBytes = 33554432
+
+# ---------------------------------------------------------------------------
+# Network primitive -- upload one file and poll for the analysis result.
+# Returns the parsed analysis response object, or $null on upload/poll
+# failure (callers decide whether that is fatal). Uses curl.exe so it runs
+# unchanged on PowerShell 5.1 and 7.
+# ---------------------------------------------------------------------------
+function Invoke-VirusTotalScan {
+   param(
+      [Parameter(Mandatory = $true)][string]$FilePath,
+      [Parameter(Mandatory = $true)][string]$ApiKey
+   )
+
+   $filesize  = (Get-Item -LiteralPath $FilePath).Length
+   $uploadUrl = $script:VtFilesUrl
+
+   # Files >32MB need a one-shot large-file upload URL.
+   if ($filesize -gt $script:VtLargeFileBytes) {
+      try {
+         $ulResp = Invoke-RestMethod -Uri $script:VtUploadUrlUrl -Method Get -Headers @{ 'x-apikey' = $ApiKey }
+         $uploadUrl = $ulResp.data
+      }
+      catch {
+         Write-Host "    Failed to get large-file upload URL: $_" -ForegroundColor Red
+         return $null
+      }
+   }
+
+   $curlOut = & curl.exe --silent --request POST `
+                         --url $uploadUrl `
+                         --header "x-apikey: $ApiKey" `
+                         --form "file=@$FilePath"
+   if ($LASTEXITCODE -ne 0) {
+      Write-Host "    curl upload failed (exit $LASTEXITCODE)" -ForegroundColor Red
+      return $null
+   }
+   try {
+      $upResp = $curlOut | ConvertFrom-Json
+   }
+   catch {
+      Write-Host "    Upload response not JSON: $curlOut" -ForegroundColor Red
+      return $null
+   }
+   $analysisId = $upResp.data.id
+   if (-not $analysisId) {
+      Write-Host "    No analysis id in upload response" -ForegroundColor Red
+      return $null
+   }
+
+   # Poll /analyses/{id} every 15s up to 10 minutes total.
+   for ($i = 1; $i -le 40; $i++) {
+      Start-Sleep -Seconds 15
+      try {
+         $poll = Invoke-RestMethod -Uri "$($script:VtAnalysesUrl)/$analysisId" -Method Get -Headers @{ 'x-apikey' = $ApiKey }
+      }
+      catch {
+         Write-Host "    Poll $i/40 error: $_" -ForegroundColor DarkYellow
+         continue
+      }
+      if ($poll.data.attributes.status -eq 'completed') {
+         return $poll
+      }
+      Write-Host "    Poll $i/40: status=$($poll.data.attributes.status)" -ForegroundColor DarkGray
+   }
+   Write-Host "    Poll timed out after 10 minutes" -ForegroundColor Red
+   return $null
+}
+
+# ---------------------------------------------------------------------------
+# Pure (network-free) helpers -- shared verdict + result shaping + report.
+# ---------------------------------------------------------------------------
+
+# Single definition of the threshold verdict, used by both callers.
+function Get-VtVerdict {
+   param([int]$Malicious, [int]$Suspicious, [int]$Threshold)
+
+   if ($Malicious -ge $Threshold) { return 'BLOCKED' }
+   if ($Malicious -gt 0 -or $Suspicious -gt 0) { return 'WARN' }
+   return 'CLEAN'
+}
+
+# Shape a completed VT analysis response into a flat result record (used by
+# the CI report AND FullBuild's console pre-flight, so stats parsing lives in
+# exactly one place).
+function ConvertTo-VtResult {
+   param([string]$FileName, $Analysis, [int]$Threshold)
+
+   $stats     = $Analysis.data.attributes.stats
+   $malicious = [int]$stats.malicious
+   $suspicious= [int]$stats.suspicious
+   $undetected= [int]$stats.undetected
+   $harmless  = [int]$stats.harmless
+   $failure   = [int]$stats.failure
+   $sha       = [string]$Analysis.meta.file_info.sha256
+
+   $details = @()
+   if ($malicious -gt 0 -or $suspicious -gt 0) {
+      $details = @(
+         foreach ($engine in $Analysis.data.attributes.results.PSObject.Properties) {
+            if ($engine.Value.category -in @('malicious', 'suspicious')) {
+               [pscustomobject]@{
+                  Engine   = $engine.Name
+                  Category = $engine.Value.category
+                  Result   = $engine.Value.result
+               }
+            }
+         }
+      )
+   }
+
+   [pscustomobject]@{
+      File       = $FileName
+      Status     = 'OK'
+      Malicious  = $malicious
+      Suspicious = $suspicious
+      Undetected = $undetected
+      Harmless   = $harmless
+      Total      = $malicious + $suspicious + $undetected + $harmless + $failure
+      Sha        = $sha
+      Permalink  = "$($script:VtGuiFileUrl)/$sha"
+      Details    = $details
+      Verdict    = Get-VtVerdict -Malicious $malicious -Suspicious $suspicious -Threshold $Threshold
+   }
+}
+
+function Get-VtFailure {
+   param([object[]]$Results, [int]$Threshold)
+
+   @(
+      foreach ($r in $Results) {
+         if ($r.Status -ne 'OK') {
+            "$($r.File) (scan incomplete)"
+         }
+         elseif ($r.Verdict -eq 'BLOCKED') {
+            "$($r.File) ($($r.Malicious) malicious detections >= threshold $Threshold)"
+         }
+      }
+   )
+}
+
+function New-VtMarkdownReport {
+   param(
+      [object[]]$Results,
+      [int]$Threshold,
+      [string]$RefName,
+      [string]$ShortSha,
+      [string]$ScanDate
+   )
+
+   $md = [System.Collections.Generic.List[string]]::new()
+   $md.Add('# VirusTotal Scan Report')
+   $md.Add('')
+   $md.Add("**Build**: $RefName | **Date**: $ScanDate | **Commit**: $ShortSha")
+   $md.Add("**Detection threshold**: $Threshold malicious engines")
+   $md.Add('')
+   $md.Add('## Results Summary')
+   $md.Add('')
+   $md.Add('| File | Malicious | Suspicious | Clean | Total | Result | Link |')
+   $md.Add('|------|-----------|------------|-------|-------|--------|------|')
+   foreach ($r in $Results) {
+      if ($r.Status -ne 'OK') {
+         $md.Add("| $($r.File) | - | - | - | - | SCAN INCOMPLETE | - |")
+      }
+      elseif ($r.Verdict -eq 'BLOCKED') {
+         $md.Add("| $($r.File) | **$($r.Malicious)** | $($r.Suspicious) | $($r.Undetected) | $($r.Total) | BLOCKED | [View]($($r.Permalink)) |")
+      }
+      elseif ($r.Verdict -eq 'WARN') {
+         $md.Add("| $($r.File) | $($r.Malicious) | $($r.Suspicious) | $($r.Undetected) | $($r.Total) | WARN (below threshold) | [View]($($r.Permalink)) |")
+      }
+      else {
+         $clean = $r.Undetected + $r.Harmless
+         $md.Add("| $($r.File) | $($r.Malicious) | $($r.Suspicious) | $clean | $($r.Total) | CLEAN | [View]($($r.Permalink)) |")
+      }
+   }
+
+   if ($Results | Where-Object { $_.Details.Count -gt 0 }) {
+      $md.Add('')
+      $md.Add('## Detection Details')
+      $md.Add('')
+      foreach ($r in $Results) {
+         if ($r.Details.Count -gt 0) {
+            $md.Add("### $($r.File)")
+            $md.Add('')
+            $md.Add('| Engine | Category | Detection |')
+            $md.Add('|--------|----------|-----------|')
+            foreach ($d in $r.Details) {
+               $md.Add("| $($d.Engine) | $($d.Category) | $($d.Result) |")
+            }
+            $md.Add('')
+         }
+      }
+   }
+
+   $md.Add('')
+   $md.Add('## File Hashes (SHA-256)')
+   $md.Add('')
+   $md.Add('```')
+   foreach ($r in $Results) {
+      if ($r.Sha) {
+         $md.Add("$($r.Sha)  $($r.File)")
+      }
+   }
+   $md.Add('```')
+   $md.Add('')
+   $md.Add('---')
+   $md.Add("*Scanned by [VirusTotal](https://www.virustotal.com) via GitHub Actions | Threshold: $Threshold malicious detections*")
+
+   return ($md -join "`n")
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: exercise the network-free logic against built-in sample data.
+# ---------------------------------------------------------------------------
+function Invoke-SelfTest {
+   Write-Host '=== SELF-TEST: Get-VtVerdict / ConvertTo-VtResult / Get-VtFailure / New-VtMarkdownReport ==='
+
+   # Sample VT analysis shaped like the real TR4W case (a handful of heuristic
+   # detections on an unsigned, packed PE).
+   $sample = [pscustomobject]@{
+      data = [pscustomobject]@{
+         attributes = [pscustomobject]@{
+            status = 'completed'
+            stats  = [pscustomobject]@{ malicious = 7; suspicious = 1; undetected = 60; harmless = 0; failure = 2 }
+            results = [pscustomobject]@{
+               'DrWeb'   = [pscustomobject]@{ category = 'malicious';  result = 'Tool.VulnDriver.32' }
+               'Wacatac' = [pscustomobject]@{ category = 'malicious';  result = 'Wacatac.B!ml' }
+               'VBA32'   = [pscustomobject]@{ category = 'suspicious'; result = 'BScope.Trojan' }
+               'CleanAV' = [pscustomobject]@{ category = 'undetected'; result = $null }
+            }
+         }
+      }
+      meta = [pscustomobject]@{ file_info = [pscustomobject]@{ sha256 = 'abc123def456' } }
+   }
+
+   $errors = @()
+
+   # Verdict boundaries.
+   if ((Get-VtVerdict -Malicious 7 -Suspicious 0 -Threshold 8) -ne 'WARN')    { $errors += 'verdict 7<8 should be WARN' }
+   if ((Get-VtVerdict -Malicious 8 -Suspicious 0 -Threshold 8) -ne 'BLOCKED') { $errors += 'verdict 8>=8 should be BLOCKED' }
+   if ((Get-VtVerdict -Malicious 0 -Suspicious 0 -Threshold 8) -ne 'CLEAN')   { $errors += 'verdict 0/0 should be CLEAN' }
+
+   $blocked = ConvertTo-VtResult -FileName 'tr4w_setup_eng.exe' -Analysis $sample -Threshold 7
+   if ($blocked.Malicious -ne 7)        { $errors += "expected Malicious=7, got $($blocked.Malicious)" }
+   if ($blocked.Total -ne 70)           { $errors += "expected Total=70, got $($blocked.Total)" }
+   if ($blocked.Details.Count -ne 3)    { $errors += "expected 3 detail rows, got $($blocked.Details.Count)" }
+   if ($blocked.Verdict -ne 'BLOCKED')  { $errors += "expected BLOCKED at threshold 7, got $($blocked.Verdict)" }
+   if ($blocked.Sha -ne 'abc123def456') { $errors += "sha mismatch: $($blocked.Sha)" }
+
+   $warn = ConvertTo-VtResult -FileName 'tr4w_setup_rus.exe' -Analysis $sample -Threshold 8
+   if ($warn.Verdict -ne 'WARN')        { $errors += "expected WARN at threshold 8, got $($warn.Verdict)" }
+
+   $incomplete = [pscustomobject]@{
+      File = 'tr4w_setup_ger.exe'; Status = 'SCAN_INCOMPLETE'; Malicious = 0; Suspicious = 0
+      Undetected = 0; Harmless = 0; Total = 0; Sha = ''; Permalink = ''; Details = @(); Verdict = 'CLEAN'
+   }
+
+   $results = @($warn, $incomplete)
+   $failuresAt8 = Get-VtFailure -Results $results -Threshold 8
+   if ($failuresAt8.Count -ne 1)        { $errors += "threshold 8: expected 1 failure (incomplete only), got $($failuresAt8.Count)" }
+
+   $report = New-VtMarkdownReport -Results @($warn, $incomplete) -Threshold 8 -RefName 'v4.147.22' -ShortSha 'deadbee' -ScanDate '2026-05-29 12:00 UTC'
+   if ($report -notmatch 'WARN \(below threshold\)') { $errors += 'report missing WARN row' }
+   if ($report -notmatch 'SCAN INCOMPLETE')          { $errors += 'report missing SCAN INCOMPLETE row' }
+   if ($report -notmatch 'Tool\.VulnDriver\.32')     { $errors += 'report missing detection detail' }
+
+   Write-Host ''
+   Write-Host '--- Sample report ---'
+   Write-Host $report
+   Write-Host ''
+
+   if ($errors.Count -gt 0) {
+      Write-Host 'SELF-TEST FAILED:'
+      $errors | ForEach-Object { Write-Host "  - $_" }
+      exit 1
+   }
+   Write-Host 'SELF-TEST PASSED.'
+}
+
+# ---------------------------------------------------------------------------
+# Entry point. When dot-sourced (FullBuild loading the functions), do nothing.
+# ---------------------------------------------------------------------------
+if ($MyInvocation.InvocationName -eq '.') {
+   return
+}
+
+if ($SelfTest) {
+   Invoke-SelfTest
+   return
+}
+
+# --- CI authoritative scan ---
+if ([string]::IsNullOrWhiteSpace($InstallerDir) -or [string]::IsNullOrWhiteSpace($ReportPath)) {
+   throw 'InstallerDir and ReportPath are required unless -SelfTest is specified.'
+}
+
+$apiKey = $env:VT_API_KEY
+if ([string]::IsNullOrWhiteSpace($apiKey)) {
+   Write-Error 'VT_API_KEY environment variable is empty -- cannot scan.'
+   exit 1
+}
+
+$scanFiles = @(Get-ChildItem -LiteralPath $InstallerDir -Recurse -Filter 'tr4w_setup_*.exe' -File -ErrorAction SilentlyContinue)
+if ($scanFiles.Count -eq 0) {
+   Write-Error "No installers (tr4w_setup_*.exe) found under '$InstallerDir'."
+   exit 1
+}
+Write-Host "Found $($scanFiles.Count) installer(s) to scan:"
+$scanFiles | ForEach-Object { Write-Host "  $($_.FullName)" }
+
+$results = @(
+   foreach ($file in $scanFiles) {
+      Write-Host ''
+      Write-Host "Scanning: $($file.Name)"
+      $analysis = Invoke-VirusTotalScan -FilePath $file.FullName -ApiKey $apiKey
+      if ($null -eq $analysis) {
+         Write-Host '  Result: SCAN INCOMPLETE (upload or poll failed)'
+         [pscustomobject]@{
+            File = $file.Name; Status = 'SCAN_INCOMPLETE'; Malicious = 0; Suspicious = 0
+            Undetected = 0; Harmless = 0; Total = 0; Sha = ''; Permalink = ''; Details = @(); Verdict = 'CLEAN'
+         }
+      }
+      else {
+         $r = ConvertTo-VtResult -FileName $file.Name -Analysis $analysis -Threshold $Threshold
+         Write-Host "  Result: $($r.Verdict) -- $($r.Malicious) malicious / $($r.Suspicious) suspicious of $($r.Total) engines"
+         $r
+      }
+   }
+)
+
+$failures = Get-VtFailure -Results $results -Threshold $Threshold
+
+$scanDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm') + ' UTC'
+$shortSha = if ($CommitSha.Length -ge 7) { $CommitSha.Substring(0, 7) } else { $CommitSha }
+$report   = New-VtMarkdownReport -Results $results -Threshold $Threshold -RefName $RefName -ShortSha $shortSha -ScanDate $scanDate
+
+# UTF-8 (no BOM under pwsh, which is what the CI step uses) so the Markdown
+# renders cleanly on the release page.
+Set-Content -LiteralPath $ReportPath -Value $report -Encoding utf8
+Write-Host ''
+Write-Host '=== Scan Report ==='
+Write-Host $report
+
+if ($failures.Count -gt 0) {
+   Write-Host ''
+   Write-Host 'SCAN FAILED -- release will be blocked:'
+   $failures | ForEach-Object { Write-Host "  $_" }
+   exit 1
+}
+Write-Host ''
+Write-Host "All installer(s) passed VirusTotal scan (threshold: $Threshold)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,15 @@
 #   2. Tag push v4.X.Y-all   -> Full ENG + 7 per-language installers
 #   3. Manual (Actions UI)   -> Run workflow button, "Build all languages" checkbox
 #
-# Pipeline:
-#   build (Windows runner)        -> compile, NSIS, upload installer artifact
+# Pipeline (TR4W is Windows-only; ALL jobs run on the self-hosted
+# [self-hosted, win-ci] lab runner -- nothing runs on GitHub-hosted servers):
+#   build (win-ci)                -> compile, NSIS, upload installer artifact
 #                                    (UPX is opt-in via FullBuild.ps1's -UseUpx
 #                                    switch; CI does not pass it as of 2026-05-28)
-#   virustotal-scan (ubuntu)      -> download installer(s), scan via VT API,
+#   virustotal-scan (win-ci)      -> download installer(s), scan via VT API
+#                                    (PowerShell 7: .github/scripts/Invoke-VirusTotalScan.ps1),
 #                                    produce virustotal-report.md, upload as artifact
-#   release (ubuntu)              -> only on tag push; download both artifacts,
+#   release (win-ci)              -> only on tag push; download both artifacts,
 #                                    create draft release with installer(s)
 #                                    AND the VT report attached
 #
@@ -224,8 +226,8 @@ jobs:
           if-no-files-found: error
 
   # =================================================================
-  # VirusTotal scan -- runs on ubuntu (we don't need Windows), pulls
-  # the installer artifact from the build job, uploads each installer
+  # VirusTotal scan -- runs on the self-hosted win-ci runner (PowerShell 7).
+  # Pulls the installer artifact from the build job, uploads each installer
   # to VT, polls for completion, builds a Markdown report, and uploads
   # it as a separate artifact for the release job to attach.
   #
@@ -235,7 +237,7 @@ jobs:
   virustotal-scan:
     name: VirusTotal Scan
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, win-ci]
     if: >-
       always()
       && needs.build.result == 'success'
@@ -251,232 +253,20 @@ jobs:
       - name: Scan installers with VirusTotal
         env:
           VT_API_KEY: ${{ secrets.VIRUS_TOTAL_API_KEY }}
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-
-          if [ -z "${VT_API_KEY:-}" ]; then
-            echo "VIRUS_TOTAL_API_KEY secret is empty -- cannot scan." >&2
-            exit 1
-          fi
-
-          # Collect installer files to scan.
-          SCAN_FILES=()
-          while IFS= read -r -d '' f; do
-            SCAN_FILES+=("$f")
-          done < <(find installers -name 'tr4w_setup_*.exe' -print0 2>/dev/null)
-
-          if [ ${#SCAN_FILES[@]} -eq 0 ]; then
-            echo "No installers found to scan." >&2
-            exit 1
-          fi
-
-          echo "Found ${#SCAN_FILES[@]} installer(s) to scan:"
-          printf '  %s\n' "${SCAN_FILES[@]}"
-
-          # --- Helper: upload a file to VirusTotal ---
-          upload_file() {
-            local filepath="$1"
-            local filesize
-            filesize=$(stat -c%s "$filepath")
-            local upload_url="https://www.virustotal.com/api/v3/files"
-
-            # Files >32MB need a special upload URL.
-            if [ "$filesize" -gt 33554432 ]; then
-              echo "  File >32MB, requesting large-file upload URL..." >&2
-              upload_url=$(curl -s --request GET \
-                --url "https://www.virustotal.com/api/v3/files/upload_url" \
-                --header "x-apikey: ${VT_API_KEY}" | jq -r '.data')
-              if [ -z "$upload_url" ] || [ "$upload_url" = "null" ]; then
-                echo "  ERROR: Failed to get large-file upload URL" >&2
-                return 1
-              fi
-            fi
-
-            local response
-            response=$(curl -s --request POST \
-              --url "$upload_url" \
-              --header "x-apikey: ${VT_API_KEY}" \
-              --form "file=@${filepath}")
-
-            local analysis_id
-            analysis_id=$(echo "$response" | jq -r '.data.id // empty')
-            if [ -z "$analysis_id" ]; then
-              echo "  ERROR: Upload failed. Response: $response" >&2
-              return 1
-            fi
-            echo "$analysis_id"
-          }
-
-          # --- Helper: poll for analysis completion ---
-          poll_analysis() {
-            local analysis_id="$1"
-            local max_attempts=40   # 40 * 15s = 10 min max
-            local attempt=0
-            while [ $attempt -lt $max_attempts ]; do
-              attempt=$((attempt + 1))
-              sleep 15
-              local response
-              response=$(curl -s --request GET \
-                --url "https://www.virustotal.com/api/v3/analyses/${analysis_id}" \
-                --header "x-apikey: ${VT_API_KEY}")
-              local status
-              status=$(echo "$response" | jq -r '.data.attributes.status // empty')
-              if [ "$status" = "completed" ]; then
-                echo "$response"
-                return 0
-              fi
-              echo "  Poll $attempt/$max_attempts: status=$status" >&2
-            done
-            echo "  ERROR: Analysis timed out after $max_attempts attempts" >&2
-            return 1
-          }
-
-          declare -A RESULTS
-          declare -A ENGINE_DETAILS
-          SCAN_DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          REF_NAME="${{ github.ref_name }}"
-
-          for filepath in "${SCAN_FILES[@]}"; do
-            filename=$(basename "$filepath")
-            echo ""
-            echo "Scanning: $filename"
-
-            echo "  Uploading to VirusTotal..."
-            analysis_id=$(upload_file "$filepath") || {
-              RESULTS["$filename"]="UPLOAD_FAILED|||||||"
-              continue
-            }
-            echo "  Analysis ID: $analysis_id"
-
-            echo "  Waiting for analysis..."
-            analysis_response=$(poll_analysis "$analysis_id") || {
-              RESULTS["$filename"]="POLL_TIMEOUT|||||||"
-              continue
-            }
-
-            malicious=$(echo "$analysis_response"  | jq -r '.data.attributes.stats.malicious  // 0')
-            suspicious=$(echo "$analysis_response" | jq -r '.data.attributes.stats.suspicious // 0')
-            undetected=$(echo "$analysis_response" | jq -r '.data.attributes.stats.undetected // 0')
-            harmless=$(echo "$analysis_response"   | jq -r '.data.attributes.stats.harmless   // 0')
-            failure=$(echo "$analysis_response"    | jq -r '.data.attributes.stats.failure    // 0')
-            total=$((malicious + suspicious + undetected + harmless + failure))
-            file_sha256=$(echo "$analysis_response" | jq -r '.meta.file_info.sha256 // empty')
-            permalink="https://www.virustotal.com/gui/file/${file_sha256}"
-
-            engine_details=""
-            if [ "$malicious" -gt 0 ] || [ "$suspicious" -gt 0 ]; then
-              engine_details=$(echo "$analysis_response" | jq -r '
-                [.data.attributes.results | to_entries[]
-                 | select(.value.category == "malicious" or .value.category == "suspicious")
-                 | "\(.key)|\(.value.category)|\(.value.result)"]
-                | join("\n")')
-            fi
-
-            RESULTS["$filename"]="${malicious}|${suspicious}|${undetected}|${harmless}|${total}|${permalink}|${file_sha256}"
-            ENGINE_DETAILS["$filename"]="$engine_details"
-
-            if [ "$malicious" -gt 0 ] || [ "$suspicious" -gt 0 ]; then
-              echo "  Result: ${malicious} malicious, ${suspicious} suspicious out of ${total} engines"
-            else
-              echo "  Result: CLEAN (${total} engines)"
-            fi
-          done
-
-          # --- Pass/fail per threshold ---
-          THRESHOLD="${{ env.VT_MALICIOUS_THRESHOLD }}"
-          SCAN_FAILED=false
-          FAILED_FILES=()
-          for filename in "${!RESULTS[@]}"; do
-            IFS='|' read -r mal sus undet harm tot link sha <<< "${RESULTS[$filename]}"
-            if [ "$mal" = "UPLOAD_FAILED" ] || [ "$mal" = "POLL_TIMEOUT" ]; then
-              SCAN_FAILED=true
-              FAILED_FILES+=("$filename (scan incomplete)")
-            elif [ "$mal" -ge "$THRESHOLD" ]; then
-              SCAN_FAILED=true
-              FAILED_FILES+=("$filename (${mal} malicious detections >= threshold ${THRESHOLD})")
-            fi
-          done
-
-          # --- Markdown report ---
-          {
-            echo "# VirusTotal Scan Report"
-            echo ""
-            echo "**Build**: ${REF_NAME} | **Date**: ${SCAN_DATE} | **Commit**: ${SHORT_SHA}"
-            echo "**Detection threshold**: ${THRESHOLD} malicious engines"
-            echo ""
-            echo "## Results Summary"
-            echo ""
-            echo "| File | Malicious | Suspicious | Clean | Total | Result | Link |"
-            echo "|------|-----------|------------|-------|-------|--------|------|"
-            for filename in "${!RESULTS[@]}"; do
-              IFS='|' read -r mal sus undet harm tot link sha <<< "${RESULTS[$filename]}"
-              if [ "$mal" = "UPLOAD_FAILED" ]; then
-                echo "| ${filename} | - | - | - | - | UPLOAD FAILED | - |"
-              elif [ "$mal" = "POLL_TIMEOUT" ]; then
-                echo "| ${filename} | - | - | - | - | TIMEOUT | - |"
-              elif [ "$mal" -ge "$THRESHOLD" ]; then
-                echo "| ${filename} | **${mal}** | ${sus} | ${undet} | ${tot} | BLOCKED | [View](${link}) |"
-              elif [ "$mal" -gt 0 ] || [ "$sus" -gt 0 ]; then
-                echo "| ${filename} | ${mal} | ${sus} | ${undet} | ${tot} | WARN (below threshold) | [View](${link}) |"
-              else
-                clean=$((undet + harm))
-                echo "| ${filename} | ${mal} | ${sus} | ${clean} | ${tot} | CLEAN | [View](${link}) |"
-              fi
-            done
-
-            HAS_DETECTIONS=false
-            for filename in "${!ENGINE_DETAILS[@]}"; do
-              if [ -n "${ENGINE_DETAILS[$filename]}" ]; then HAS_DETECTIONS=true; break; fi
-            done
-            if [ "$HAS_DETECTIONS" = true ]; then
-              echo ""
-              echo "## Detection Details"
-              echo ""
-              for filename in "${!ENGINE_DETAILS[@]}"; do
-                details="${ENGINE_DETAILS[$filename]}"
-                if [ -n "$details" ]; then
-                  echo "### ${filename}"
-                  echo ""
-                  echo "| Engine | Category | Detection |"
-                  echo "|--------|----------|-----------|"
-                  echo "$details" | while IFS='|' read -r eng cat res; do
-                    echo "| ${eng} | ${cat} | ${res} |"
-                  done
-                  echo ""
-                fi
-              done
-            fi
-
-            echo ""
-            echo "## File Hashes (SHA-256)"
-            echo ""
-            echo '```'
-            for filename in "${!RESULTS[@]}"; do
-              IFS='|' read -r mal sus undet harm tot link sha <<< "${RESULTS[$filename]}"
-              if [ -n "$sha" ] && [ "$sha" != "" ]; then
-                echo "${sha}  ${filename}"
-              fi
-            done
-            echo '```'
-            echo ""
-            echo "---"
-            echo "*Scanned by [VirusTotal](https://www.virustotal.com) via GitHub Actions | Threshold: ${THRESHOLD} malicious detections*"
-          } > virustotal-report.md
-
-          echo ""
-          echo "=== Scan Report ==="
-          cat virustotal-report.md
-
-          if [ "$SCAN_FAILED" = true ]; then
-            echo ""
-            echo "SCAN FAILED -- release will be blocked:"
-            printf '  %s\n' "${FAILED_FILES[@]}"
-            exit 1
-          fi
-          echo ""
-          echo "All installer(s) passed VirusTotal scan (threshold: ${THRESHOLD})"
+          # PowerShell 7 port of the former bash VT-scan (Windows-only project;
+          # whole pipeline runs on the lab runner now). Logic lives in a
+          # standalone, unit-tested script (run it with -SelfTest to validate
+          # the parse/report logic without the API). The API key is passed via
+          # the VT_API_KEY env var above, never on the command line.
+          & '${{ github.workspace }}\.github\scripts\Invoke-VirusTotalScan.ps1' `
+            -InstallerDir 'installers' `
+            -ReportPath   'virustotal-report.md' `
+            -Threshold    ([int]'${{ env.VT_MALICIOUS_THRESHOLD }}') `
+            -RefName      '${{ github.ref_name }}' `
+            -CommitSha    '${{ github.sha }}'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload VT report artifact
         if: always()
@@ -494,7 +284,7 @@ jobs:
   release:
     name: Create draft GitHub Release
     needs: [build, virustotal-scan]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, win-ci]
     if: github.event_name == 'push'
 
     steps:
@@ -511,7 +301,8 @@ jobs:
           path: release-files
 
       - name: List release files
-        run: ls -la release-files/
+        shell: pwsh
+        run: Get-ChildItem -LiteralPath release-files | Format-Table Name, Length, LastWriteTime
 
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,90 @@
+# Place at .github/workflows/version-guard.yml in n4af/tr4w
+#
+# Purpose:
+#   Guard against tr4w/src/Version.pas being dropped or corrupted by a merge.
+#
+#   On 2026-05-29 an "evil merge" (commit 2beeb9b) resolved a Version.pas
+#   conflict between two version-bumped branches by deleting the file
+#   entirely. Nothing caught it at merge time -- release.yml only reads
+#   Version.pas at TAG time, long after the bad merge had landed on master.
+#
+#   This workflow runs at the moment a change lands -- on every pull request
+#   and on every push to master -- and fails fast if Version.pas is missing
+#   or no longer contains a parseable version string.
+#
+# What it deliberately does NOT do:
+#   It does NOT require the version to be bumped or changed in a PR. The
+#   project's release process intentionally bumps Version.pas LATE -- only
+#   after a PR is validated on a teammate's machine, as a separate step right
+#   before tagging. So a normal PR (and a fresh merge to master) legitimately
+#   still carries the PREVIOUS version string. This guard only asserts the
+#   file exists and parses; the tag/version match stays in release.yml.
+#
+# Runner / shell:
+#   Runs on the same self-hosted [self-hosted, win-ci] runner as release.yml's
+#   build job (TR4W is a Windows-only project) and uses PowerShell with the
+#   SAME Select-String extraction release.yml uses at tag time -- so the guard
+#   and the release job validate Version.pas identically. No toolchain, no
+#   build: this is a sub-second text check.
+
+name: Version.pas Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+# A newer push to the same ref supersedes an in-flight check.
+concurrency:
+  group: version-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-guard:
+    name: Verify Version.pas is present and parseable
+    runs-on: [self-hosted, win-ci]
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Assert Version.pas exists and parses
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $file = Join-Path $env:GITHUB_WORKSPACE 'tr4w\src\Version.pas'
+
+          # 1. Existence -- the exact failure mode of the 2beeb9b evil merge.
+          if (-not (Test-Path $file)) {
+            Write-Host "::error file=tr4w/src/Version.pas::tr4w/src/Version.pas is missing."
+            Write-Host "Version.pas is the single source of truth for the release version and MUST NOT be dropped."
+            Write-Host "If a merge removed it, restore it (e.g. 'git checkout <last-good-commit> -- tr4w/src/Version.pas') before merging."
+            exit 1
+          }
+
+          # 2. Parseable version constant -- identical regex to the
+          #    'Extract version from src/Version.pas' step in release.yml,
+          #    so if this guard passes the release workflow can always read
+          #    the version.
+          $match = Select-String -Path $file `
+                                 -Pattern "TR4W_CURRENTVERSION_NUMBER\s*=\s*'([^']+)'" `
+                   | Select-Object -First 1
+          if (-not $match) {
+            Write-Host "::error file=tr4w/src/Version.pas::Could not find a TR4W_CURRENTVERSION_NUMBER = '...' line in tr4w/src/Version.pas."
+            Write-Host "The file is present but its version constant is missing or malformed."
+            exit 1
+          }
+          $version = $match.Matches[0].Groups[1].Value
+
+          # 3. Sanity-check the shape (dotted numeric, e.g. 4.147.22). Catches a
+          #    constant that survived but got corrupted to garbage. Lenient on
+          #    the major number (future-proof for v5+); NO comparison against
+          #    any expected value -- bumps happen later, by design.
+          if ($version -notmatch '^[0-9]+(\.[0-9]+)+$') {
+            Write-Host "::error file=tr4w/src/Version.pas::TR4W_CURRENTVERSION_NUMBER = '$version' is not a valid dotted version (expected e.g. 4.147.22)."
+            exit 1
+          }
+
+          Write-Host "Version.pas present; TR4W_CURRENTVERSION_NUMBER = '$version' -- OK"

--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -320,74 +320,14 @@ function Test-InstallerDependencies {
     return $true
 }
 
-# Upload one file to VirusTotal and poll for the analysis result.
-# Uses curl.exe for the multipart upload because Windows PowerShell 5.1's
-# Invoke-RestMethod lacks the -Form switch (PS 7+ only). curl.exe ships
-# with Windows 10 1803+ so the dependency is effectively zero.
-# Returns the parsed analysis response object on success, or $null on
-# upload/poll failure (informational only -- callers don't fail the
-# build).
-function Invoke-VirusTotalScan {
-    param(
-        [Parameter(Mandatory=$true)][string]$FilePath,
-        [Parameter(Mandatory=$true)][string]$ApiKey
-    )
-
-    $filesize = (Get-Item $FilePath).Length
-    $uploadUrl = 'https://www.virustotal.com/api/v3/files'
-
-    # Files >32MB need a one-shot large-file upload URL.
-    if ($filesize -gt 33554432) {
-        try {
-            $ulResp = Invoke-RestMethod -Uri 'https://www.virustotal.com/api/v3/files/upload_url' `
-                                        -Method Get `
-                                        -Headers @{ 'x-apikey' = $ApiKey }
-            $uploadUrl = $ulResp.data
-        } catch {
-            Write-Host "    Failed to get large-file upload URL: $_" -ForegroundColor Red
-            return $null
-        }
-    }
-
-    $curlOut = & curl.exe --silent --request POST `
-                          --url $uploadUrl `
-                          --header "x-apikey: $ApiKey" `
-                          --form "file=@$FilePath"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "    curl upload failed (exit $LASTEXITCODE)" -ForegroundColor Red
-        return $null
-    }
-    try {
-        $upResp = $curlOut | ConvertFrom-Json
-    } catch {
-        Write-Host "    Upload response not JSON: $curlOut" -ForegroundColor Red
-        return $null
-    }
-    $analysisId = $upResp.data.id
-    if (-not $analysisId) {
-        Write-Host "    No analysis id in upload response" -ForegroundColor Red
-        return $null
-    }
-
-    # Poll /analyses/{id} every 15s up to 10 minutes total.
-    for ($i = 1; $i -le 40; $i++) {
-        Start-Sleep -Seconds 15
-        try {
-            $poll = Invoke-RestMethod -Uri "https://www.virustotal.com/api/v3/analyses/$analysisId" `
-                                       -Method Get `
-                                       -Headers @{ 'x-apikey' = $ApiKey }
-        } catch {
-            Write-Host "    Poll $i/40 error: $_" -ForegroundColor DarkYellow
-            continue
-        }
-        if ($poll.data.attributes.status -eq 'completed') {
-            return $poll
-        }
-        Write-Host "    Poll $i/40: status=$($poll.data.attributes.status)" -ForegroundColor DarkGray
-    }
-    Write-Host "    Poll timed out after 10 minutes" -ForegroundColor Red
-    return $null
-}
+# VirusTotal scan logic is shared with the CI release pipeline -- the single
+# source of truth lives in .github/scripts/Invoke-VirusTotalScan.ps1. Dot-
+# source it to load Invoke-VirusTotalScan (curl-based upload + poll, returns
+# the analysis object or $null), ConvertTo-VtResult, and Get-VtVerdict. That
+# script no-ops when dot-sourced; it only runs a scan when invoked directly
+# (the CI release job does that). $ProjectRoot is one level above tr4w\ (see
+# the param block), so the shared script sits at <root>\.github\scripts\.
+. (Join-Path $ProjectRoot '.github\scripts\Invoke-VirusTotalScan.ps1')
 
 # Helper: UPX + makensis for the exe currently in target\tr4w.exe.
 # Pass empty $langCode for the no-suffix ENG installer, or the lowercase
@@ -793,23 +733,17 @@ if ($result -eq 0 -and $BuildInstallers -and (Test-Path $RELEASE_DIR)) {
                     Write-Host "    Scan unavailable -- continuing." -ForegroundColor Yellow
                     continue
                 }
-                $stats   = $vt.data.attributes.stats
-                $mal     = [int]$stats.malicious
-                $sus     = [int]$stats.suspicious
-                $undet   = [int]$stats.undetected
-                $harm    = [int]$stats.harmless
-                $fail    = [int]$stats.failure
-                $total   = $mal + $sus + $undet + $harm + $fail
-                $sha     = $vt.meta.file_info.sha256
-                if ($mal -ge $VT_MALICIOUS_THRESHOLD) {
-                    $verdict = "BLOCKED (>= CI threshold of $VT_MALICIOUS_THRESHOLD)"; $color = "Red"
-                } elseif ($mal -gt 0 -or $sus -gt 0) {
-                    $verdict = "WARN (below CI threshold)"; $color = "Yellow"
-                } else {
-                    $verdict = "CLEAN"; $color = "Green"
+                # Shape via the shared helper so stats parsing + the
+                # threshold verdict live in exactly one place (the same code
+                # the CI report uses).
+                $r = ConvertTo-VtResult -FileName $inst.Name -Analysis $vt -Threshold $VT_MALICIOUS_THRESHOLD
+                switch ($r.Verdict) {
+                    'BLOCKED' { $verdict = "BLOCKED (>= CI threshold of $VT_MALICIOUS_THRESHOLD)"; $color = "Red" }
+                    'WARN'    { $verdict = "WARN (below CI threshold)";                            $color = "Yellow" }
+                    default   { $verdict = "CLEAN";                                                $color = "Green" }
                 }
-                Write-Host "    $verdict -- $mal malicious / $sus suspicious / $($undet + $harm) clean of $total engines" -ForegroundColor $color
-                Write-Host "    https://www.virustotal.com/gui/file/$sha" -ForegroundColor Cyan
+                Write-Host "    $verdict -- $($r.Malicious) malicious / $($r.Suspicious) suspicious / $($r.Undetected + $r.Harmless) clean of $($r.Total) engines" -ForegroundColor $color
+                Write-Host "    https://www.virustotal.com/gui/file/$($r.Sha)" -ForegroundColor Cyan
             }
             Write-Host ""
             Write-Host "Local scan complete. CI VT-scan is the authoritative gate on tag push." -ForegroundColor DarkGray


### PR DESCRIPTION
Two related CI changes. TR4W is a Windows-only project; all CI now runs on the self-hosted `[self-hosted, win-ci]` lab runner — nothing on GitHub-hosted servers.

## 1. Version.pas merge guard (`f40daf2`)
On 2026-05-29 an "evil merge" (`2beeb9b`) resolved a `Version.pas` conflict between two version-bumped branches by deleting the file outright. Nothing caught it at merge time — `release.yml` only reads `Version.pas` at **tag** time.

New `.github/workflows/version-guard.yml` runs on **every pull_request and push to master** and fails fast if `tr4w/src/Version.pas` is missing or no longer contains a parseable `TR4W_CURRENTVERSION_NUMBER`. It uses the **same `Select-String` extraction** `release.yml` uses at tag time.

It deliberately does **not** require a version bump — the release process bumps `Version.pas` late (after PR validation, right before tagging), so a normal PR legitimately carries the previous version string. Existence + parse only.

## 2. Entire release pipeline on self-hosted win-ci (`2e70261`)
`build` already ran on win-ci, but `virustotal-scan` and `release` still ran on GitHub-hosted `ubuntu-latest`. Both moved to the lab runner.

The VT scan was ~230 lines of bash (curl + jq). Replaced with a single shared PowerShell script `.github/scripts/Invoke-VirusTotalScan.ps1` — the one source of truth for VT logic:
- Uses `curl.exe` for the multipart upload (no `-Form` / no pwsh-7 dependency) so it runs identically under Windows PowerShell 5.1 and pwsh 7.
- Run directly (`-InstallerDir`/`-ReportPath`) → CI authoritative scan (writes the Markdown report, exits non-zero past `-Threshold`). Dot-sourced → just exposes the functions.
- **Deduplicates** with the local build: `tr4w/FullBuild.ps1` had a near-identical VT upload/poll/verdict copy. It now dot-sources the shared script, so upload, polling, stats parsing, and the threshold verdict live in exactly one place. As a bonus, `Build.cmd` now exercises the same VT code CI uses.

The `release` job's only shell step (`ls -la`) becomes `Get-ChildItem`; the download/upload/gh-release actions are JS actions that run unchanged on a self-hosted Windows runner. API key still arrives via `VT_API_KEY` (mapped from `secrets.VIRUS_TOTAL_API_KEY`), never on the command line.

## Testing
- Parse + `-SelfTest` pass on **both** PowerShell 5.1 and pwsh 7 (verdict boundaries, result shaping, failure detection, report generation).
- Dot-source loads the functions and no-ops under 5.1 (how `FullBuild` consumes it).
- `curl.exe` confirmed present on the runner.
- **Live end-to-end confirmed:** a `BuildAllInstallers` run uploaded installers to VirusTotal via the shared script and the scan worked.

## Out of scope / related
- #941 — ESP missing from the VERSIONINFO `$langMap` in `FullBuild.ps1` (pre-existing, cosmetic, non-fatal; to be fixed on the ESP/master branch).