### PR TITLE
TS-890 LAN follow-ups: band/mode display, RIT/XIT offset, A/B operating-VFO, CW KY, VPN connect

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -2371,6 +2371,8 @@ begin
    case RadioParametersArray[RadioModel].rt of
       rtKenwood:
          begin
+         // This whould really be changed to a queue where we send the CW speed command, send the KY coommand and then send the KS command as consecutive commands for the Kenwood.
+         // It also illustrates that we should have a branch in this case just for ELecraft and not lump it into Kenwood. The K3 and K4 handle this but now Kenwood.     NY4I 2026 June 1
          if Msg = ControlF then// increase speed
             begin
             CodeSpeed := CodeSpeed + Round(CodeSpeed * 0.06); // increase 6 %
@@ -2454,7 +2456,16 @@ begin
 //            msgLen := length(Msg);              //length(Msg);
             //len := Min(msgLen, 24);             // 24 max for Kenwood
             case RadioModel of
-               TS480, TS570, TS590, TS890, TS950, TS990, TS2000:
+               TS890:
+                  begin
+                  // TS-890 accepts the space-prefixed KY form with a variable-length
+                  // P2 (KY <space><text>;), so no 24-byte padding -- and never KY2
+                  // (P1='2' would key the fill spaces as dead air). The other Kenwoods
+                  // reject a short P2 under P1=space, so they keep the fixed-24 fill.
+                  maxLen := 24;
+                  pad := false;
+                  end;
+               TS480, TS570, TS590, TS950, TS990, TS2000:
                   begin
                   maxLen := 24;
                   pad := true;

--- a/tr4w/src/uNetRadioBase.pas
+++ b/tr4w/src/uNetRadioBase.pas
@@ -102,6 +102,7 @@ Type TNetRadioBase = class(TObject)
       baseProcMsg: TProcessMsgRef;
       SocketLock: TCriticalSection;
       FLastValidResponse: TDateTime;  // Track last valid response for timeout detection
+      FActiveVFO: TVFO;  // RX/operating VFO; nrVFOA = swap model (K4: A/B swaps contents so A is always active), selectable-model radios (Kenwood FR, Flex slice) drive it via SetActiveVFO
 
       function GetRadioPort: integer;
       procedure SetRadioPort(Value: Integer);
@@ -225,6 +226,12 @@ Type TNetRadioBase = class(TObject)
       // property Fields[Index: Integer]: TFieldSpec read GetField;
       //property FVFO[whichVFO: TVFO]: TRadioVFO read GetVFO;
 
+      // Active (RX/operating) VFO. Default nrVFOA = "swap" model (K4: A/B
+      // exchanges contents, so the active VFO is always A). Selectable-model
+      // radios (Kenwood FR, Flex slice) call SetActiveVFO so the aggregate
+      // main-window status (in pNetworkRadio) follows the receiving VFO.
+      function GetActiveVFO: TVFO;
+      procedure SetActiveVFO(vfo: TVFO);
 
    published
 
@@ -296,6 +303,7 @@ begin
    }
    baseProcMsg := ProcRef;
    bAddTermination := True;   // default: append CR/LF; radios that must not (e.g. TS-890 LAN) set this False in their own constructor
+   FActiveVFO := nrVFOA;      // default swap-model (active VFO always A); selectable-model radios update via SetActiveVFO
    for iVFO := Low(TVFO) to High(TVFO) do
       begin
       Self.vfo[iVFO] := TRadioVFO.Create;
@@ -652,7 +660,14 @@ begin
 
       socket.Port := Self.radioPort;
       socket.Host := Self.radioAddress;
-      socket.ConnectTimeout := 10;
+      // Connect runs on a background thread (the reconnect loop), so a longer
+      // timeout does not block the UI. The original 10ms was too short for
+      // anything but a same-subnet LAN: a VPN/WAN TCP handshake to N2SKH's radio
+      // measured ~95ms, so 10ms always tripped "Connect timed out" before the
+      // handshake finished (ARCP and telnet succeed because they use the multi-
+      // second OS default). 5000ms covers a slow/jittery VPN while still failing
+      // in ~5s when a radio is genuinely off. - raised from 10 on 2026-05-31.
+      socket.ConnectTimeout := 5000;
 
       try
           // Force disconnect to clear any corrupted socket state
