### PR TITLE
Run VirusTotal scan under Windows PowerShell 5.1, not pwsh

### DIFF
--- a/.github/scripts/Invoke-VirusTotalScan.ps1
+++ b/.github/scripts/Invoke-VirusTotalScan.ps1
@@ -19,8 +19,8 @@
 
    The multipart upload uses curl.exe (ships with Windows 10 1803+), NOT
    Invoke-RestMethod -Form. That keeps the script identical under Windows
-   PowerShell 5.1 (FullBuild runs under powershell.exe) and PowerShell 7 (the
-   CI step runs under pwsh) -- no -Form / no pwsh-7 dependency.
+   PowerShell 5.1 (both FullBuild's local pre-flight and the CI step run under
+   powershell.exe) and PowerShell 7 -- no -Form / no pwsh-7 dependency.
 
    The VirusTotal API key is read from the VT_API_KEY environment variable in
    CI mode (mapped from secrets.VIRUS_TOTAL_API_KEY); FullBuild passes its key
@@ -393,9 +393,13 @@ $scanDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm') + ' UTC'
 $shortSha = if ($CommitSha.Length -ge 7) { $CommitSha.Substring(0, 7) } else { $CommitSha }
 $report   = New-VtMarkdownReport -Results $results -Threshold $Threshold -RefName $RefName -ShortSha $shortSha -ScanDate $scanDate
 
-# UTF-8 (no BOM under pwsh, which is what the CI step uses) so the Markdown
-# renders cleanly on the release page.
-Set-Content -LiteralPath $ReportPath -Value $report -Encoding utf8
+# Write UTF-8 WITHOUT a BOM so the Markdown renders cleanly on the release
+# page. Windows PowerShell 5.1's `Set-Content -Encoding utf8` would add a BOM,
+# so write via .NET with a BOM-less UTF8Encoding. Resolve the (possibly
+# relative) path against PowerShell's current location -- [IO.File] uses the
+# process working dir, which is not kept in sync with Get-Location.
+$reportFull = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ReportPath)
+[System.IO.File]::WriteAllText($reportFull, $report, (New-Object System.Text.UTF8Encoding($false)))
 Write-Host ''
 Write-Host '=== Scan Report ==='
 Write-Host $report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@
 #                                    (UPX is opt-in via FullBuild.ps1's -UseUpx
 #                                    switch; CI does not pass it as of 2026-05-28)
 #   virustotal-scan (win-ci)      -> download installer(s), scan via VT API
-#                                    (PowerShell 7: .github/scripts/Invoke-VirusTotalScan.ps1),
+#                                    (Windows PowerShell 5.1: .github/scripts/Invoke-VirusTotalScan.ps1),
 #                                    produce virustotal-report.md, upload as artifact
 #   release (win-ci)              -> only on tag push; download both artifacts,
 #                                    create draft release with installer(s)
@@ -253,10 +253,12 @@ jobs:
       - name: Scan installers with VirusTotal
         env:
           VT_API_KEY: ${{ secrets.VIRUS_TOTAL_API_KEY }}
-        shell: pwsh
+        shell: powershell
         run: |
-          # PowerShell 7 port of the former bash VT-scan (Windows-only project;
-          # whole pipeline runs on the lab runner now). Logic lives in a
+          # VT-scan under Windows PowerShell 5.1 (the runner has 5.1
+          # machine-wide; the script is runtime-agnostic -- curl.exe upload,
+          # no -Form -- so this CI step and FullBuild's local pre-flight share
+          # one file). Logic lives in a
           # standalone, unit-tested script (run it with -SelfTest to validate
           # the parse/report logic without the API). The API key is passed via
           # the VT_API_KEY env var above, never on the command line.
@@ -301,7 +303,7 @@ jobs:
           path: release-files
 
       - name: List release files
-        shell: pwsh
+        shell: powershell
         run: Get-ChildItem -LiteralPath release-files | Format-Table Name, Length, LastWriteTime
 
       - name: Create draft GitHub Release


### PR DESCRIPTION
## Problem

The `v4.147.24-all` release failed at the VirusTotal step with:

```
Error: pwsh: command not found
```

The `virustotal-scan` and `release` jobs in `release.yml` used `shell: pwsh`, but the self-hosted `win-ci` runner has **no machine-wide PowerShell 7**. Confirmed on the runner:

- Runner service `actions.runner.n4af-TR4W.windows11-ci` runs as **`LocalSystem`**.
- `C:\Program Files\PowerShell\7\pwsh.exe` → **does not exist**.
- Machine `PATH` has only Windows PowerShell 5.1.
- The only `pwsh` is a **per-user Microsoft Store app-execution-alias** (0-byte stub) under the `Runner` account's `%LOCALAPPDATA%\...\WindowsApps` — invisible to the `LocalSystem` service.

So `pwsh` resolves when you log in interactively as `Runner`, but not for the runner's job process. Both observations reconcile: a per-user Store install can't be seen by a LocalSystem service.

## Fix

- Switch both `shell: pwsh` steps (VT scan, file listing) to `shell: powershell` (Windows PowerShell 5.1, which is on the machine PATH and is what every other step in the pipeline already uses).
- `Invoke-VirusTotalScan.ps1` is already runtime-agnostic by design (multipart upload via `curl.exe`, no `Invoke-RestMethod -Form`), and `FullBuild.ps1` already dot-sources it under 5.1 for the local pre-flight — so **no logic change** is needed. `-SelfTest` passes under 5.1.
- Fix the report writer: 5.1's `Set-Content -Encoding utf8` emits a BOM, so write BOM-less UTF-8 via .NET, resolving the (possibly relative) path against PowerShell's current location. Verified: no BOM under 5.1.
- Update stale "PowerShell 7" comments.

## Verification

- `Invoke-VirusTotalScan.ps1 -SelfTest` → PASSED under Windows PowerShell 5.1.
- BOM-less write path verified (first bytes `23 20 54`, no `EF BB BF`).

## Note on releasing 4.147.24

A tag-triggered run uses the workflow file **at the tagged commit**, so re-running the old run won't help (it re-reads the broken YAML at `v4.147.24-all` → `9516208`). After this merges, the `v4.147.24-all` tag must be **deleted and recreated on the new master HEAD** to re-trigger the pipeline with the fixed workflow (`Version.pas` is still 4.147.24, so tag validation passes).