### PR TITLE
Serial holds across X-QSO; keep external-log contact (#954, #949)

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -4698,7 +4698,7 @@ begin
 
     // Not the way to do this as the radio does not know the extendedMode--just Mode. NY4I
     //RData.ExtMode := ActiveRadioptr.CurrentStatus.ExtendedMode; // 4.93.3
-    RData.NumberSent := TotalContacts + 1;
+    RData.NumberSent := NextSerialToSend;  // Issue #954: highest sent serial + 1, not a QSO count
     RData.Frequency := Freq;
 
     if ActiveMode in [Phone, FM] then
@@ -4755,7 +4755,7 @@ begin
     end;
   end;
   // ny4i Don't do this please - Issue 466 -=> Rdata.ExtMode := ActiveRadioptr^.CurrentStatus.ExtendedMode ; // 4.93.3
-  RData.NumberSent := TotalContacts + 1;
+  RData.NumberSent := NextSerialToSend;  // Issue #954: highest sent serial + 1, not a QSO count
   RData.Frequency := Freq;
 
   if RData.RSTSent = 0 then
@@ -5489,6 +5489,13 @@ begin
       if (not TempRXData.ceQSO_Skiped) and (TempRXData.Band <> NoBand) and
         (TempRXData.Mode <> NoMode) then
       begin
+        // Issue #954: feed the serial high-water mark.  This counts every
+        // non-deleted QSO that consumed a number -- INCLUDING X-QSO -- which is
+        // exactly why it lives OUTSIDE the #750 guard below: marking a QSO X-QSO
+        // (or deleting a mid-log QSO) must not roll the sent serial backward.
+        // Range/sentinel filtering is handled inside UpdateMaxSerialSent.
+        if not TempRXData.ceQSO_Deleted then
+          UpdateMaxSerialSent(TempRXData.Band, TempRXData.NumberSent);
         // Issue #750: X-QSO records are kept in the log (and the
         // editable log view -- they paint grayed) but contribute
         // nothing to QSOTotals, multipliers, points, or the dupe

--- a/tr4w/src/trdos/LOGDUPE.PAS
+++ b/tr4w/src/trdos/LOGDUPE.PAS
@@ -296,6 +296,16 @@ var
   QSOTotals                             : QSOTotalArray; { This may not also be exactly the same as
   DupeList.Totals because of dupes read in }
 
+  // Issue #954: highest serial (NumberSent) actually sent, tracked per band
+  // (the AllBands index is the whole-station high-water mark).  The next serial
+  // to send is this value + 1 -- see NextSerialToSend in LOGEDIT.  It is kept in
+  // lockstep with QSOTotals (zeroed in the dupe-sheet reset, updated in LoadinLog
+  // and in the live add), but UNLIKE QSOTotals it INCLUDES X-QSO records (they
+  // consumed a number) and EXCLUDES deleted ones.  That is what stops marking a
+  // QSO X-QSO -- or deleting a mid-log QSO -- from rolling the serial backward
+  // and re-issuing a number already sent on the air.
+  MaxSerialSent                         : array[BandType] of integer;
+
   RemainingMultDisplay                  : RemainingMultiplierType = rmNoRemMultDisplay;
 
 //  RemMultMatrix                         : array[Band160..All, CW..Both, RemainingMultiplierType] of RemainingMultListPointer;
@@ -1326,6 +1336,7 @@ begin
   Windows.ZeroMemory(@RemMultMatrix, SizeOf(RemMultMatrix));
 }
   Windows.ZeroMemory(@QSOTotals, SizeOf(QSOTotals));
+  Windows.ZeroMemory(@MaxSerialSent, SizeOf(MaxSerialSent));  // Issue #954: rebuilt by LoadinLog
   Windows.ZeroMemory(@ContinentQSOCount, SizeOf(ContinentQSOCount));
 
 //  Windows.ZeroMemory(@MultSheet, SizeOf(MultSheet));

--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -170,6 +170,8 @@ function QuickEditResponseWithPartials(Prompt: Str80; MaxInputLength: integer):
 procedure Send88Message;
 procedure ShowStationInformation(Call: CallPtr {CallString});
 function TotalContacts: integer;