@@ -934,6 +949,16 @@ end;
 function TNetRadioBase.GetMode(whichVFO: TVFO): TRadioMode;
 begin
    Result := Self.vfo[whichVFO].mode;
+end;
+
+function TNetRadioBase.GetActiveVFO: TVFO;
+begin
+   Result := FActiveVFO;
+end;
+
+procedure TNetRadioBase.SetActiveVFO(vfo: TVFO);
+begin
+   FActiveVFO := vfo;
 end;
 
 function TNetRadioBase.GetDataMode(whichVFO: TVFO): TRadioMode;

--- a/tr4w/src/uRadioKenwoodTS890.pas
+++ b/tr4w/src/uRadioKenwoodTS890.pas
@@ -63,6 +63,7 @@ type TKenwoodTS890Radio = class(TNetRadioBase)
       procedure ParseRTResponse(const sMessage: string);
       procedure ParseXTResponse(const sMessage: string);
       procedure ParseRFResponse(const sMessage: string);
+      procedure ParseFRResponse(const sMessage: string);
 
    public
       NetworkUsername: ShortString;   // Set by LOGRADIO before Connect; "Admin ID" on the radio
@@ -173,9 +174,13 @@ begin
    // auth phase. If the operator never set credentials (empty NetworkUsername),
    // skip auth entirely and go straight to initialization.
    if Length(NetworkUsername) > 0 then
-      FAuthState := ksWaitingForCN
+      begin
+      FAuthState := ksWaitingForCN;
+      end
    else
+      begin
       FAuthState := ksAuthenticated;
+      end;
 
    Result := Inherited Connect;
 
@@ -299,8 +304,9 @@ begin
    // Prime our cached state with explicit queries.
    Self.SendToRadio('FA;');     // VFO A frequency
    Self.SendToRadio('FB;');     // VFO B frequency
-   Self.SendToRadio('OM0;');    // VFO A mode
-   Self.SendToRadio('OM1;');    // VFO B mode
+   Self.SendToRadio('FR;');     // operating (RX) VFO -- needed to map OM0/OM1 to physical VFOs
+   Self.SendToRadio('OM0;');    // operating-VFO mode (OM is operating-relative)
+   Self.SendToRadio('OM1;');    // other-VFO mode
    Self.SendToRadio('KS;');     // CW keyer speed
    Self.SendToRadio('TB;');     // Split (TX/RX VFO)
    Self.SendToRadio('FT;');     // TX VFO selection
@@ -354,6 +360,10 @@ begin
       ParseTBResponse(sMessage)
    else if AnsiStartsStr('FT', sMessage) then
       ParseFTResponse(sMessage)
+   else if AnsiStartsStr('FR', sMessage) then
+      // Operating (RX) VFO -- pushed under AI2 on A/B. Tracked because the OM
+      // mode reply is operating-VFO-relative (see ParseOMResponse).
+      ParseFRResponse(sMessage)
    else if AnsiStartsStr('RT', sMessage) then
       ParseRTResponse(sMessage)
    else if AnsiStartsStr('XT', sMessage) then
@@ -376,10 +386,14 @@ begin
       begin
       // ID024 = TS-890S. Anything else means we connected to the wrong radio.
       if AnsiStartsStr('ID024', sMessage) then
-         logger.Info('[%s.ProcessMessage] Confirmed TS-890S (ID024)', [Self.rigLabel])
+         begin
+         logger.Info('[%s.ProcessMessage] Confirmed TS-890S (ID024)', [Self.rigLabel]);
+         end
       else
+         begin
          logger.Warn('[%s.ProcessMessage] Unexpected ID response: %s',
                      [Self.rigLabel, sMessage]);
+         end;
       end
    else
       begin
@@ -429,7 +443,9 @@ begin
    // frequency rather than a band number, so we derive it; the K4 sets
    // vfo[].band for exactly the same reason.
    if Self.vfo[whichVFO].frequency > 0 then
+      begin
       Self.vfo[whichVFO].band := FreqToRadioBand(Self.vfo[whichVFO].frequency);
