### PR TITLE
Add ESP to VERSIONINFO $langMap in FullBuild.ps1 (fixes #941)

### DIFF
--- a/tr4w/FullBuild.ps1
+++ b/tr4w/FullBuild.ps1
@@ -1,6 +1,6 @@
 param(
     # When set, after the default ENG build, loop through every other
-    # supported LANG_xxx (RUS, SER, MNG, CZE, ROM, GER, UKR) and rebuild
+    # supported LANG_xxx (RUS, SER, MNG, CZE, ROM, GER, UKR, ESP) and rebuild
     # against each. Excludes POL/CHN (broken constants, issue #925).
     [switch]$AllLanguages,
 
@@ -179,6 +179,7 @@ function Write-VersionInfoResource {
         'ENG' = @{ LangId = 0x0409; CodePage = 1252; Name = 'English (United States)' }
         'RUS' = @{ LangId = 0x0419; CodePage = 1251; Name = 'Russian' }
         'GER' = @{ LangId = 0x0407; CodePage = 1252; Name = 'German' }
+        'ESP' = @{ LangId = 0x0C0A; CodePage = 1252; Name = 'Spanish (Spain)' }
         'CZE' = @{ LangId = 0x0405; CodePage = 1250; Name = 'Czech' }
         'ROM' = @{ LangId = 0x0418; CodePage = 1250; Name = 'Romanian' }
         'UKR' = @{ LangId = 0x0422; CodePage = 1251; Name = 'Ukrainian' }


### PR DESCRIPTION
Fixes #941.

## Problem

The 2026-05-28 ESP backfill added ESP to the build matrix (`$otherLangs`) but **not** to the VERSIONINFO language table (`$langMap`). Per-language ESP builds therefore emitted:

```
No VERSIONINFO LANGID mapping for 'ESP' -- defaulting to ENG
```

and tagged the ESP `tr4w.exe`'s embedded version info (Properties → Details) as English (`0x0409` / CP1252). Cosmetic metadata only — the UI was already fully Spanish via `-DLANG_ESP` + the ESP `.res`, and the fallback is non-fatal so the build/installer/VirusTotal scan all proceeded.

## Fix

- Added `'ESP' = @{ LangId = 0x0C0A; CodePage = 1252; Name = 'Spanish (Spain)' }` to `$langMap`.
  - `0x0C0A` = Spanish (Spain, International/Modern sort, es-ES) — confirmed by maintainer.
  - CP1252 (Western Latin-1), same as ENG/GER.
  - Resulting StringFileInfo block name: `0C0A04E4`.
- Updated the stale param-doc comment (line 3) to include ESP in the supported-language list.

ESP is now consistent across both the build matrix and `$langMap`.

## Verify

Run `FullBuild.ps1 -AllLanguages`: the ESP iteration no longer prints the LANGID warning, and `tr4w_esp.exe` → Properties → Details shows Spanish (Spain).