+function NextSerialToSend: integer;  { Issue #954: next serial to send = highest sent + 1 }
+procedure UpdateMaxSerialSent(Band: BandType; SerialNum: integer);  { Issue #954 }
 function TotalCWContacts: integer;
 function TotalPhoneContacts: integer;
 function TotalScore: LONGINT;
@@ -289,6 +291,46 @@ begin
      logger.debug('In TotalContacts, (QSONumberByBand is false so AllBands) returning ' + IntToStr(Result));
      end;
 
+end;
+
+// Issue #954.  Record that SerialNum was sent on Band, keeping the per-band and
+// whole-station (AllBands) high-water marks.  Ignores values that are not real
+// contest serials: non-positive / unset numbers and the ADIF import sentinel
+// ($FFFF = uADIF.SENTINEL_WORD), which is stamped on imported QSOs that carried
+// no sent-serial field.  No real contest serial comes anywhere near 65535, so
+// this filter is unambiguous and a single bad import can never poison the
+// high-water mark.  Called from the two places QSOTotals is built (LoadinLog and
+// the live add); isolated as its own procedure so the long callers don't inline
+// the global's address (Delphi 7 codegen).
+procedure UpdateMaxSerialSent(Band: BandType; SerialNum: integer);
+begin
+   if (SerialNum <= 0) or (SerialNum >= $FFFF) then
+      Exit;
+   if SerialNum > MaxSerialSent[Band] then
+      MaxSerialSent[Band] := SerialNum;
+   if SerialNum > MaxSerialSent[AllBands] then
+      MaxSerialSent[AllBands] := SerialNum;
+end;
+
+// Issue #954.  The next serial to send is one past the HIGHEST serial we have
+// actually sent (max NumberSent in the log), NOT a QSO count.  Counting QSOs
+// (the historical TotalContacts + 1) silently drops the number whenever a QSO
+// stops counting -- X-QSO, or a deleted mid-log QSO -- and then re-issues a
+// serial already sent on the air.  Tracking the high-water mark is monotonic
+// across both cases.  Networked operation is unchanged: it still uses the
+// server-assigned serial.
+function NextSerialToSend: integer;
+begin
+   if ServerSerialNumber <> 0 then
+      begin
+      Result := ServerSerialNumber;  // == old (ServerSerialNumber - 1) + 1
+      Exit;
+      end;
+
+   if QSONumberByBand then
+      Result := MaxSerialSent[ActiveBand] + 1
+   else
+      Result := MaxSerialSent[AllBands] + 1;
 end;
 
 procedure BandDownOrUp(Direction: DirectionType);

--- a/tr4w/src/trdos/LOGSUBS1.PAS
+++ b/tr4w/src/trdos/LOGSUBS1.PAS
@@ -318,7 +318,7 @@ begin
       begin
         if ActiveRadioPtr^.LastDisplayedFreq <> 0 then
         begin
-          Str(TotalContacts + 1, QSONumberString);
+          Str(NextSerialToSend, QSONumberString);  // Issue #954
           //   BandMapCursorFrequency := ActiveRadioPtr^.LastDisplayedFreq;      // GAV Removed, not required
           tCreateAndAddNewSpot('CQ/ ' + QSONumberString, False, ActiveRadioPtr);
           LastCQFrequency := ActiveRadioPtr^.LastDisplayedFreq;

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -567,7 +567,7 @@ var
   SecString, TempString                 : Str80;
 begin
   Str(Seconds, SecString);
-  Str(TotalContacts + 1, TempString);
+  Str(NextSerialToSend, TempString);  // Issue #954
   TempString := '; Backcopy made for QSO #' + TempString + ' at ' +
     GetTimeString + ' for ' + SecString + ' seconds.';
   PushLogStringIntoEditableLogAndLogPopedQSO(TempString, True);
@@ -1053,7 +1053,7 @@ begin
         {KK1L: 6.68 From here to REPEAT added to put autoCQ in band map and send multi info message.}
       if BandMapEnable and (Radio1.LastDisplayedFreq {LastDisplayedFreq[RadioOne]} <> 0) and (OpMode = CQOpMode) and BandMapDisplayCQ then
       begin
-        Str(TotalContacts + 1, QSONumberString);
+        Str(NextSerialToSend, QSONumberString);  // Issue #954
         BandMapCursorFrequency := ActiveRadioPtr.LastDisplayedFreq {LastDisplayedFreq[ActiveRadio]};
             //            NewBandMapEntry('CQ/ ' + QSONumberString, LastDisplayedFreq[ActiveRadio], 0, ActiveMode, False, False, BandMapDecayTime, True, MyCall);
         tCreateAndAddNewSpot('CQ/ ' + QSONumberString, False, ActiveRadioPtr {?});
@@ -1494,6 +1494,7 @@ begin
   if TempMode = FM then TempMode := Phone;
   if ((RXData.Mode <> NoMode) and (RXData.Band <> NoBand) and (RXData.ceRecordKind = rkQSO)) then
   begin
+    UpdateMaxSerialSent(RXData.Band, RXData.NumberSent);  // Issue #954: track highest sent serial
     inc(QSOTotals[RXData.Band, TempMode]);
     inc(QSOTotals[RXData.Band, Both]);
     inc(QSOTotals[AllBands, TempMode]);
@@ -2055,7 +2056,7 @@ nop
                      end;
                      repeat
                        PutUpExchangeWindow;
-                       DisplayNextQSONumber(TotalContacts + 1);
+                       DisplayNextQSONumber;  // Issue #954: value computed inside (NextSerialToSend)
                        ClearContestExchange(ReceivedData);
                        ExchangeHasBeenSent := False;
                      until not SearchAndPounce;

--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -1760,7 +1760,11 @@ procedure DisplayNextQSONumber;
 const
   QSONumberStringArray                  : array[boolean] of PChar = ('%d', '*%d');   
 begin
-  Format(wsprintfBuffer, QSONumberStringArray[AutoQSONumberDecrement], TotalContacts + 1);
+  // Issue #954: show the next serial we will actually send (high-water mark of
+  // numbers sent + 1), NOT a QSO count.  Count-based display reverted the number
+  // whenever a QSO stopped counting (X-QSO, mid-log delete).  NextSerialToSend
+  // also returns ServerSerialNumber in networked mode, matching the old value.
+  Format(wsprintfBuffer, QSONumberStringArray[AutoQSONumberDecrement], NextSerialToSend);
   if ServerSerialNumber <> 0 then
     if PreviousSerialNumberType = sntReserved then
       Windows.lstrcat(wsprintfBuffer, 'L');

--- a/tr4w/src/trdos/LogSend.pas
+++ b/tr4w/src/trdos/LogSend.pas
@@ -74,7 +74,7 @@ begin
     if DVPMessagesArrayIndex = DVPArraySize then Exit;
     if FileName = '#' then
     begin
-      QSONumber := TotalContacts + 1;
+      QSONumber := NextSerialToSend;  // Issue #954
       if AutoQSONumberDecrement then
         if (ActiveMainWindow = awCallWindow)
         //if tr4w_CallWindowActive
@@ -170,7 +170,7 @@ begin
 
         '#':
           begin
-            QSONumber := TotalContacts + 1;
+            QSONumber := NextSerialToSend;  // Issue #954
 
             if TailEnding then inc(QSONumber);
 
@@ -461,7 +461,7 @@ begin
 
           CASE SendChar OF
               '#': BEGIN
-                   QSONumber := TotalContacts + 1;
+                   QSONumber := NextSerialToSend;  // Issue #954
 
                    IF TailEnding THEN Inc (QSONumber);
 

--- a/tr4w/src/uEditQSO.pas
+++ b/tr4w/src/uEditQSO.pas
@@ -718,6 +718,19 @@ begin
      // Issue #783 -- HamScore RTC: send <contactdelete> next cycle.
      HamScoreOnDelete(EditableQSORXData);
      end
+  else if EditableQSORXData.ceXQSO then
+     begin
+     // Issues #949 / #954 -- X-QSO is NOT a delete. The contact really happened,
+     // so it stays in the log and the external logger and keeps the serial it
+     // consumed; it is only removed from the CONTEST score. So drop it from the
+     // score feeds (contactdelete to UDP + HamScore) but deliberately DO NOT
+     // touch the external logger. (The serial it consumed is preserved because
+     // the next serial is the high-water mark of numbers actually sent, not a
+     // QSO count -- the X-QSO record stays in the log so it still counts toward
+     // that mark.  See NextSerialToSend / MaxSerialSent, Issue #954.)
+     SendDeletedContactToUDP(EditableQSORXData);
+     HamScoreOnDelete(EditableQSORXData);
+     end
   else
      begin
      LogEditedContactToUDP(EditableQSORxData);

--- a/tr4w/target/commands_help_eng.ini
+++ b/tr4w/target/commands_help_eng.ini
@@ -1030,7 +1030,7 @@ DESCRIPTION=The } character in a CW message will send the prefix or suffix of a 
 
 [SERIAL PORT DEBUG]
 DEFAULT=FALSE
-DESCRIPTION=
+DESCRIPTION=No longer used due to Windows restrictions on monitoring the serial port.
 
 [SERVER ADDRESS]
 DEFAULT=LOCALHOST
@@ -1418,7 +1418,7 @@ DESCRIPTION=Alternate CQ SSB exchange message sent when the name of the calling 
 
 [CTY UPDATE CHECK ON STARTUP]
 DEFAULT=TRUE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=When TRUE, caused TR4W to check the version of the CTY.DAT file to see if a more recent one is available. If so, it offers to download the latest file via ALT-O.
 
 [DUPE SHEET ENABLE]
 DEFAULT=TO BE COMPLETED
@@ -1429,20 +1429,20 @@ DEFAULT=FALSE
 DESCRIPTION=TO BE COMPLETED
 
 [EXCHANGE WINDOW S&P BACKGROUND]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=Green
+DESCRIPTION=The background color of the Exchange window when in S&P mode.
 
 [HAMLIB ASYNC ONLY]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=This is a debugging option for investigating HamLib issues.
 
 [HAMLIB DEBUG]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=This enabled HamLib debug logging.
 
 [HAMLIB TRACE]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=This enabled HamLib TRACE logging. Warning - this produces voluminous output.
 
 [HAMSCORE ENABLE]
 DEFAULT=FALSE
@@ -1458,7 +1458,7 @@ DESCRIPTION=Some contests prefer that the real-time information not be sent (str
 
 [HAMSCORE URL]
 DEFAULT=http://scoredistributor.net/
-DESCRIPTION=This is th eURL used to send real-time contest data, to post score info or both.
+DESCRIPTION=This is the URL used to send real-time contest data, to post score info or both.
 
 [HAMSCORE USERNAME]
 DEFAULT=Blank
@@ -1482,7 +1482,7 @@ DESCRIPTION=DEPRECATED - From the TRLOG days when the multi-network was a serial
 
 [MY FOC NUMBER]
 DEFAULT=
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=Enter your FOC number.
 
 [MY ITU ZONE]
 DEFAULT=0
@@ -1522,7 +1522,7 @@ DESCRIPTION=SSB voice message sent before the QSO exchange. Programmed via Alt+P
 
 [QSY INACTIVE RADIO]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=If TRUE, when you click on BANDMAP entry, it will QSY on the inactive radio. Note that TwoRadioMode must also be enabled for this to work.
 
 [QUICK QSL CW MESSAGE]
 DEFAULT=
@@ -1537,35 +1537,35 @@ DEFAULT=\
 DESCRIPTION=TO BE COMPLETED
 
 [QUICK QSL MESSAGE]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=Blank
+DESCRIPTION=This is a copy of QUICK QSL MESSAGE 1 below. Setting this has the same effect as setting the latter.
 
 [QUICK QSL MESSAGE 1]
-DEFAULT=
-DESCRIPTION=Short phone acknowledgement message 1, sent when QUICK QSL KEY 1 is pressed instead of Enter. Programmed via Alt+P.
+DEFAULT=Blank
+DESCRIPTION=Short CW acknowledgement message 1, sent when QUICK QSL KEY 1 is pressed instead of Enter. Programmed via Alt+P.
 
 [QUICK QSL MESSAGE 2]
-DEFAULT=
-DESCRIPTION=Short phone acknowledgement message 2, sent when QUICK QSL KEY 2 is pressed. Programmed via Alt+P.
+DEFAULT=Blank
+DESCRIPTION=Short CW acknowledgement message 2, sent when QUICK QSL KEY 2 is pressed. Programmed via Alt+P.
 
 [QUICK QSL SSB MESSAGE]
-DEFAULT=
+DEFAULT=Blank
 DESCRIPTION=Short SSB voice acknowledgement message. Programmed via Alt+P. ### R
 
 [RADIO ONE COMMAND PAUSE]
-DEFAULT=TO BE COMPLETED
+DEFAULT=0
 DESCRIPTION=TO BE COMPLETED
 
 [RADIO ONE ICOM DATA MODE ID]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=1
+DESCRIPTION=On Icom radios that support multiple data modes (USB-D1, USB-D2, etc), this is is the number data mode used.
 
 [RADIO ONE ICOM NETWORK PASSWORD]
-DEFAULT=TO BE COMPLETED
+DEFAULT=Blank
 DESCRIPTION=DEPRECATED
 
 [RADIO ONE ICOM NETWORK USERNAME]
-DEFAULT=TO BE COMPLETED
+DEFAULT=Blank
 DESCRIPTION=DEPRECATED
 
 [RADIO ONE IP ADDRESS]
@@ -1585,11 +1585,11 @@ DEFAULT=0
 DESCRIPTION=When using a networked radio, this is the port used to connect. The port varies depending upon the type of radio. Elecraft K4 is 9200, Icom is typically 50001 and Nenwood is 60000. Flex default is NNNN.
 
 [RADIO TWO COMMAND PAUSE]
-DEFAULT=TO BE COMPLETED
+DEFAULT=0
 DESCRIPTION=TO BE COMPLETED
 
 [RADIO TWO HAMLIB ID]
-DEFAULT=TO BE COMPLETED
+DEFAULT=Default radio model for the selected radio
 DESCRIPTION=If you choose to use Hamlib rather than TR4W's native radio support, this is the model of the radio Hamlib assigns. Unless you have a reason, please use the program default. This would only be needed for new radio with a test versionof Hamlib or some other reason.
 
 [RADIO TWO ICOM DATA MODE ID]
@@ -1597,25 +1597,24 @@ DEFAULT=TO BE COMPLETED
 DESCRIPTION=TO BE COMPLETED
 
 [RADIO TWO ICOM NETWORK PASSWORD]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=DEPRECATED
+DEFAULT=Blank
+DESCRIPTION=DEPRECATED - Use NETWORK PASSWORD
 
 [RADIO TWO ICOM NETWORK USERNAME]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=DEPRECATED
+DEFAULT=Blank
+DESCRIPTION=DEPRECATED - Use NETWORK USERNAME
 
 [RADIO TWO IP ADDRESS]
 DEFAULT=0.0.0.0
 DESCRIPTION=For a networked radio connection, the IP address to use for the radio. Check your radio manual to see how to find this address.
 
-
 [RADIO TWO NETWORK PASSWORD]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=Blank
+DESCRIPTION=For networked radios that need a password, specify it here. This is so far for Icom and Kenwood.
 
 [RADIO TWO NETWORK USERNAME]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=Blank
+DESCRIPTION=For networked radios that need a user, specify it here. This is so far for Icom and Kenwood.
 
 [RADIO TWO TCP PORT]
 DEFAULT=0
@@ -1626,8 +1625,8 @@ DEFAULT=False
 DESCRIPTION=If you choose to use Hamlib rather than TR4W's native radio support, set this option to TRUE.
 
 [REPEAT S&P CW EXCHANGE]
-DEFAULT=TO BE COMPLETED
-DESCRIPTION=TO BE COMPLETED
+DEFAULT=Blank
+DESCRIPTION=CW Exchange sent ween repeating the exchange in S&P mode.
 
 [REPEAT S&P EXCHANGE]
 DEFAULT=
@@ -1659,11 +1658,11 @@ DESCRIPTION=TO BE COMPLETED
 
 [SERVER AUTO SYNCHRONIZE LOG ON CONNECT]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=When running in network mode, rather than asking th euser if they want to sync the logs, the program does so automatically. It reports any errors it finds.
 
 [SPOT COLLECTOR ENABLED]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=When using the DXLab Suite of programs, this will allow SpotCollector to populate the TR4W callsign window when clicking on a spot.
 
 [UPDATE RESTART FILE ENABLE]
 DEFAULT=FALSE
@@ -1671,12 +1670,12 @@ DESCRIPTION=PENDING RE-IMPLEMENTATION. When enabled, TR4W rewrites the restart f
 
 [WSJT-X MULTICAST GROUP]
 DEFAULT=
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=This is the multi-cast IP address used to send messages to WSJT-X. This allows different programs to run simultaneously (such as JT-Alert, GridTracker, etc).
 
 [WSJT-X RADIO CONTROL ENABLED]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=When TRUE, TR4W will offer a radio server such that WSJT-X can select DXLab Commander as the radio type. This allows TR4W to control the radio, but still allows WSJT-X to control the radio as well.
 
 [YCCC SO2R ENABLE]
 DEFAULT=FALSE
-DESCRIPTION=TO BE COMPLETED
+DESCRIPTION=If TRUE, the YCCC SO2R box is supported for switching radio audio streams and other steps involving two-radio mode.


### PR DESCRIPTION
## Summary
Fixes two related X-QSO bugs, plus a batch of help-INI description fills (separate commit).

### #954 — next serial reverts when a QSO is marked X-QSO
The next serial to send was computed as `TotalContacts + 1`, a count of *scoring* QSOs. Marking a QSO X-QSO (or deleting a mid-log QSO) drops that count, so the next serial rolled backward — it was re-displayed, re-sent on the air via the `#` macro, and re-stamped into `NumberSent`, i.e. a **duplicate serial**.

**Fix:** track a per-band high-water mark of the serials actually sent; the next serial is `max(NumberSent) + 1`, which only ever advances.
- `LOGDUPE`: `MaxSerialSent[BandType]`, zeroed alongside `QSOTotals`, maintained over non-deleted QSO records **including** X-QSO (they consumed a number) and **excluding** deleted ones.
- `LOGEDIT`: `NextSerialToSend` (max + 1; returns `ServerSerialNumber` in networked mode, unchanged) and `UpdateMaxSerialSent` (ignores the `$FFFF` ADIF import sentinel and non-positive values — no real serial comes near 65535).
- `LoadinLog` (MainUnit) and the live add (`LOGSUBS2`) feed the mark.
- The next-number display (`LOGWIND.DisplayNextQSONumber`), the on-air `#` macro (`LogSend`, CW + voice), the `NumberSent` stamp (MainUnit), and the CQ-spot labels (`LOGSUBS1`/`LOGSUBS2`) all use `NextSerialToSend`.
- `TotalContacts` and `QSOTotals` are untouched, so the #750 score grid, the status display, the every-10 beep, and `AUTO QSO NUMBER DECREMENT` (F2 repeat) behave exactly as before.

### #949 — X-QSO should not delete the contact from the external log
`uEditQSO` now marks X-QSO by sending a `contactdelete` to the score feeds (UDP + HamScore) while leaving the external logger (DXKeeper) **alone** — the contact stays logged externally but drops out of the contest score.

### Help INI
Fills 30 of 55 `TO BE COMPLETED` description placeholders in `commands_help_eng.ini` (continuing #952). Separate commit.

## Testing
- Built via `FullBuild.ps1`; unit tests pass.
- Log #1/#2, mark #2 X-QSO → next serial **holds at 3** (verified in the UI).

Closes #954
Closes #949