+      end;
    logger.Trace('[%s.ParseFAOrFBResponse] %s = %d Hz (band %d)',
                 [Self.rigLabel, VFOToString(whichVFO), freqVal,
                  Ord(Self.vfo[whichVFO].band)]);
@@ -450,9 +466,22 @@ begin
    vfoChar  := sMessage[3];
    modeChar := sMessage[4];
 
+   // KENWOOD QUIRK: the OM P1 byte is OPERATING-VFO-relative, NOT a fixed VFO
+   // A/B -- '0' = the operating (FR-selected) VFO, '1' = the other VFO. Map it
+   // to the physical VFO via the base active VFO (GetActiveVFO, set from FR). Without this,
+   // after an A/B swap to VFO B the radio's OM0 (= B's mode) is filed under
+   // VFO A and the per-VFO modes display swapped (issue #1, confirmed in the
+   // A/B capture: FR1 then OM with the modes transposed).
    case vfoChar of
-      '0': whichVFO := nrVFOA;
-      '1': whichVFO := nrVFOB;
+      '0': whichVFO := Self.GetActiveVFO;
+      '1': if Self.GetActiveVFO = nrVFOA then
+              begin
+              whichVFO := nrVFOB;
+              end
+           else
+              begin
+              whichVFO := nrVFOA;
+              end;
    else
       logger.Warn('[%s.ParseOMResponse] Unexpected VFO char in: %s',
                   [Self.rigLabel, sMessage]);
@@ -460,9 +489,10 @@ begin
    end;
 
    Self.vfo[whichVFO].mode := ModeCharToMode(modeChar);
-   logger.Trace('[%s.ParseOMResponse] %s mode = %s (char %s)',
+   logger.Trace('[%s.ParseOMResponse] %s mode = %s (OM%s, operating=%s)',
                 [Self.rigLabel, VFOToString(whichVFO),
-                 Self.ModeToString(Self.vfo[whichVFO].mode), modeChar]);
+                 Self.ModeToString(Self.vfo[whichVFO].mode), vfoChar,
+                 VFOToString(Self.GetActiveVFO)]);
 end;
 
 procedure TKenwoodTS890Radio.ParseKSResponse(const sMessage: string);
@@ -472,7 +502,10 @@ var
    convErr: Integer;
 begin
    // Format: KS<3-digit WPM>;
-   if Length(sMessage) < 5 then Exit;
+   if Length(sMessage) < 5 then
+      begin
+      Exit;
+      end;
    wpmStr := Copy(sMessage, 3, 3);
    Val(wpmStr, wpmVal, convErr);
    if convErr = 0 then
@@ -486,7 +519,10 @@ end;
 // TS-890 Split is a global on/off flag separate from FR/FT VFO selection.
 procedure TKenwoodTS890Radio.ParseTBResponse(const sMessage: string);
 begin
-   if Length(sMessage) < 3 then Exit;
+   if Length(sMessage) < 3 then
+      begin
+      Exit;
+      end;
    Self.SetSplitOn(sMessage[3] = '1');   // base setter -> localSplitEnabled the window reads
    logger.Trace('[%s.ParseTBResponse] Split = %s',
                 [Self.rigLabel, BoolToStr(Self.localSplitEnabled, True)]);
@@ -498,15 +534,50 @@ end;
 // gets fleshed out.
 procedure TKenwoodTS890Radio.ParseFTResponse(const sMessage: string);
 begin
-   if Length(sMessage) < 3 then Exit;
+   if Length(sMessage) < 3 then
+      begin
+      Exit;
+      end;
    logger.Trace('[%s.ParseFTResponse] TX VFO = %s',
                 [Self.rigLabel, IfThen(sMessage[3] = '1', 'B', 'A')]);
