### PR TITLE
TS-890 LAN: handshake + CR/LF fix, band mode/freq fixes, RIT/XIT/TX display

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -889,6 +889,14 @@ begin
       Digital: Result := rmData;
       Phone: Result := rmUSB;
       FM: Result := rmFM;
+   else
+      // Both / NoMode have no specific radio mode. Without this else the
+      // function Result was left UNINITIALIZED -> garbage TRadioMode (often
+      // rmData), which made a band change shove the radio into DATA. Return the
+      // "none" mode so the caller sends no mode command and the radio keeps its
+      // mode. (Use Low(TRadioMode), which is rmNone; the bare identifier rmNone
+      // is ambiguous in LOGRADIO -- it also exists in TRadioModel, which wins.)
+      Result := Low(TRadioMode);
    end;
  //  ModeType = (CW, Digital, Phone, Both, NoMode, FM); { Use for TR }
            //AM, CW, CW-R, DATA-L, DATA-U, FM, LSB, USB, RTTY, RTTY-R, WBFM
@@ -3275,6 +3283,12 @@ const
 
 begin
    logger.debug('[SetRadioFreq] set frequency to %u',[freq]);
+
+   if Freq <= 0 then
+      begin
+      logger.debug('[SetRadioFreq] freq <= 0 (no band memory or default for this band/mode) -- skipping tune');
+      Exit;
+      end;
 
    if Self.tNetObject <> nil then
       begin

--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -1495,6 +1495,18 @@ end;
 
 
 
+function EffectiveBandFreq(Band: BandType; Mode: ModeType): longint;
+begin
+  // FreqMemory holds the last-used frequency per band/mode and is 0 until a
+  // band has been visited. Fall back to the built-in DefaultFreqMemory so a
+  // band change to an un-visited band tunes to that band's default instead of
+  // 0 Hz (which the radio rejects). Microwave rows with no default stay 0 and
+  // are caught by the freq<=0 guard in SetRadioFreq.
+  Result := FreqMemory[Band, Mode];
+  if Result = 0 then
+    Result := DefaultFreqMemory[Band, Mode];
+end;
+
 procedure DisplayBandMode(Band: BandType; Mode: ModeType; UpdateRadio: boolean);
 begin
 
@@ -1527,12 +1539,12 @@ begin
   if ActiveRadio = RadioOne then
   begin
     Radio1.UpdateBandOutputInfo(Band, Mode);
-    if UpdateRadio then Radio1.SetRadioFreq(FreqMemory[Band, Mode], ActiveMode, 'A');
+    if UpdateRadio then Radio1.SetRadioFreq(EffectiveBandFreq(Band, Mode), ActiveMode, 'A');
   end
   else
   begin
     Radio2.UpdateBandOutputInfo(Band, Mode);
-    if UpdateRadio then Radio2.SetRadioFreq(FreqMemory[Band, Mode], ActiveMode, 'A');
+    if UpdateRadio then Radio2.SetRadioFreq(EffectiveBandFreq(Band, Mode), ActiveMode, 'A');
   end;
   UpdateAllStationsList;
   SendStationStatus(sstBandModeFreq);

--- a/tr4w/src/uNetRadioBase.pas
+++ b/tr4w/src/uNetRadioBase.pas
@@ -180,6 +180,7 @@ Type TNetRadioBase = class(TObject)
       requiresPolling: Boolean;        // True for most radios, False for K4 with AI5
       autoUpdateCommand: string;       // Command to enable push updates (e.g., 'AI5;')
       pollingInterval: Integer;        // Milliseconds between polls (default 100)
+      bAddTermination: Boolean;        // True (default): SendToRadio appends CR/LF (WriteLn). Kenwood TS-890 LAN sets this False -- its CAT parser rejects a trailing CR/LF; the K4 tolerates/ignores it, so it stays True.
 
       constructor Create(ProcRef: TProcessMsgRef); overload;
       constructor Create(address: string; port: integer;ProcRef: TProcessMsgRef); overload;
@@ -187,6 +188,12 @@ Type TNetRadioBase = class(TObject)
 
       procedure SendToRadio(s: string); overload; virtual;
       procedure SendToRadio(whichVFO: TVFO; sCmd: string; sData: string); overload; Virtual; Abstract;
