### PR TITLE
Point dev/test build scripts at the bundled Indy tree

### DIFF
--- a/tr4w/BatchCompile.cmd
+++ b/tr4w/BatchCompile.cmd
@@ -1,7 +1,7 @@
-set LIB=C:\Indy\Lib\Core;
-set LIB=%LIB%C:\Indy\Lib\System;
+set LIB=C:\tr4w\tr4w\include\Core;
+set LIB=%LIB%C:\tr4w\tr4w\include\System;
 set LIB=%LIB%C:\tr4w\tr4w\include;
-set LIB=%LIB%C:\Indy\Lib\Protocols;
+set LIB=%LIB%C:\tr4w\tr4w\include\Protocols;
 rem set LIB=%LIB%C:\Dev\D6\Source\ToolsApi;
 rem set LIB=%LIB%C:\Dev\D6\Source\RTL\Lib;
 rem set LIB=%LIB%C:\Infocare\Components\genericSQL;

--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -544,9 +544,10 @@ if ($result -eq 0) {
         # downstream consumes target\tr4w.exe or src\*.dcu, so this loop
         # can leave them in whatever state the final language produced.
         #
-        # Indy DCUs at C:\Indy\Indy\Lib\* stay cached across iterations,
-        # which is the only way to keep per-language builds under ~3 min
-        # each instead of ~3 min just for the Indy rebuild alone.
+        # Indy DCUs (compiled from the bundled include\ tree) stay cached
+        # across iterations, which is the only way to keep per-language
+        # builds under ~3 min each instead of ~3 min just for the Indy
+        # rebuild alone.
         #
         # POL/CHN are excluded -- they each have many missing
         # constants tracked separately under issue #925.

--- a/tr4w/test/CompileRadioTester.cmd
+++ b/tr4w/test/CompileRadioTester.cmd
@@ -1,10 +1,10 @@
 @echo off
 REM Compile RadioFactoryTester.dpr using Delphi 7 command-line compiler
 
-set LIB=C:\Indy\Lib\Core;
-set LIB=%LIB%C:\Indy\Lib\System;
+set LIB=C:\tr4w\tr4w\include\Core;
+set LIB=%LIB%C:\tr4w\tr4w\include\System;
 set LIB=%LIB%C:\tr4w\tr4w\include;
-set LIB=%LIB%C:\Indy\Lib\Protocols;
+set LIB=%LIB%C:\tr4w\tr4w\include\Protocols;
 
 set EXE=C:\TR4W\tr4w\target
 cd C:\tr4w\tr4w

--- a/tr4w/test/CompileRadioTester.ps1
+++ b/tr4w/test/CompileRadioTester.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Continue"
 
-$LIB = "C:\Indy\Lib\Core;C:\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Lib\Protocols;C:\tr4w\tr4w\src;C:\tr4w\tr4w\src\trdos;C:\tr4w\tr4w\src\utils"
+$LIB = "C:\tr4w\tr4w\include\Core;C:\tr4w\tr4w\include\System;C:\tr4w\tr4w\include;C:\tr4w\tr4w\include\Protocols;C:\tr4w\tr4w\src;C:\tr4w\tr4w\src\trdos;C:\tr4w\tr4w\src\utils"
 $DCC32 = "C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE"
 $PROJECT = "C:\TR4W\tr4w\test\RadioFactoryTester.dpr"
 $EXE_DIR = "C:\TR4W\tr4w\target"

--- a/tr4w/test/CompileTest.cmd
+++ b/tr4w/test/CompileTest.cmd
@@ -1,8 +1,8 @@
 @echo off
-set LIB=C:\Indy\Lib\Core;
-set LIB=%LIB%C:\Indy\Lib\System;
+set LIB=C:\tr4w\tr4w\include\Core;
+set LIB=%LIB%C:\tr4w\tr4w\include\System;
 set LIB=%LIB%C:\tr4w\tr4w\include;
-set LIB=%LIB%C:\Indy\Lib\Protocols;
+set LIB=%LIB%C:\tr4w\tr4w\include\Protocols;
 set EXE=C:\TR4W\tr4w\target
 cd C:\tr4w\tr4w
 "c:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE" src\uHamLibDirect.pas -$D+ -$L+ -$Y+ -NC:\Temp /U%LIB% /I%LIB% /E%EXE%

--- a/tr4w/test/CompileTest.ps1
+++ b/tr4w/test/CompileTest.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Continue"
 
-$LIB = "C:\Indy\Lib\Core;C:\Indy\Lib\System;C:\tr4w\tr4w\include;C:\Indy\Lib\Protocols"
+$LIB = "C:\tr4w\tr4w\include\Core;C:\tr4w\tr4w\include\System;C:\tr4w\tr4w\include;C:\tr4w\tr4w\include\Protocols"
 $DCC32 = "C:\Program Files (x86)\Borland\Delphi7\Bin\DCC32.EXE"
 $SRC = "c:\tr4w\tr4w\src"
 

--- a/tr4w/tr4wserver/BuildServer.ps1
+++ b/tr4w/tr4wserver/BuildServer.ps1
@@ -4,7 +4,7 @@ param(
     # location and the same env vars FullBuild.ps1 uses.
     [string]$ProjectRoot = (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent),
     [string]$Delphi7Bin  = $(if ($env:DELPHI7_BIN) { $env:DELPHI7_BIN } else { "C:\Program Files (x86)\Borland\Delphi7\Bin" }),
-    [string]$IndyRoot    = $(if ($env:INDY_ROOT)   { $env:INDY_ROOT }   else { "C:\Indy\Indy\Lib" })
+    [string]$IndyRoot    = $(if ($env:INDY_ROOT)   { $env:INDY_ROOT }   else { Join-Path (Join-Path $ProjectRoot "tr4w") "include" })
 )
 
 $ErrorActionPreference = "Continue"


### PR DESCRIPTION
## What

`BatchCompile.cmd`, `test/CompileTest.{cmd,ps1}`, and `test/CompileRadioTester.{cmd,ps1}` hardcoded an external Indy install at `C:\Indy\Lib\{Core,System,Protocols}`. The project bundles Indy 10.6.3.3 under `tr4w\include\{Core,System,Protocols}`, so these now point at the bundled tree -- removing the external-install dependency.

`BuildServer.ps1`'s `$IndyRoot` default was `C:\Indy\Indy\Lib`, contradicting its own header comment ("defaults derived from script location, same as FullBuild.ps1"). It now defaults to the bundled `tr4w\include` like `FullBuild.ps1`, so **standalone** server builds work without an external Indy.

Also corrected a stale `C:\Indy\Indy\Lib` path in a `FullBuild.ps1` comment.

## Why it's safe (no CI impact)

CI runs `FullBuild.ps1`, which already uses the bundled tree and passes `-IndyRoot` when chaining `BuildServer.ps1`. These scripts are dev/standalone conveniences not exercised by CI.

## Change (7 files)

- 5 dev/test scripts: `C:\Indy\Lib\*` -> `C:\tr4w\tr4w\include\*`
- `BuildServer.ps1`: `$IndyRoot` default -> bundled `tr4w\include` (derived from `$ProjectRoot`)
- `FullBuild.ps1`: comment path corrected

## Known follow-up (out of scope here)

The 5 dev scripts remain machine-specific in other respects (repo at `C:\tr4w`, output at `C:\TR4W\tr4w\target`, `C:\Temp`, fixed Delphi path). Making them fully portable (derive paths from script location like `FullBuild.ps1`/`BuildServer.ps1`) is a separate change.

## Verify

Run `BuildServer.ps1` standalone (no `-IndyRoot`) on a machine with the bundled tree -> server compiles. Dev scripts work when the repo is at `C:\tr4w`.