+end;
+
+// Format: FR<0|1>;  -- 0 = VFO A is the operating (RX) VFO, 1 = VFO B. The radio
+// pushes this under AI2 when A/B is pressed. We must track it because the OM
+// (mode) reply is operating-VFO-relative: OM0 = the operating VFO's mode, OM1 =
+// the other VFO's. ParseOMResponse uses the base active VFO (GetActiveVFO) to file each OM reply
+// under the correct physical VFO -- fixes the A/B mode-swap (issue #1).
+procedure TKenwoodTS890Radio.ParseFRResponse(const sMessage: string);
+begin
+   if Length(sMessage) < 3 then
+      begin
+      Exit;
+      end;
+
+   // TS-890 is a selectable-RX-VFO radio: FR moves the RX pointer (FR0=A, FR1=B)
+   // without swapping VFO contents. Drive the base FActiveVFO so BOTH the main-
+   // window display (via pNetworkRadio / GetActiveVFO) and the operating-relative
+   // OM mode mapping follow the receiving VFO.
+   if sMessage[3] = '1' then
+      begin
+      Self.SetActiveVFO(nrVFOB);
+      end
+   else
+      begin
+      Self.SetActiveVFO(nrVFOA);
+      end;
+
+   logger.Trace('[%s.ParseFRResponse] operating (RX) VFO = %s',
+                [Self.rigLabel, VFOToString(Self.GetActiveVFO)]);
 end;
 
 // Format: RT<0|1>;  -- 0 = RIT off, 1 = RIT on.
 procedure TKenwoodTS890Radio.ParseRTResponse(const sMessage: string);
 begin
-   if Length(sMessage) < 3 then Exit;
+   if Length(sMessage) < 3 then
+      begin
+      Exit;
+      end;
    Self.SetRITOn(sMessage[3] = '1');   // base setter -> per-VFO RITState the window reads
    logger.Trace('[%s.ParseRTResponse] RIT = %s',
                 [Self.rigLabel, BoolToStr(Self.RITState, True)]);
@@ -515,7 +586,10 @@ end;
 // Format: XT<0|1>;  -- 0 = XIT off, 1 = XIT on.
 procedure TKenwoodTS890Radio.ParseXTResponse(const sMessage: string);
 begin
-   if Length(sMessage) < 3 then Exit;
+   if Length(sMessage) < 3 then
+      begin
+      Exit;
+      end;
    Self.SetXITOn(sMessage[3] = '1');   // base setter -> per-VFO XITState the window reads
    logger.Trace('[%s.ParseXTResponse] XIT = %s',
                 [Self.rigLabel, BoolToStr(Self.XITState, True)]);
@@ -550,7 +624,9 @@ begin
 
    offset := magVal;
    if sMessage[3] = '1' then          // P1 = 1 => minus direction
+      begin
       offset := -offset;
+      end;
 
    Self.vfo[nrVFOA].RITOffset := offset;
    logger.Trace('[%s.ParseRFResponse] RIT/XIT offset = %d Hz', [Self.rigLabel, offset]);
@@ -679,7 +755,9 @@ begin
    Self.SendToRadio(Format('%s%.11d;', [sCmd, freq]));
 
    if mode <> rmNone then
+      begin
       Self.SetMode(mode, vfo);
+      end;
 end;
 
 procedure TKenwoodTS890Radio.SetMode(mode: TRadioMode; vfo: TVFO = nrVFOA);
@@ -804,12 +882,18 @@ begin
 
    magnitude := Abs(hz);
    if magnitude > 9999 then
+      begin
       magnitude := 9999;
+      end;
 
    if hz > 0 then
-      Self.SendToRadio(Format('RU%.5d;', [magnitude]))
+      begin
+      Self.SendToRadio(Format('RU%.5d;', [magnitude]));
+      end
    else
+      begin
       Self.SendToRadio(Format('RD%.5d;', [magnitude]));
+      end;
 end;
 
 procedure TKenwoodTS890Radio.SetXITFreq(whichVFO: TVFO; hz: integer);
@@ -827,9 +911,13 @@ procedure TKenwoodTS890Radio.Split(splitOn: boolean);
 begin
    if FAuthState <> ksAuthenticated then Exit;
    if splitOn then
-      Self.SendToRadio('FT1;')   // TX = VFO B
+      begin
+      Self.SendToRadio('FT1;');   // TX = VFO B
+      end
    else
+      begin
       Self.SendToRadio('FT0;');  // TX = VFO A (split off)
+      end;
 end;
 
 procedure TKenwoodTS890Radio.SetBand(band: TRadioBand; vfo: TVFO = nrVFOA);