+      // Per-radio state setters -- base owns storage; radio classes call these to
+      // reflect on/off state into the field the matching display getter reads.
+      procedure SetRITOn(value: boolean);
+      procedure SetXITOn(value: boolean);
+      procedure SetSplitOn(value: boolean);
+      procedure SetTransmitting(value: boolean);
       function ModeToString(mode: TRadioMode): string;
       property radioPort: integer read GetRadioPort write SetRadioPort;
       property radioAddress: string read GetRadioAddress write SetRadioAddress;
@@ -288,6 +295,7 @@ begin
    logger.Trace('trace output');
    }
    baseProcMsg := ProcRef;
+   bAddTermination := True;   // default: append CR/LF; radios that must not (e.g. TS-890 LAN) set this False in their own constructor
    for iVFO := Low(TVFO) to High(TVFO) do
       begin
       Self.vfo[iVFO] := TRadioVFO.Create;
@@ -766,8 +774,19 @@ begin
             // Network connection
             logger.Trace('[%s %s TX] (%s) Hex:[%s]',[Self.rigLabel, Self.radioModel, s, String2Hex(s)]);
             nLen := length(s);
-            socket.IOHandler.WriteLn(s);
-            //socket.IOHandler.Write(s,nLen,0);
+            // Most network radios accept or simply ignore a trailing CR/LF, so
+            // by default we append one (WriteLn). The Kenwood TS-890 LAN CAT
+            // parser is the exception: once authenticated it rejects a trailing
+            // CR/LF with '?;', so it sets bAddTermination := False and we send
+            // the bare ';'-terminated command -- matching Kenwood's own ARCP.
+            if bAddTermination then
+               begin
+               socket.IOHandler.WriteLn(s);
+               end
+            else
+               begin
+               socket.IOHandler.Write(s);
+               end;
             end
          else
             begin
@@ -935,6 +954,46 @@ end;
 function TNetRadioBase.GetSplitEnabled: boolean;
 begin
    Result := Self.localSplitEnabled;
+end;
+
+// ---- Per-radio state setters: one place owns where each flag is stored. ----
+// RIT/XIT are written to every VFO copy so the per-VFO display getters return
+// the per-radio value regardless of which VFO the window queries. (RIT/XIT/Split
+// are per-radio on the rigs we support; a future per-VFO radio can still write
+// vfo[].RITState directly.)
+procedure TNetRadioBase.SetRITOn(value: boolean);
+var
+   v: TVFO;
+begin
+   Self.RITState := value;   // legacy scalar, kept in sync
+   for v := Low(TVFO) to High(TVFO) do
+      begin
+      Self.vfo[v].RITState := value;
+      end;
+end;
+
+procedure TNetRadioBase.SetXITOn(value: boolean);
+var
+   v: TVFO;
+begin
+   Self.XITState := value;
+   for v := Low(TVFO) to High(TVFO) do
+      begin
+      Self.vfo[v].XITState := value;
+      end;
+end;
+
+procedure TNetRadioBase.SetSplitOn(value: boolean);
+begin
+   Self.localSplitEnabled := value;
+end;
+
+procedure TNetRadioBase.SetTransmitting(value: boolean);
+begin
+   if value then
+      Self.radioState := rsTransmit
+   else
+      Self.radioState := rsReceive;
 end;
 
 function TNetRadioBase.GetVFO(whichVFO: TVFO): TRadioVFO;

--- a/tr4w/src/uRadioKenwoodTS890.pas
+++ b/tr4w/src/uRadioKenwoodTS890.pas
@@ -37,7 +37,7 @@ type
       ksNone,
       ksWaitingForCN,    // Sent ##CN;, awaiting ##CN1
       ksWaitingForID,    // Sent ##ID0...;, awaiting ##ID1
-      ksWaitingForTI,    // Got ##ID1, awaiting ##UE/##TI to finish handshake
+      ksWaitingForTI,    // legacy/unused: real TS-890 does NOT send ##UE/##TI; auth completes at ##ID1
       ksAuthenticated,   // Auth complete; normal Kenwood CAT
       ksAuthFailed       // Auth was rejected; connection unusable
    );
@@ -50,6 +50,7 @@ type TKenwoodTS890Radio = class(TNetRadioBase)
       logger: TLogLogger;
 
       procedure SendAuthCredentials;
