### PR TITLE
Offline TRMASTER.DTA builder toolset

### DIFF
--- a/tr4w/tools/trmaster/.gitignore
+++ b/tr4w/tools/trmaster/.gitignore
@@ -1,0 +1,9 @@
+# build tooling only -- never commit data artifacts or downloads
+__pycache__/
+*.pyc
+_work/
+seed/
+*.dta
+*.DTA
+*.xlsx
+*.csv

--- a/tr4w/tools/trmaster/README.md
+++ b/tr4w/tools/trmaster/README.md
@@ -1,0 +1,120 @@
+# TRMASTER.DTA offline builder
+
+Offline tooling to (re)generate `TRMASTER.DTA` without depending on an external
+maintainer's pipeline. **Nothing here runs inside TR4W** — run it before a build.
+
+It unions a fresh callsign list (supercheckpartial) with the membership/name
+layer (CWops, FOC, HSC) and a curated name seed, optionally prunes lapsed
+US/UK/CA calls, backfills names from QRZ, and writes the same **K1EA
+"CT / TRlog" `.dta`** TR4W already reads (no program changes).
+
+## Files
+
+- **`build_trmaster.cmd`** — the monthly one-command runner. Downloads sources,
+  builds, QRZ-fills names, prunes, and deploys to `tr4w\target\TRMASTER.DTA`
+  (previous file → `.bak`). Edit the variables at the top. **Start here.**
+- **`trmaster_build.py`** — downloads sources, merges, prunes, writes, validates.
+- **`trmaster_codec.py`** — reader/writer for the `.dta` format + a self-test.
+  `python trmaster_codec.py ../../target/TRMASTER.DTA` reports a field census and
+  a read→write→read round-trip (PASS = writer reproduces the same calls, fields,
+  and bucket placement the reader sees).
+- **`trmaster_names_qrz.py`** — QRZ name resolver. Looks up still-nameless calls
+  in a built `.dta` and emits a `CALL,NAME` CSV for `--names-csv`. Name priority:
+  **nickname** ("Tom") → `fname` ("Thomas") → the `name` field **if it looks like
+  a person, not a club** (recovers DX individuals like `9M2OCX→SHAHRUL`). Names
+  are ASCII-folded (José→JOSE) for CW. Creds from `~/qrz_settings.cfg`; its own
+  UTF-8 JSON cache with **atomic incremental saves** (kill-safe) and a **180-day
+  TTL for names / 30-day for no-name results**. `--cache-only` regenerates the
+  CSV from cache with no API calls. **Skips cleanly** (empty CSV, exit 0) with no
+  QRZ subscription, so a future maintainer without QRZ can still build.
+
+## Quick start (monthly)
+
+```
+build_trmaster.cmd
+```
+
+On first run it seeds `seed\TRMASTER_seed.DTA` from the current
+`target\TRMASTER.DTA`, then: downloads SCP.DB (+ MASTER.DTA + CWops), builds,
+runs QRZ, builds again with names, and deploys. Re-run `trmaster_names_qrz.py`
+(step 3) a few times the first month to backfill the ~44k bare calls; the cache
+makes later runs fast.
+
+## Format (documented in `trmaster_codec.py`)
+
+- 37×37 = 1,369 buckets (`A–Z 0–9 /`); 5,480-byte offset table (1,369 starts +
+  1 end-offset = file size); then null-terminated `call + ^tag fields` records.
+- A call is stored in the bucket of **each distinct adjacent char pair**, **except
+  `JA`** (deliberately skipped — too common; matches `LogSCP.BestTwoLetters`).
+- Field tags (verified against `N4AF`): `=N`/^N = first name (UPPERCASE),
+  `=U`/^U = **CWops number**, `=F`/^F = **FOC number**, `=V`/^V = **HSC number**,
+  plus Section/CQZone/Grid/ITUZone/Check/QTH/Hits/Speed/etc.
+
+## Sources
+
+- **supercheckpartial MASTER.DTA** — `https://supercheckpartial.com/downloads/MASTER.DTA`
+  (calls only; the SCP coverage layer, ~50k). Read directly by the codec.
+- **supercheckpartial SCP.DB** — `https://supercheckpartial.com/downloads/SCP.DB`
+  (SQLite; `callsigns` ~69k with `verified` bitmask). Used for the QRZ-verified
+  prune. Note: its `annual_rate` is **lifetime QSOs ÷ years active** — a lifetime
+  average with **no recency**, so it can't tell active-now from long-lapsed.
+- **CWops roster CSV** — Google Sheets `…/export?format=csv`. Positional columns
+  (no header): `[2]=call, [3]=CWops#, [4]=first name`. Refreshed every run.
+- **FOC / HSC** — seeded from the curated seed file (no live feed: the FOC page is
+  a Cloudflare/AJAX wall). Override with `--foc-csv` / `--hsc-csv CALL,NUM[,NAME]`.
+
+## Pruning lapsed calls (`--prune-qrz-unverified SCP.DB`)
+
+Drops calls SCP.DB marks **not QRZ-verified** — but **only US/UK/CA** prefixes
+(`K/N/W/AA-AL`, `G/M/2E/2I/2M/2U/2W`, `VA/VE/VO/VY`), where QRZ/licensing coverage
+is comprehensive enough that "not QRZ-verified" means lapsed/invalid. **DX calls
+are always kept** (QRZ is not a definitive source outside those regions), and
+curated CWops/FOC/HSC/seed calls are never pruned. In practice this removes
+~158 dead US/UK/CA calls while keeping ~1,822 valid DX without QRZ pages.
+
+## Name augmentation
+
+The bare SCP calls have no name. **QRZ** (`trmaster_names_qrz.py`) is the source:
+it has the on-air **nickname** *and* covers **international** calls. Credentials in
+`~/qrz_settings.cfg`. No subscription → it skips and calls stay bare (fine for SCP).
+*(FCC ULS `en.first_name` is a US-only fallback if ever needed — gives the formal
+name, not the nickname — exportable to a `--names-csv`.)*
+
+## Merge precedence (per call)
+
+1. curated **seed** (preserve accumulated Name + memberships + orphan names)
+2. CWops CSV → `User1` (CWops #) + Name (current roster wins)
+3. FOC → `FOC` # + Name (fills if missing)
+4. HSC → `User2` (HSC #)
+5. `--names-csv` (QRZ) fills any remaining nameless call
+
+Calls present only in the SCP source stay **bare** — still work for Super Check
+Partial, just no prefill.
+
+## Self-reference / what to back up
+
+`build_trmaster.cmd` reads a **frozen** `seed\TRMASTER_seed.DTA` (created once) and
+*writes* `target\TRMASTER.DTA`. There is **no read-from-and-write-to-`target`
+loop**, so the monthly `target` output is fully regenerable and you do **not** need
+to keep old copies (one `.bak` is kept for rollback). The files that carry
+non-regenerable history — **back these up**:
+
+- `seed\TRMASTER_seed.DTA` — frozen curated names / FOC / HSC / orphan names.
+- `~\.publicLogProcessor\qrz_name_cache.json` — accumulated QRZ lookups (the
+  expensive part; otherwise re-querying ~44k calls).
+
+Caveat: FOC/HSC are frozen at the seed snapshot (no live roster feed); CWops is
+refreshed live each run; QRZ names grow via the cache. Re-baseline the seed
+(`copy target → seed`) only as a deliberate choice.
+
+## `_work/`
+
+Scratch dir for downloads + caches; git-ignored. Never commit downloaded data.
+
+## Status / follow-ups
+
+- Codec round-trip **proven** vs the shipped `TRMASTER.DTA` (6,354 calls); reads
+  supercheckpartial's foreign `MASTER.DTA` (50,015 calls) cleanly.
+- Current build: ~53k calls, ~8.6k named, US/UK/CA prune, validated.
+- TODO: live FOC/HSC roster feeds; optional — measure live SCP lookup speed with
+  the larger file before making it the default.

--- a/tr4w/tools/trmaster/build_trmaster.cmd
+++ b/tr4w/tools/trmaster/build_trmaster.cmd
@@ -1,0 +1,74 @@
+@echo off
+REM ===========================================================================
+REM  build_trmaster.cmd  --  monthly TRMASTER.DTA build for TR4W
+REM
+REM  Produces  tools\trmaster\TRMASTER.DTA  and STOPS.  It never touches
+REM  tr4w\target\ -- copying the result into place is YOUR deploy step.
+REM
+REM  Pipeline:
+REM    1. download supercheckpartial SCP.DB (MASTER.DTA + CWops auto-download)
+REM    2. build pass 1: MASTER universe + curated seed/rosters, US/UK/CA
+REM       QRZ-verified prune  ->  identifies which calls still need names
+REM    3. QRZ name resolver fills the bare calls (cached; cheap on re-runs)
+REM    4. build pass 2: same inputs + the QRZ names  ->  TRMASTER.DTA
+REM
+REM  Inputs that carry history (back these up; see README):
+REM    seed\TRMASTER_seed.DTA                  curated names / FOC / HSC / orphans
+REM    %USERPROFILE%\.publicLogProcessor\qrz_name_cache.json   accumulated QRZ names
+REM ===========================================================================
+
+setlocal
+cd /d "%~dp0"
+
+set "PYTHON=python"
+set "WORK=_work"
+set "SEED=seed\TRMASTER_seed.DTA"
+set "OUT=TRMASTER.DTA"
+set "SCPDB=%WORK%\SCP.DB"
+set "NAMES=%WORK%\qrz_names.csv"
+set "QRZ_LIMIT=5000"
+set "CWOPS_URL=https://docs.google.com/spreadsheets/d/1Ew8b1WAorFRCixGRsr031atxmS0SsycvmOczS_fDqzc/export?format=csv"
+
+if not exist "%WORK%" mkdir "%WORK%"
+
+REM --- the curated seed is a required, one-time input (never read from target) -
+if not exist "%SEED%" (
+    echo ERROR: missing curated seed "%SEED%".
+    echo One-time setup: copy your curated TRMASTER.DTA there, e.g.
+    echo     mkdir seed ^&^& copy "your_curated_TRMASTER.DTA" "%SEED%"
+    goto :error
+)
+
+REM --- 1. refresh SCP.DB (used for the QRZ-verified prune) --------------------
+echo [1/4] downloading SCP.DB ...
+curl -sL --fail -o "%SCPDB%" https://supercheckpartial.com/downloads/SCP.DB || goto :error
+
+REM --- 2. first build (downloads MASTER.DTA + CWops; --force = fresh) ---------
+echo [2/4] build pass 1 (universe + rosters + prune) ...
+"%PYTHON%" trmaster_build.py --out "%OUT%" --existing "%SEED%" ^
+    --download-master --force --cwops-url "%CWOPS_URL%" ^
+    --prune-qrz-unverified "%SCPDB%" || goto :error
+
+REM --- 3. QRZ name resolution for the bare calls (skips cleanly if no creds) --
+echo [3/4] QRZ name lookups (limit %QRZ_LIMIT%) ...
+"%PYTHON%" trmaster_names_qrz.py --dta "%OUT%" --out "%NAMES%" ^
+    --limit %QRZ_LIMIT% --sleep 0.2 || goto :error
+
+REM --- 4. final build with names --------------------------------------------
+echo [4/4] build pass 2 (with QRZ names) ...
+"%PYTHON%" trmaster_build.py --out "%OUT%" --existing "%SEED%" ^
+    --download-master --cwops-url "%CWOPS_URL%" ^
+    --prune-qrz-unverified "%SCPDB%" --names-csv "%NAMES%" || goto :error
+
+echo.
+echo Done.  Built:  %~dp0%OUT%
+echo Deploy step (yours):  copy "%~dp0%OUT%"  to  tr4w\target\TRMASTER.DTA
+echo (First month: re-run step 3 a few times to backfill the ~44k bare names.)
+endlocal
+exit /b 0
+
+:error
+echo.
+echo *** build_trmaster FAILED (errorlevel %errorlevel%). ***
+endlocal
+exit /b 1

--- a/tr4w/tools/trmaster/trmaster_build.py
+++ b/tr4w/tools/trmaster/trmaster_build.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Offline TRMASTER.DTA builder.
+
+Unions a fresh callsign list (supercheckpartial MASTER.DTA, or optionally the
+richer SCP.DB sqlite) with the membership/name layer (CWops roster CSV, FOC,
+HSC) and any previously-accumulated names from the existing TRMASTER.DTA, then
+writes a single K1EA .dta that TR4W's existing reader consumes unchanged.
+
+Pipeline (precedence shown):
+  call universe  = MASTER.DTA calls  (+ every roster/existing call)
+  per call fields:
+    1. existing TRMASTER.DTA            (preserve accumulated Name + memberships)
+    2. CWops CSV   -> User1 (CWops #) + Name (overrides; roster is current)
+    3. FOC         -> FOC #            + Name (fills if missing)
+    4. HSC         -> User2 (HSC #)
+    5. name resolver (optional --names-csv from your FCC/QRZ script) fills any
+       call still missing a Name
+
+Nothing here runs inside TR4W. Run it before the monthly build.
+
+  python trmaster_build.py --out TRMASTER.DTA \
+      --existing ../../target/TRMASTER.DTA \
+      --download-master --cwops-url <google-csv-export-url> \
+      [--scp-db _work/SCP.DB] [--names-csv names.csv] [--foc-csv foc.csv]
+
+See README.md in this directory for source URLs and the FCC/QRZ hook.
+"""
+
+import argparse
+import csv
+import os
+import re
+import sqlite3
+import sys
+import urllib.request
+
+import trmaster_codec as tc
+
+CALL_RE = re.compile(r"^[A-Z0-9/]{3,}$")
+
+# Prefixes where QRZ / licensing coverage is comprehensive enough that
+# "not QRZ-verified" reliably means lapsed/invalid: US (K/N/W/AA-AL),
+# UK (G/M/2E/2I/2M/2U/2W), Canada (VA/VE/VO/VY). Everywhere else is DX, where
+# QRZ is NOT a definitive source, so those calls are never pruned.
+US_UK_CA_RE = re.compile(r"^([KNW]|A[A-L]|G|M|2[EIMUW]|V[AEOY])")
+
+
+def is_qrz_reliable_region(call):
+    return bool(US_UK_CA_RE.match(call))
+MASTER_DTA_URL = "https://supercheckpartial.com/downloads/MASTER.DTA"
+SCP_DB_URL = "https://supercheckpartial.com/downloads/SCP.DB"
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def download(url, dest, force=False):
+    if os.path.exists(dest) and not force:
+        log(f"  cached: {dest} ({os.path.getsize(dest)} bytes)")
+        return dest
+    log(f"  downloading {url} -> {dest}")
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    req = urllib.request.Request(url, headers={"User-Agent": "tr4w-trmaster-build"})
+    with urllib.request.urlopen(req, timeout=120) as r, open(dest, "wb") as f:
+        f.write(r.read())
+    log(f"  saved {os.path.getsize(dest)} bytes")
+    return dest
+
+
+def valid_call(c):
+    return bool(c) and bool(CALL_RE.match(c))
+
+
+# --- source loaders ---------------------------------------------------------
+
+def load_calls_from_dta(path):
+    """Just the callsign universe from a .dta (e.g. supercheckpartial MASTER.DTA)."""
+    return set(tc.read_dta(path)["calls"].keys())
+
+
+def load_calls_from_scpdb(path, min_annual_rate=0):
+    """Callsign universe from SCP.DB; optional activity floor via annual_rate."""
+    out = set()
+    c = sqlite3.connect(path)
+    for call, rate in c.execute("select callsign, annual_rate from callsigns"):
+        if call and valid_call(call.upper()):
+            if min_annual_rate and (rate or 0) < min_annual_rate:
+                continue
+            out.add(call.upper())
+    c.close()
+    return out
+
+
+def load_scpdb_verified(path):
+    """From SCP.DB return (all_calls, qrz_verified_calls).
+    QRZ-verified = bit 4 of the `verified` bitmask."""
+    allc, ver = set(), set()
+    c = sqlite3.connect(path)
+    for call, v in c.execute("select callsign, verified from callsigns"):
+        if not call:
+            continue
+        cu = call.upper()
+        allc.add(cu)
+        if (v or 0) & (1 << 4):
+            ver.add(cu)
+    c.close()
+    return allc, ver
+
+
+def load_existing(path):
+    """Existing TRMASTER fields, to preserve accumulated names + memberships."""
+    if not path or not os.path.exists(path):
+        return {}
+    return tc.read_dta(path)["calls"]
+
+
+def parse_cwops_csv(path):
+    """CWops roster CSV -> {CALL: {'User1': cwops#, 'Name': FIRSTNAME}}.
+
+    Positional columns (no usable header): [2]=call [3]=number [4]=first name.
+    """
+    out = {}
+    with open(path, newline="", encoding="utf-8", errors="replace") as f:
+        for row in csv.reader(f):
+            if len(row) < 5:
+                continue
+            call = row[2].strip().upper()
+            num = row[3].strip()
+            name = row[4].strip().upper()
+            if not valid_call(call) or not num.isdigit():
+                continue
+            rec = {"User1": num}
+            if name:
+                rec["Name"] = name
+            out[call] = rec
+    return out
+
+
+def parse_simple_csv(path, field):
+    """Generic 'CALL,NUMBER[,NAME]' loader for FOC/HSC exports.
+    `field` is 'FOC' or 'User2'. Returns {CALL: {field: num, ['Name': NAME]}}.
+    """
+    out = {}
+    if not path or not os.path.exists(path):
+        return out
+    with open(path, newline="", encoding="utf-8", errors="replace") as f:
+        for row in csv.reader(f):
+            if not row:
+                continue
+            call = row[0].strip().upper()
+            if not valid_call(call):
+                continue
+            rec = {}
+            if len(row) > 1 and row[1].strip():
+                rec[field] = row[1].strip()
+            if len(row) > 2 and row[2].strip():
+                rec["Name"] = row[2].strip().upper()
+            if rec:
+                out[call] = rec
+    return out
+
+
+def load_names_csv(path):
+    """Optional name source (e.g. produced by the user's FCC/QRZ scripts):
+    'CALL,NAME' -> {CALL: NAME(upper)}.  This is the name-resolver hook.
+    """
+    out = {}
+    if not path or not os.path.exists(path):
+        return out
+    with open(path, newline="", encoding="utf-8", errors="replace") as f:
+        for row in csv.reader(f):
+            if len(row) >= 2 and valid_call(row[0].strip().upper()) and row[1].strip():
+                out[row[0].strip().upper()] = row[1].strip().upper()
+    return out
+
+
+# --- merge ------------------------------------------------------------------
+
+def merge(universe, existing, cwops, foc, hsc, names):
+    """Build {CALL: fields} by the documented precedence."""
+    calls = set(universe) | set(existing) | set(cwops) | set(foc) | set(hsc)
+    out = {}
+    for call in calls:
+        f = {}
+        # 1. preserve accumulated data
+        if call in existing:
+            f.update(existing[call])
+        # 2. CWops (current roster wins for number + name)
+        if call in cwops:
+            f["User1"] = cwops[call]["User1"]
+            if cwops[call].get("Name"):
+                f["Name"] = cwops[call]["Name"]
+        # 3. FOC
+        if call in foc:
+            if foc[call].get("FOC"):
+                f["FOC"] = foc[call]["FOC"]
+            if foc[call].get("Name") and not f.get("Name"):
+                f["Name"] = foc[call]["Name"]
+        # 4. HSC
+        if call in hsc and hsc[call].get("User2"):
+            f["User2"] = hsc[call]["User2"]
+        # 5. name resolver fills the gap
+        if not f.get("Name") and call in names:
+            f["Name"] = names[call]
+        out[call] = f
+    return out
+
+
+def census(calls, label):
+    def has(fld):
+        return sum(1 for v in calls.values() if v.get(fld))
+    log(f"=== {label}: {len(calls)} calls ===")
+    for fld in ("Name", "User1", "FOC", "User2"):
+        log(f"    {fld:6}: {has(fld)}")
+    log(f"    bare (no name): {sum(1 for v in calls.values() if not v.get('Name'))}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Offline TRMASTER.DTA builder")
+    ap.add_argument("--out", default="TRMASTER.DTA")
+    ap.add_argument("--existing", help="existing TRMASTER.DTA to preserve names from")
+    ap.add_argument("--master-dta", help="local supercheckpartial MASTER.DTA")
+    ap.add_argument("--download-master", action="store_true",
+                    help="download the latest MASTER.DTA")
+    ap.add_argument("--scp-db", help="SCP.DB sqlite as the call universe (instead of MASTER.DTA)")
+    ap.add_argument("--min-annual-rate", type=int, default=0,
+                    help="when using --scp-db, drop calls below this activity rate")
+    ap.add_argument("--cwops-csv", help="local CWops roster CSV")
+    ap.add_argument("--cwops-url", help="CWops roster CSV export URL")
+    ap.add_argument("--foc-csv", help="FOC export CSV (CALL,NUM[,NAME])")
+    ap.add_argument("--hsc-csv", help="HSC export CSV (CALL,NUM[,NAME])")
+    ap.add_argument("--names-csv", help="name source CSV (CALL,NAME) from FCC/QRZ")
+    ap.add_argument("--prune-qrz-unverified", metavar="SCP.DB",
+                    help="drop universe calls that SCP.DB marks NOT QRZ-verified "
+                         "(removes lapsed/unverifiable calls; curated CWops/FOC/"
+                         "HSC/existing calls are never pruned)")
+    ap.add_argument("--workdir", default="_work")
+    ap.add_argument("--force", action="store_true", help="re-download even if cached")
+    args = ap.parse_args(argv)
+
+    # 1. call universe
+    if args.scp_db:
+        log("call universe: SCP.DB")
+        universe = load_calls_from_scpdb(args.scp_db, args.min_annual_rate)
+    else:
+        mpath = args.master_dta
+        if args.download_master or not mpath:
+            mpath = download(MASTER_DTA_URL, os.path.join(args.workdir, "MASTER.DTA"),
+                             force=args.force)
+        log("call universe: MASTER.DTA")
+        universe = load_calls_from_dta(mpath)
+    log(f"  universe calls: {len(universe)}")
+
+    # Optional prune: keep only QRZ-verified universe calls (SCP.DB bit 4).
+    # Calls absent from SCP.DB are kept (can't judge); curated calls are added
+    # later by merge() regardless, so they are never pruned here.
+    if args.prune_qrz_unverified:
+        allc, ver = load_scpdb_verified(args.prune_qrz_unverified)
+        before = len(universe)
+        # Prune ONLY US/UK/CA calls that SCP.DB knows are not QRZ-verified.
+        # DX calls are kept regardless (QRZ is not definitive outside those
+        # regions); curated CWops/FOC/HSC/existing calls are added by merge()
+        # afterward, so they are never pruned here.
+        universe = {c for c in universe
+                    if not (is_qrz_reliable_region(c) and c in allc and c not in ver)}
+        log(f"  QRZ-verified prune (US/UK/CA only): {before} -> {len(universe)} "
+            f"(dropped {before - len(universe)}; DX kept)")
+
+    # 2. layers
+    existing = load_existing(args.existing)
+    log(f"  existing TRMASTER calls: {len(existing)}")
+
+    cwops_path = args.cwops_csv
+    if args.cwops_url and not cwops_path:
+        cwops_path = download(args.cwops_url, os.path.join(args.workdir, "cwops.csv"),
+                              force=args.force)
+    cwops = parse_cwops_csv(cwops_path) if cwops_path else {}
+    log(f"  CWops roster: {len(cwops)}")
+
+    # FOC/HSC: seed from existing TRMASTER, override with explicit exports if given
+    foc = {c: {"FOC": v["FOC"], "Name": v.get("Name")}
+           for c, v in existing.items() if v.get("FOC")}
+    foc.update(parse_simple_csv(args.foc_csv, "FOC"))
+    hsc = {c: {"User2": v["User2"]} for c, v in existing.items() if v.get("User2")}
+    hsc.update(parse_simple_csv(args.hsc_csv, "User2"))
+    log(f"  FOC entries: {len(foc)}   HSC entries: {len(hsc)}")
+
+    names = load_names_csv(args.names_csv)
+    log(f"  name-resolver names: {len(names)}")
+
+    # 3. merge + write
+    merged = merge(universe, existing, cwops, foc, hsc, names)
+    census(merged, "merged")
+    size = tc.write_dta(args.out, merged)
+    log(f"\nwrote {args.out}: {size} bytes")
+
+    # 4. validate output is readable + self-consistent
+    back = tc.read_dta(args.out)
+    ok = (len(back["calls"]) == len(merged)
+          and back["end_offset"] == back["file_size"])
+    log(f"validate: re-read {len(back['calls'])} calls, "
+        f"end-offset {'OK' if back['end_offset']==back['file_size'] else 'MISMATCH'} "
+        f"-> {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tr4w/tools/trmaster/trmaster_codec.py
+++ b/tr4w/tools/trmaster/trmaster_codec.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+TRMASTER.DTA codec — read/write the K1EA "CT / TRlog" Super Check Partial
+binary format, plus a self-test that proves the writer round-trips against a
+real file.
+
+Format (confirmed against tr4w/src/trdos/LOGSCP.PAS, src/uSCP.pas, src/VC.pas
+and supercheckpartial.com's formats page):
+
+  Header: 37 x 37 = 1369 little-endian uint32 bucket *start* offsets, then a
+          1370th uint32 = end offset = total file size.  => 5480-byte table.
+  Body:   null-terminated records grouped into the 1369 buckets, laid out in
+          linear order  bucket(X,Y) at index X*37 + Y.
+  Index:  A-Z -> 0..25, 0-9 -> 26..35, '/' -> 36   (uSCP.scpMakeIndex).
+  Record: callsign chars (each byte > 26), then for every non-empty field a
+          one-byte control tag followed by its value, terminated by NUL (0).
+          Most values are printable strings; Hits (^H) and Speed (^S) carry a
+          single *binary* byte.  (LOGSCP.ConvertDatbaseEntryRecordToEntryArray
+          is the canonical encoder this mirrors.)
+  Bucketing: a call is stored once in the bucket of EACH distinct adjacent
+          character pair it contains, so it is findable via any two-letter
+          substring of a partial (LOGSCP.FirstCellForThisCall confirms this).
+
+This module is offline tooling only — it never touches the running program.
+"""
+
+import os
+import struct
+import sys
+import tempfile
+
+# --- format constants -------------------------------------------------------
+
+HEADER_BUCKETS = 37 * 37            # 1369
+HEADER_LONGS = HEADER_BUCKETS + 1   # 1370 (buckets + end-offset)
+HEADER_BYTES = HEADER_LONGS * 4     # 5480
+NUL = 0
+
+# control tag byte -> DataBaseEntryRecord field name (VC.pas:1218-1244).
+# Order here is the canonical write order from ConvertDatbaseEntryRecordToEntryArray.
+STRING_TAGS = [
+    (0x01, "Section"),   # ^A
+    (0x03, "CQZone"),    # ^C
+    (0x06, "FOC"),       # ^F
+    # Hits (^H, 0x08) is binary - handled separately, written here in order
+    (0x07, "Grid"),      # ^G
+    (0x09, "ITUZone"),   # ^I
+    (0x0B, "Check"),     # ^K
+    (0x0E, "Name"),      # ^N
+    (0x0F, "OldCall"),   # ^O
+    (0x11, "QTH"),       # ^Q
+    # Speed (^S, 0x13) is binary
+    (0x14, "TenTen"),    # ^T
+    (0x15, "User1"),     # ^U  (CWops)
+    (0x16, "User2"),     # ^V  (HSC)
+    (0x17, "User3"),     # ^W
+    (0x18, "User4"),     # ^X
+    (0x19, "User5"),     # ^Y
+]
+TAG_TO_FIELD = {t: f for t, f in STRING_TAGS}
+TAG_TO_FIELD[0x08] = "Hits"     # binary
+TAG_TO_FIELD[0x13] = "Speed"    # binary
+BINARY_TAGS = {0x08, 0x13}
+FIELD_TO_TAG = {f: t for t, f in TAG_TO_FIELD.items()}
+
+# canonical field write order (matches the Pascal encoder)
+WRITE_ORDER = ["Section", "CQZone", "FOC", "Hits", "Grid", "ITUZone", "Check",
+               "Name", "OldCall", "QTH", "Speed", "TenTen",
+               "User1", "User2", "User3", "User4", "User5"]
+
+
+def scp_index(ch):
+    """Map a callsign char to its 0..36 bucket index, or None if not bucketable."""
+    o = ord(ch)
+    if 65 <= o <= 90:        # A-Z
+        return o - 65
+    if 48 <= o <= 57:        # 0-9
+        return o - 48 + 26
+    if ch == "/":
+        return 36
+    return None
+
+
+def bucket_pairs(call):
+    """Set of (X,Y) buckets a call belongs in: each distinct adjacent char pair.
+
+    The 'JA' pair is deliberately excluded — it is so common (Japanese prefixes)
+    that its bucket would be useless for narrowing, and LogSCP.BestTwoLetters
+    skips it on lookup, so the builder must skip it on write too.
+    """
+    pairs = set()
+    for i in range(len(call) - 1):
+        if call[i:i + 2] == "JA":
+            continue
+        x = scp_index(call[i])
+        y = scp_index(call[i + 1])
+        if x is not None and y is not None:
+            pairs.add((x, y))
+    return pairs
+
+
+# --- record encode/decode ---------------------------------------------------
+
+def encode_record(call, fields):
+    """Encode one call + fields dict into the null-terminated record bytes."""
+    out = bytearray(call.encode("latin-1"))
+    for name in WRITE_ORDER:
+        val = fields.get(name)
+        if val in (None, "", 0):
+            continue
+        tag = FIELD_TO_TAG[name]
+        out.append(tag)
+        if name in ("Hits", "Speed"):
+            out.append(int(val) & 0xFF)
+        else:
+            # .dta is single-byte (ANSI). Existing latin-1 data round-trips
+            # losslessly; any stray non-latin-1 char (e.g. an un-folded QRZ
+            # name) becomes '?' rather than crashing the build.
+            out += str(val).encode("latin-1", "replace")
+    out.append(NUL)
+    return bytes(out)
+
+
+def _decode_record(buf, start):
+    """Decode one record beginning at offset `start`. Returns (call, fields, next_offset)."""
+    i = start
+    n = len(buf)
+    # callsign: leading bytes > 26 (ControlZ); stops at first tag/NUL
+    cs = i
+    while i < n and buf[i] > 26:
+        i += 1
+    call = buf[cs:i].decode("latin-1")
+    fields = {}
+    while i < n:
+        b = buf[i]
+        if b == NUL:
+            i += 1
+            break
+        field = TAG_TO_FIELD.get(b)
+        i += 1
+        if field is None:
+            # unknown tag byte; skip defensively
+            continue
+        if b in BINARY_TAGS:
+            fields[field] = buf[i] if i < n else 0
+            i += 1
+        else:
+            vs = i
+            while i < n and buf[i] >= 32:
+                i += 1
+            fields[field] = buf[vs:i].decode("latin-1")
+    return call, fields, i
+
+
+# --- file read --------------------------------------------------------------
+
+def read_dta(path):
+    """
+    Parse a TRMASTER/MASTER .dta file.
+
+    Returns dict:
+      calls        : {CALL: fields_dict}            (fields merged across buckets)
+      buckets_of   : {CALL: set((X,Y), ...)}        (buckets the call appeared in)
+      n_records    : total raw records (calls are duplicated across buckets)
+      file_size    : bytes
+      end_offset   : the uint32 end-offset stored at byte 5476
+    """
+    data = open(path, "rb").read()
+    if len(data) < HEADER_BYTES:
+        raise ValueError(f"{path}: too small to be a .dta ({len(data)} bytes)")
+    offsets = struct.unpack_from("<%dI" % HEADER_LONGS, data, 0)
+    end_offset = offsets[HEADER_BUCKETS]  # the 1370th long
+    calls = {}
+    buckets_of = {}
+    n_records = 0
+    for k in range(HEADER_BUCKETS):
+        x, y = divmod(k, 37)
+        start = offsets[k]
+        stop = offsets[k + 1]
+        if start == stop:
+            continue
+        if not (HEADER_BYTES <= start <= len(data)) or stop > len(data):
+            raise ValueError(f"bucket {k} ({x},{y}) bad offsets {start}..{stop}")
+        i = start
+        while i < stop:
+            call, fields, i = _decode_record(data, i)
+            if not call:
+                continue
+            n_records += 1
+            buckets_of.setdefault(call, set()).add((x, y))
+            cur = calls.setdefault(call, {})
+            for fk, fv in fields.items():
+                if fv not in (None, "", 0):
+                    cur[fk] = fv
+    return {
+        "calls": calls,
+        "buckets_of": buckets_of,
+        "n_records": n_records,
+        "file_size": len(data),
+        "end_offset": end_offset,
+    }
+
+
+# --- file write -------------------------------------------------------------
+
+def write_dta(path, calls):
+    """
+    Write `calls` ({CALL: fields_dict}) to a K1EA .dta file, bucketing each call
+    into every adjacent-pair bucket it belongs to.
+    """
+    buckets = [bytearray() for _ in range(HEADER_BUCKETS)]
+    for call in sorted(calls):
+        rec = encode_record(call, calls[call])
+        for (x, y) in bucket_pairs(call):
+            buckets[x * 37 + y] += rec
+
+    # compute offsets
+    offsets = [0] * HEADER_LONGS
+    pos = HEADER_BYTES
+    for k in range(HEADER_BUCKETS):
+        offsets[k] = pos
+        pos += len(buckets[k])
+    offsets[HEADER_BUCKETS] = pos  # end offset == final file size
+
+    with open(path, "wb") as f:
+        f.write(struct.pack("<%dI" % HEADER_LONGS, *offsets))
+        for b in buckets:
+            f.write(b)
+    return pos
+
+
+# --- self-test --------------------------------------------------------------
+
+def selftest(src_path):
+    """Read src -> write to temp -> read back -> assert semantic equivalence."""
+    print(f"=== self-test against {src_path} ===")
+    a = read_dta(src_path)
+    print(f"  source: {a['file_size']} bytes, end-offset field={a['end_offset']} "
+          f"({'OK' if a['end_offset'] == a['file_size'] else 'MISMATCH'})")
+    print(f"  unique calls: {len(a['calls'])}   raw records: {a['n_records']}")
+
+    # bucketing rule check: every bucket a call appeared in must equal the
+    # adjacent-pair rule we use when writing.
+    rule_mismatch = 0
+    for call, got in a["buckets_of"].items():
+        if got != bucket_pairs(call):
+            rule_mismatch += 1
+    print(f"  bucketing-rule mismatches: {rule_mismatch}  "
+          f"({'rule confirmed' if rule_mismatch == 0 else 'RULE DIFFERS'})")
+
+    fd, tmp = tempfile.mkstemp(suffix=".dta")
+    os.close(fd)
+    try:
+        size = write_dta(tmp, a["calls"])
+        b = read_dta(tmp)
+        print(f"  rewritten: {size} bytes, unique calls: {len(b['calls'])}, "
+              f"raw records: {b['n_records']}")
+
+        # semantic equivalence: same call set + same fields per call
+        ca, cb = set(a["calls"]), set(b["calls"])
+        miss = ca - cb
+        extra = cb - ca
+        fieldsdiff = sum(1 for c in (ca & cb) if a["calls"][c] != b["calls"][c])
+        bucketsdiff = sum(1 for c in (ca & cb)
+                          if a["buckets_of"][c] != b["buckets_of"][c])
+        print(f"  calls missing after round-trip: {len(miss)}")
+        print(f"  calls added after round-trip:   {len(extra)}")
+        print(f"  calls with differing fields:    {fieldsdiff}")
+        print(f"  calls with differing buckets:   {bucketsdiff}")
+        ok = not miss and not extra and fieldsdiff == 0 and bucketsdiff == 0
+        print(f"  ROUND-TRIP: {'PASS' if ok else 'FAIL'}")
+        return ok
+    finally:
+        os.remove(tmp)
+
+
+def analyze(src_path):
+    a = read_dta(src_path)
+    calls = a["calls"]
+    def has(f):
+        return sum(1 for v in calls.values() if v.get(f))
+    print(f"=== field census: {src_path} ===")
+    print(f"  unique calls: {len(calls)}")
+    for f in ("Name", "User1", "FOC", "User2", "CQZone", "ITUZone",
+              "Check", "Grid", "QTH", "Hits", "Speed"):
+        print(f"    {f:8}: {has(f)}")
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "tr4w/target/TRMASTER.DTA"
+    analyze(path)
+    print()
+    ok = selftest(path)
+    sys.exit(0 if ok else 1)

--- a/tr4w/tools/trmaster/trmaster_names_qrz.py
+++ b/tr4w/tools/trmaster/trmaster_names_qrz.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+QRZ name resolver — produce a CALL,NAME CSV for trmaster_build.py --names-csv.
+
+Self-contained (no dependency on any other project), but credential- and
+cache-compatible with the ContestLoggerStats QRZ tooling:
+
+  credentials : ~/qrz_settings.cfg   ([qrz] username=... password=...)
+  name cache  : ~/.publicLogProcessor/qrz_name_cache.json   (separate from
+                that project's qrz_cache.json, which stores grid not names)
+
+For each candidate call it looks up QRZ and emits the on-air name, preferring
+the **nickname** field (e.g. "Tom") over the formal first name `fname`
+("Thomas") — nickname is what gets sent in CW exchanges.  Misses are cached so
+they are not retried.
+
+QRZ is optional.  If the credentials file / [qrz] section is missing (e.g. a
+future maintainer without a QRZ subscription), this prints a notice and exits 0
+without producing names — the merge step then simply leaves those calls bare.
+
+Typical use (resolve the still-nameless calls in a built .dta, in bounded
+batches so the cache accumulates across runs):
+
+  python trmaster_names_qrz.py --dta _work/TRMASTER_new.DTA \
+      --out _work/qrz_names.csv --limit 2000
+  python trmaster_build.py ... --names-csv _work/qrz_names.csv
+"""
+
+import argparse
+import configparser
+import csv
+import json
+import os
+import sys
+import time
+import unicodedata
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+import trmaster_codec as tc
+
+
+def ascii_fold(s):
+    """Transliterate to ASCII (José -> JOSE, Björn -> BJORN). The .dta is
+    single-byte and CW is ASCII, so contest names are folded to plain ASCII."""
+    if not s:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in nfkd if not unicodedata.combining(c)) \
+        .encode("ascii", "ignore").decode("ascii")
+
+
+# Words that mark a QRZ `name` field as a club/org rather than a person, used
+# by the name-field fallback so we recover individuals (e.g. 9M2OCX -> SHAHRUL)
+# without picking up "NC CONTESTERS" or "ARRL HQ OPERATORS CLUB".
+CLUB_WORDS = {
+    "CLUB", "CONTEST", "CONTESTERS", "RADIO", "ASSOCIATION", "ASSN", "ASSOC",
+    "SOCIETY", "GROUP", "TEAM", "ARC", "FRATERNITY", "OPERATORS", "DX",
+    "UNIVERSITY", "COLLEGE", "SCHOOL", "MILITARY", "GUARD", "AMATEUR",
+    "STATION", "FOUNDATION", "ROAMERS", "ALUMNI", "KLUB", "REPEATER",
+    "EMERGENCY", "ARES", "RACES", "SCOUT", "MEMORIAL", "EXPEDITION",
+}
+
+DEFAULT_CFG = os.path.expanduser("~/qrz_settings.cfg")
+DEFAULT_CACHE = os.path.expanduser("~/.publicLogProcessor/qrz_name_cache.json")
+QRZ_API_URL = "https://xmldata.qrz.com/xml/current/"
+
+
+def log(m):
+    print(m, flush=True)
+
+
+def read_credentials(cfg_path):
+    """Return (user, pass) or None if unavailable -> caller skips QRZ gracefully."""
+    if not os.path.isfile(os.path.expanduser(cfg_path)):
+        return None
+    cfg = configparser.ConfigParser()
+    cfg.read(os.path.expanduser(cfg_path))
+    if not cfg.has_section("qrz"):
+        return None
+    u = cfg.get("qrz", "username", fallback="").strip()
+    p = cfg.get("qrz", "password", fallback="").strip()
+    return (u, p) if u and p else None
+
+
+class QRZNameClient:
+    """Minimal QRZ XML client that keeps nickname/fname; JSON name cache."""
+
+    def __init__(self, username, password, cache_path,
+                 hit_max_age_days=180, miss_max_age_days=30):
+        self._user = username
+        self._pass = password
+        self._cache_path = cache_path
+        self._key = None
+        self._cache = {}
+        self._dirty = False
+        self._now = int(time.time())
+        # Names are stable -> long TTL; "no name" results re-checked sooner in
+        # case a call gets licensed or its QRZ profile gains a name. 0 = never.
+        self._hit_max_secs = int(hit_max_age_days) * 86400
+        self._miss_max_secs = int(miss_max_age_days) * 86400
+        if os.path.isfile(cache_path):
+            try:
+                with open(cache_path, encoding="utf-8") as f:   # must match save()
+                    self._cache = json.load(f)
+            except (OSError, ValueError) as e:
+                print(f"  WARNING: cache load failed ({cache_path}): {e}; "
+                      f"starting empty", file=sys.stderr)
+                self._cache = {}
+
+    def save(self):
+        """Atomic write (tmp + os.replace) so a kill never corrupts the cache."""
+        if not self._dirty:
+            return
+        os.makedirs(os.path.dirname(self._cache_path) or ".", exist_ok=True)
+        tmp = self._cache_path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(self._cache, f, indent=1, ensure_ascii=False)
+        os.replace(tmp, self._cache_path)   # atomic on same filesystem
+        self._dirty = False
+
+    def _fresh(self, entry):
+        # entries WITH a name use the long (hit) TTL; "no name" entries use the
+        # shorter (miss) TTL.
+        ttl = self._hit_max_secs if entry.get("name") else self._miss_max_secs
+        if ttl <= 0:
+            return True   # 0 = never expire
+        return (self._now - int(entry.get("ts", 0))) <= ttl
+
+    def needs_lookup(self, call):
+        """True if this call is not cached, or its cache entry is stale."""
+        e = self._cache.get(call.upper().strip())
+        return e is None or not self._fresh(e)
+
+    @staticmethod
+    def _ns(root):
+        return root.tag.split("}")[0] + "}" if "}" in root.tag else ""
+
+    def _session(self):
+        url = QRZ_API_URL + "?" + urllib.parse.urlencode(
+            {"username": self._user, "password": self._pass})
+        with urllib.request.urlopen(url, timeout=15) as r:
+            root = ET.fromstring(r.read())
+        ns = self._ns(root)
+        s = root.find(f"{ns}Session")
+        err = s.findtext(f"{ns}Error") if s is not None else "no Session"
+        if err:
+            raise RuntimeError(f"QRZ session error: {err}")
+        self._key = s.findtext(f"{ns}Key")
+        if not self._key:
+            raise RuntimeError("QRZ: no session key")
+
+    def _api(self, call, retry=True):
+        """Return dict of QRZ <Callsign> fields, or None if not found."""
+        if self._key is None:
+            self._session()
+        url = QRZ_API_URL + "?" + urllib.parse.urlencode(
+            {"s": self._key, "callsign": call})
+        with urllib.request.urlopen(url, timeout=15) as r:
+            root = ET.fromstring(r.read())
+        ns = self._ns(root)
+        s = root.find(f"{ns}Session")
+        if s is not None:
+            err = s.findtext(f"{ns}Error")
+            if err:
+                if retry and ("Timeout" in err or "session" in err.lower()):
+                    self._key = None
+                    return self._api(call, retry=False)
+                if "not found" in err.lower():
+                    return None
+                raise RuntimeError(f"QRZ lookup error: {err}")
+        cs = root.find(f"{ns}Callsign")
+        if cs is None:
+            return None
+        out = {}
+        for child in cs:
+            tag = child.tag.split("}")[-1]
+            if child.text:
+                out[tag] = child.text
+        return out
+
+    @staticmethod
+    def _name_from(fields):
+        """On-air name: nickname > fname > the `name` field if it looks like a
+        person (not a club). All uppercased."""
+        nick = (fields.get("nickname") or "").strip()
+        if nick:
+            return nick.split()[0].upper()
+        fn = (fields.get("fname") or "").strip()
+        if fn:
+            return fn.split()[0].upper()
+        # Fallback: some ops (esp. DX) put their name in QRZ's `name` field with
+        # no fname. Use it only when it looks like an individual, not a club/org.
+        nm = (fields.get("name") or "").strip()
+        if nm:
+            toks = nm.upper().split()
+            if len(toks) <= 2 and not (set(toks) & CLUB_WORDS):
+                return toks[0]
+        return ""
+
+    def name(self, call):
+        """Return on-air name for call ('' if none), using/refreshing the cache.
+
+        A cached entry is reused unless it is stale (older than max-age-days).
+        Both hits and misses are stamped with 'ts' so the TTL applies uniformly.
+        """
+        key = call.upper().strip()
+        e = self._cache.get(key)
+        if e is not None and self._fresh(e):
+            return e.get("name", "")
+        fields = self._api(key)
+        if fields is None:
+            entry = {"name": "", "ts": self._now}          # cached miss
+        else:
+            entry = {
+                "name": self._name_from(fields),
+                "nickname": fields.get("nickname", ""),
+                "fname": fields.get("fname", ""),
+                "qname": fields.get("name", ""),   # QRZ entity/last/org field
+                "country": fields.get("country", ""),
+                "ts": self._now,
+            }
+        self._cache[key] = entry
+        self._dirty = True
+        return entry.get("name", "")
+
+
+def candidate_calls(args):
+    """Calls to resolve: explicit file, or the still-nameless calls in a .dta."""
+    if args.calls_file:
+        with open(args.calls_file) as f:
+            return [ln.strip().upper() for ln in f if ln.strip()]
+    data = tc.read_dta(args.dta)
+    calls = data["calls"]
+    if args.all:
+        cand = list(calls.keys())
+    else:
+        cand = [c for c, v in calls.items() if not v.get("Name")]
+    return sorted(cand)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="QRZ name resolver -> CALL,NAME CSV")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--dta", help="built .dta; resolve its still-nameless calls")
+    src.add_argument("--calls-file", help="explicit list, one call per line")
+    ap.add_argument("--out", required=True, help="output CALL,NAME CSV")
+    ap.add_argument("--qrz-cfg", default=DEFAULT_CFG, help="QRZ creds (default ~/qrz_settings.cfg)")
+    ap.add_argument("--cache", default=DEFAULT_CACHE, help="name cache JSON")
+    ap.add_argument("--all", action="store_true",
+                    help="with --dta, resolve every call (not just nameless)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="max NEW (uncached/stale) lookups this run (0 = no cap)")
+    ap.add_argument("--sleep", type=float, default=0.0,
+                    help="seconds between live API calls (politeness)")
+    ap.add_argument("--max-age-days", type=int, default=180,
+                    help="re-look-up NAMED entries older than this (0 = never expire)")
+    ap.add_argument("--miss-max-age-days", type=int, default=30,
+                    help="re-look-up NO-NAME entries older than this (0 = never expire)")
+    ap.add_argument("--save-every", type=int, default=50,
+                    help="flush cache to disk every N new lookups (kill-safety)")
+    ap.add_argument("--cache-only", action="store_true",
+                    help="emit names only from cache; never query QRZ")
+    args = ap.parse_args(argv)
+
+    creds = read_credentials(args.qrz_cfg)
+    if creds is None:
+        log(f"QRZ skipped: no usable [qrz] credentials at {args.qrz_cfg}.")
+        log("  (Add ~/qrz_settings.cfg with [qrz] username/password to enable, "
+            "or proceed without QRZ — calls stay bare.)")
+        # write an empty CSV so downstream --names-csv is happy
+        open(args.out, "w").close()
+        return 0
+
+    cand = candidate_calls(args)
+    log(f"candidates: {len(cand)} call(s)")
+    client = QRZNameClient(creds[0], creds[1], os.path.expanduser(args.cache),
+                           hit_max_age_days=args.max_age_days,
+                           miss_max_age_days=args.miss_max_age_days)
+
+    rows = []
+    new_lookups = 0
+    try:
+        for call in cand:
+            will_query = client.needs_lookup(call)
+            if will_query:
+                if args.cache_only:
+                    continue                       # cache-only: skip uncached
+                if args.limit and new_lookups >= args.limit:
+                    continue
+                new_lookups += 1
+            try:
+                nm = client.name(call)
+            except Exception as e:   # network/API hiccup: stop, keep what we have
+                log(f"  stopping at {call}: {e}")
+                break
+            nm = ascii_fold(nm)
+            if nm:
+                rows.append((call, nm))
+            if will_query:
+                # periodic atomic flush so a kill loses at most --save-every lookups
+                if args.save_every and new_lookups % args.save_every == 0:
+                    client.save()
+                if args.sleep:
+                    time.sleep(args.sleep)
+    finally:
+        client.save()
+
+    with open(args.out, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        for call, nm in rows:
+            w.writerow([call, nm])
+
+    log(f"resolved names: {len(rows)}   new QRZ lookups: {new_lookups}   "
+        f"cache size: {len(client._cache)}")
+    log(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

New offline tooling under `tr4w/tools/trmaster/` to (re)generate `TRMASTER.DTA` in-house — no dependency on an external maintainer's pipeline. It reads/writes the **K1EA "CT/TRlog" `.dta`** format TR4W already consumes, so there are **no program changes** (nothing here runs inside TR4W).

## Files

- **`trmaster_codec.py`** — `.dta` reader/writer + self-test. Round-trip **proven lossless** against the shipped 6,354-call `TRMASTER.DTA`, and reads supercheckpartial's 50,015-call `MASTER.DTA` cleanly. Handles the 37×37 bucket index, the `JA`-bucket special case, and the control-char-tagged fields (`=N` name, `=U` CWops, `=F` FOC, `=V` HSC, …).
- **`trmaster_build.py`** — unions a fresh call list (supercheckpartial `MASTER.DTA`, or `SCP.DB`) with a curated **seed** + CWops/FOC/HSC rosters; optional **US/UK/CA-scoped QRZ-verified prune** (SCP.DB `verified` bit — DX is always kept); writes + validates.
- **`trmaster_names_qrz.py`** — QRZ name resolver → `CALL,NAME` CSV for `--names-csv`. Name priority **nickname → fname → person-like `name` field** (recovers DX individuals like `9M2OCX→SHAHRUL`, skips clubs). ASCII-folds names for CW; UTF-8 cache with **atomic incremental saves** (kill-safe) + **180-day/30-day TTL**; `--cache-only`; **skips cleanly** with no QRZ subscription.
- **`build_trmaster.cmd`** — monthly one-command runner. Builds `tools/trmaster/TRMASTER.DTA` and **stops** — never touches `tr4w/target/` (deploying is the operator's step). Uses a frozen seed, so there's no self-referencing read/write of `target`.
- **`README.md`** — full workflow, sources, format spec, prune, seed model, and what to back up.

## Notes

- Data artifacts (downloads, `SCP.DB`, `seed/`, `*.DTA`, `*.xlsx`, `*.csv`) are git-ignored — only scripts + docs are committed.
- A current build produces ~53k calls / ~9k names (vs the prior 6,354) — i.e. a large Super Check Partial coverage increase while preserving the curated name/CWops/FOC/HSC layer.
- Tested locally end-to-end (build, QRZ resolve, prune, validate); the codec self-test passes.

Related background captured on issue #882.