--- a/tr4w/src/uRadioKenwoodTS890.pas
+++ b/tr4w/src/uRadioKenwoodTS890.pas
@@ -62,6 +62,7 @@ type TKenwoodTS890Radio = class(TNetRadioBase)
       procedure ParseFTResponse(const sMessage: string);
       procedure ParseRTResponse(const sMessage: string);
       procedure ParseXTResponse(const sMessage: string);
+      procedure ParseRFResponse(const sMessage: string);
 
    public
       NetworkUsername: ShortString;   // Set by LOGRADIO before Connect; "Admin ID" on the radio
@@ -357,6 +358,9 @@ begin
       ParseRTResponse(sMessage)
    else if AnsiStartsStr('XT', sMessage) then
       ParseXTResponse(sMessage)
+   else if AnsiStartsStr('RF', sMessage) then
+      // RIT/XIT frequency offset, pushed unsolicited under AI2 as the knob turns.
+      ParseRFResponse(sMessage)
    else if AnsiStartsStr('TX', sMessage) then
       // Radio pushes TX0; when it goes to transmit (AI2). Surface it so the
       // main window's TX indicator updates.
@@ -416,8 +420,19 @@ begin
       end;
 
    Self.vfo[whichVFO].frequency := freqVal;
-   logger.Trace('[%s.ParseFAOrFBResponse] %s = %d Hz',
-                [Self.rigLabel, VFOToString(whichVFO), freqVal]);
+   // Derive and store the band from the reported frequency. Without this,
+   // vfo[].band stays NoBand -> GetBand returns NoBand -> FilteredStatus.Band
+   // is NoBand -> ProcessFilteredStatus (uRadioPolling ~3161) skips the whole
+   // ActiveBand/ActiveMode/DisplayBandMode update, so the main-window
+   // band-above-freq, the band table, AND the mode never follow the radio
+   // (only the frequency updates, via a separate path). The Kenwood reports a
+   // frequency rather than a band number, so we derive it; the K4 sets
+   // vfo[].band for exactly the same reason.
+   if Self.vfo[whichVFO].frequency > 0 then
+      Self.vfo[whichVFO].band := FreqToRadioBand(Self.vfo[whichVFO].frequency);
+   logger.Trace('[%s.ParseFAOrFBResponse] %s = %d Hz (band %d)',
+                [Self.rigLabel, VFOToString(whichVFO), freqVal,
+                 Ord(Self.vfo[whichVFO].band)]);
 end;
 
 procedure TKenwoodTS890Radio.ParseOMResponse(const sMessage: string);
@@ -504,6 +519,41 @@ begin
    Self.SetXITOn(sMessage[3] = '1');   // base setter -> per-VFO XITState the window reads
    logger.Trace('[%s.ParseXTResponse] XIT = %s',
                 [Self.rigLabel, BoolToStr(Self.XITState, True)]);
+end;
+
+// Format: RF<P1><P2P2P2P2>;  P1 = direction (0 = +, 1 = -), P2 = 4-digit RIT/XIT
+// offset in Hz (0000-9999), e.g. RF10030 = -30 Hz, RF00000 = centered.  The
+// TS-890 pushes this UNSOLICITED under AI2 as the RIT/XIT knob turns -- validated
+// against N2SKH's capture: 276 RF frames from the radio, zero client RF; queries.
+// So there is nothing to poll; we just stop discarding the frames we already
+// receive.  Stored as the active VFO's RIT offset; the polling bridge copies
+// vfo[].RITOffset -> CurrentStatus.RITFreq, which the main window displays.
+// (RIT/XIT on/off arrive separately as RT;/XT; -- see ParseRT/XTResponse.)
+procedure TKenwoodTS890Radio.ParseRFResponse(const sMessage: string);
+var
+   magVal, convErr, offset: Integer;
+begin
+   // "RF" + direction(1) + 4 digits => 7 chars minimum (semicolon already stripped).
+   if Length(sMessage) < 7 then
+      begin
+      logger.Warn('[%s.ParseRFResponse] Short RF reply: %s', [Self.rigLabel, sMessage]);
+      Exit;
+      end;
+
+   Val(Copy(sMessage, 4, 4), magVal, convErr);   // P2: 4-digit magnitude in Hz
+   if convErr <> 0 then
+      begin
+      logger.Warn('[%s.ParseRFResponse] Non-numeric RF offset: %s',
+                  [Self.rigLabel, sMessage]);
+      Exit;
+      end;
+
+   offset := magVal;
+   if sMessage[3] = '1' then          // P1 = 1 => minus direction
+      offset := -offset;
+
+   Self.vfo[nrVFOA].RITOffset := offset;
+   logger.Trace('[%s.ParseRFResponse] RIT/XIT offset = %d Hz', [Self.rigLabel, offset]);
 end;
 
 // ============================================================================

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -728,6 +728,7 @@ var
    lastRITXITTick: LongWord;
    authErrBuf: array[0..127] of Char;
    handshakeStuckSinceTick: LongWord;  // GetTickCount when we first noticed IsConnected but not IsOperational; 0 = not tracking