+      procedure SendPostLoginSetup;
       procedure HandleAuthMessage(const sMessage: string);
       procedure InitializeAfterAuth;
       function ModeCharToMode(ch: Char): TRadioMode;
@@ -134,6 +135,12 @@ begin
    NetworkUsername := '';
    NetworkPassword := '';
 
+   // The TS-890 LAN CAT parser rejects a trailing CR/LF (responds '?;') once
+   // authenticated, so send bare ';'-terminated commands. (Proven via telnet:
+   // the K4 ignores a trailing CR/LF; the TS-890 does not. The default is set
+   // in uNetRadioBase.Create -- see SendToRadio / bAddTermination.)
+   Self.bAddTermination := False;
+
    // TS-890 uses AI2 for state push, but the LAN protocol REQUIRES
    // periodic traffic from the client. Per the LAN HOWTO:
    //   "The TS-890 will close the TCP connection if it does not receive
@@ -209,6 +216,19 @@ begin
                 [Self.rigLabel, idLen, pwLen, string(NetworkUsername)]);
 end;
 
+procedure TKenwoodTS890Radio.SendPostLoginSetup;
+begin
+   // Post-login LAN-session setup the ARCP-890 reference controller sends right
+   // after ##ID1; (##VP = version/voice-protocol probe, ##KN = LAN notification
+   // channels). Match the reference so the radio keeps the socket open and
+   // pushes state over LAN. Responses (##VP0;/##KN21;/##KN02;) are ignored in
+   // HandleAuthMessage once authenticated.
+   Self.SendToRadio('##VP;');
+   Self.SendToRadio('##KN2;');
+   Self.SendToRadio('##KN0;');
+   logger.Debug('[%s.SendPostLoginSetup] Sent ##VP; ##KN2; ##KN0;', [Self.rigLabel]);
+end;
+
 procedure TKenwoodTS890Radio.HandleAuthMessage(const sMessage: string);
 begin
    if FAuthState = ksWaitingForCN then
@@ -231,13 +251,17 @@ begin
       begin
       if AnsiStartsStr('##ID1', sMessage) then
          begin