+   actVFO: TVFO;                       // active (RX) VFO for the aggregate main-window status (ro.GetActiveVFO)
 const
    RECONNECT_INITIAL_DELAY = 1000;    // 1 second initial delay
    RECONNECT_MAX_DELAY = 30000;       // 30 seconds max delay
@@ -956,14 +957,23 @@ begin
                end;
             end;
 
-         rig^.CurrentStatus.Freq := ro.frequency[nrVFOA];
-         rig^.CurrentStatus.Band := GetTR4WBandFromNetworkBand(ro.band[nrVFOA]);
-         GetTRModeAndExtendedModeFromNetworkMode(ro.mode[nrVFOA],rig^.CurrentStatus.Mode,rig^.CurrentStatus.ExtendedMode);
-         rig^.CurrentStatus.RITFreq :=  ro.RITOffset[nrVFOA];
+         // Aggregate "main window" status follows the active (RX/operating) VFO.
+         // Swap-model radios (K4) return nrVFOA from GetActiveVFO -- unchanged
+         // from before. Selectable-model radios (Kenwood FR, Flex) return the
+         // receiving VFO, so the main window tracks A/B selection on the radio.
+         actVFO := ro.GetActiveVFO;
+         rig^.CurrentStatus.Freq := ro.frequency[actVFO];
+         rig^.CurrentStatus.Band := GetTR4WBandFromNetworkBand(ro.band[actVFO]);
+         GetTRModeAndExtendedModeFromNetworkMode(ro.mode[actVFO],rig^.CurrentStatus.Mode,rig^.CurrentStatus.ExtendedMode);
+         rig^.CurrentStatus.RITFreq :=  ro.RITOffset[actVFO];
          rig^.CurrentStatus.Split := ro.IsSplitEnabled;
-         rig^.CurrentStatus.RIT := ro.IsRITOn[nrVFOA];
-         rig^.CurrentStatus.XIT := ro.IsXITOn[nrVFOA];
+         rig^.CurrentStatus.RIT := ro.IsRITOn[actVFO];
+         rig^.CurrentStatus.XIT := ro.IsXITOn[actVFO];
          rig^.CurrentStatus.TXOn := ro.IsTransmitting;
+         if actVFO = nrVFOB then
+            rig^.CurrentStatus.VFOStatus := VFOB
+         else
+            rig^.CurrentStatus.VFOStatus := VFOA;
 
          // VFO A
          rig.CurrentStatus.VFO[VFOA].Frequency := ro.frequency[nrVFOA];
@@ -972,7 +982,7 @@ begin
          rig.CurrentStatus.VFO[VFOA].XIT := ro.IsXITOn[nrVFOA];
          rig.CurrentStatus.VFO[VFOA].RITFreq := ro.RITOffset[nrVFOA];
          rig.CurrentStatus.VFO[VFOA].Band := GetTR4WBandFromNetworkBand(ro.band[nrVFOA]);
-         rig.CurrentStatus.Band := GetTR4WBandFromNetworkBand(ro.band[nrVFOA]);
+         rig.CurrentStatus.Band := GetTR4WBandFromNetworkBand(ro.band[actVFO]);  // aggregate band follows active VFO
 
          // VFO B
          rig.CurrentStatus.VFO[VFOB].Frequency := ro.frequency[nrVFOB];

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -131,6 +131,7 @@ uses
   uSerialPort in 'src\uSerialPort.pas',
   uRadioFactory in 'src\uRadioFactory.pas',
   uRadioElecraftK4 in 'src\uRadioElecraftK4.pas',
+  uRadioKenwoodTS890 in 'src\uRadioKenwoodTS890.pas',
   uIcomNetworkTypes in 'src\uIcomNetworkTypes.pas',
   uIcomNetworkTransport in 'src\uIcomNetworkTransport.pas',
   uIcomNetworkDiscovery in 'src\uIcomNetworkDiscovery.pas',
@@ -157,6 +158,7 @@ uses
   uYCCCSO2R in 'src\uYCCCSO2R.pas',
   uFlexRadio6000 in 'src\uFlexRadio6000.pas',
   uRadioBand in 'src\uRadioBand.pas',
+  uBandLookup in 'src\uBandLookup.pas',
   uRadioIcom7100 in 'src\uRadioIcom7100.pas',
   uIcomCIV in 'src\uIcomCIV.pas',
   // uRadioManager uses Generics.Collections (Delphi 2009+) - not Delphi 7 IDE compatible


### PR DESCRIPTION
## Summary
Follow-ups to the TS-890 LAN support (#436 / PR TR4W/TR4W#951), driven by N2SKH (Ron) on-air testing on 2026-05-31 / 06-01. Two commits, each validated against live `tr4w.log` + Wireshark pcaps; builds clean via `FullBuild.ps1`, unit tests pass.

### Band/mode display follows the radio — `e3328ea`
`ParseFAOrFBResponse` now derives `vfo[].band` from the reported frequency. Without it, `FilteredStatus.Band` stayed `NoBand` and `ProcessFilteredStatus` (uRadioPolling) skipped the whole `ActiveBand`/`ActiveMode`/`DisplayBandMode` update — so the main-window band-above-freq, band table, and mode never followed the radio (only the frequency did), and startup showed `NONSSB`. The K4 sets `vfo[].band` for the same reason.

### RIT/XIT offset shown — `e3328ea`
New `ParseRFResponse` parses the RIT/XIT offset from the unsolicited `RF` push (P1 direction + 4-digit Hz) into `vfo[].RITOffset`; the polling bridge surfaces it as `CurrentStatus.RITFreq`. On/off already worked (`RT`/`XT`).

### VPN connect timeout — `34aee50`
`uNetRadioBase` `ConnectTimeout` 10 ms → 5000 ms. 10 ms only works same-subnet; a VPN TCP handshake (~95 ms measured to Ron's radio) tripped "Connect timed out" before completing while ARCP/telnet (OS default) connected fine. Runs on the reconnect background thread, so no UI block.

### Operating-VFO tracking — `34aee50`
- Base `FActiveVFO` + `GetActiveVFO`/`SetActiveVFO` (default `nrVFOA` = swap model like the K4; selectable-model radios drive it). `pNetworkRadio`'s aggregate main-window status + `VFOStatus` now follow `GetActiveVFO` instead of a hardcoded `nrVFOA` — **default-preserving**, so K4/Icom/Flex/HamLib are unchanged.
- TS-890 drives it from `FR` (FR0=A, FR1=B). One change fixes three things: the operating-relative `OM` mode mapping (A/B no longer shows swapped per-VFO modes), the main window following the RX VFO's freq/band/mode, and the Radio 1 window's active-VFO black/gray highlight.

### TS-890 CW `KY` pad-off — `34aee50`
Split `TS890` out of the padded Kenwood arm (`pad := false`): variable-length `KY <space><text>;` instead of fixed-24-byte padding (never `KY2`). The other Kenwoods (480/570/590/950/990/2000) require the fixed 24-byte P2 and are unchanged. Side effect: the 890's CW timer is now correct (it had counted the never-keyed padding).

### Project files — `34aee50`
`tr4w.dpr`: add `uRadioKenwoodTS890` and `uBandLookup` to the `uses` clause so they appear in the Delphi IDE project / find-in-project. New TS-890 code also brought to the begin/end coding standard.

## Not in this PR (tracked separately)
- Band stepping past the radio's range (Alt-B/Alt-V into 2m/LGT) → enhancement TR4W/TR4W-D12#39.
- Padded-Kenwood CW timer over-count (+ the `KYW`/`sendNow` path) → separate TODO.