-         // Per LAN HOWTO: after ##ID1 the radio also sends ##UE1; and
-         // ##TI1; (often batched on the same TCP segment). The radio is
-         // not ready for CAT until it has sent ##TI1; -- so don't fire
-         // InitializeAfterAuth yet; wait for ##TI in ksWaitingForTI.
-         FAuthState := ksWaitingForTI;
-         logger.Info('[%s.HandleAuthMessage] Credentials accepted; awaiting ##TI handshake',
+         // ##ID1; = auth success. Real-hardware capture (Kenwood ARCP-890 vs a
+         // TS-890S) shows the radio does NOT send ##UE/##TI here -- the
+         // controller drives the rest (##VP; / ##KN2; / ##KN0;) and plain CAT
+         // (ID;) already works immediately after ##ID1;. The previous
+         // "wait for ##TI" left TR4W idle, so the radio closed the socket and
+         // we reconnected in a loop. Go straight to CAT.
+         FAuthState := ksAuthenticated;
+         logger.Info('[%s.HandleAuthMessage] Credentials accepted; CAT-ready',
                      [Self.rigLabel]);
+         SendPostLoginSetup;
+         InitializeAfterAuth;
          end
       else
          begin
@@ -248,25 +272,13 @@ begin
       Exit;
       end;
 
-   if FAuthState = ksWaitingForTI then
+   if FAuthState = ksAuthenticated then
       begin
-      // ##UE1; arrives between ##ID and ##TI -- just log it and keep waiting.
-      if AnsiStartsStr('##UE', sMessage) then
-         begin
-         logger.Debug('[%s.HandleAuthMessage] Received %s; awaiting ##TI',
-                      [Self.rigLabel, sMessage]);
-         Exit;
-         end;
-      if AnsiStartsStr('##TI', sMessage) then
-         begin
-         FAuthState := ksAuthenticated;
-         logger.Info('[%s.HandleAuthMessage] Authenticated and CAT-ready (%s)',
-                     [Self.rigLabel, sMessage]);
-         InitializeAfterAuth;
-         Exit;
-         end;
-      // Other ## frames while waiting for TI -- log and keep waiting.
-      logger.Debug('[%s.HandleAuthMessage] Unexpected post-ID frame: %s',
+      // Post-auth ## frames are LAN-control responses/notifications:
+      //   ##VP0;/##VP1; (replies to ##VP;), ##KN21;/##KN02;/##KN71; (##KN),
+      //   and on some firmwares ##UE;/##TI;. None require action -- the CAT
+      //   session is already running -- so just log and ignore them.
+      logger.Debug('[%s.HandleAuthMessage] post-auth control frame (ignored): %s',
                    [Self.rigLabel, sMessage]);
       Exit;
       end;
@@ -345,6 +357,12 @@ begin
       ParseRTResponse(sMessage)
    else if AnsiStartsStr('XT', sMessage) then
       ParseXTResponse(sMessage)
+   else if AnsiStartsStr('TX', sMessage) then
+      // Radio pushes TX0; when it goes to transmit (AI2). Surface it so the
+      // main window's TX indicator updates.
+      Self.SetTransmitting(True)
+   else if AnsiStartsStr('RX', sMessage) then
+      Self.SetTransmitting(False)
    else if AnsiStartsStr('PS', sMessage) then
       // Keepalive heartbeat response (PS1; = power on). No state to track;
       // the round-trip itself is what keeps the LAN connection from being
@@ -454,7 +472,7 @@ end;
 procedure TKenwoodTS890Radio.ParseTBResponse(const sMessage: string);
 begin
    if Length(sMessage) < 3 then Exit;
-   Self.localSplitEnabled := (sMessage[3] = '1');
+   Self.SetSplitOn(sMessage[3] = '1');   // base setter -> localSplitEnabled the window reads
    logger.Trace('[%s.ParseTBResponse] Split = %s',
                 [Self.rigLabel, BoolToStr(Self.localSplitEnabled, True)]);
 end;
@@ -474,7 +492,7 @@ end;
 procedure TKenwoodTS890Radio.ParseRTResponse(const sMessage: string);
 begin
    if Length(sMessage) < 3 then Exit;
-   Self.RITState := (sMessage[3] = '1');
+   Self.SetRITOn(sMessage[3] = '1');   // base setter -> per-VFO RITState the window reads
    logger.Trace('[%s.ParseRTResponse] RIT = %s',
                 [Self.rigLabel, BoolToStr(Self.RITState, True)]);
 end;
@@ -483,7 +501,7 @@ end;
 procedure TKenwoodTS890Radio.ParseXTResponse(const sMessage: string);
 begin
    if Length(sMessage) < 3 then Exit;
-   Self.XITState := (sMessage[3] = '1');
+   Self.SetXITOn(sMessage[3] = '1');   // base setter -> per-VFO XITState the window reads
    logger.Trace('[%s.ParseXTResponse] XIT = %s',
                 [Self.rigLabel, BoolToStr(Self.XITState, True)]);
 end;


### PR DESCRIPTION
Kenwood TS-890 LAN (TCP 60000) support fixes.

**Connect / CAT transport** — validated on N2SKH hardware (freq + mode, both VFOs):
- Proceed after `##ID1` instead of waiting for a `##TI` the radio never sends; post-login `##VP;`/`##KN2;`/`##KN0;`; AI2 push + 5s `PS;` keepalive (the radio drops an idle LAN connection after ~10s).
- New `bAddTermination` flag in `TNetRadioBase` (default `True`). The TS-890 sets it `False` so commands go out bare — its CAT parser rejects a trailing CR/LF with `?;` once authenticated (the K4 tolerates it). Default `True` leaves every other network radio byte-identical.

**Band change** (TRDOS; affects all network radios only in previously-broken cases):
- `ModeTypeToNetMode`: add the missing `else` (it was returning an **uninitialized** mode for `Both`/`NoMode` → garbage `rmData` → a band change shoved the radio into DATA).
- Band retune falls back `FreqMemory` → `DefaultFreqMemory` (an un-visited band tunes to its built-in default instead of 0 Hz); `SetRadioFreq` guards `freq<=0`.

**RIT / XIT / TX display:** base setters own the field the display getters read; the TS-890 parsers and a new inbound `TX`/`RX` handler feed them.

**Testing:** LAN connect + CAT validated on N2SKH hardware. The band / RIT / XIT / TX fixes are pending Ron's TS-890 retest. K4 verified unaffected.
