### PR TITLE
Fix typo in QSO Number popup: "nuber" -> "number"

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3417,7 +3417,7 @@ begin
 {$IF tDebugMode}
         CPUButtonProc;
 {$ELSE}
-        Format(wsprintfBuffer, 'QSO nuber %u', TotalContacts);
+        Format(wsprintfBuffer, 'QSO number %u', TotalContacts);
         ShowMessage(wsprintfBuffer);
 {$IFEND}
       end;


### PR DESCRIPTION
Fixes the typo reported by Ron, N2SKH.

The Ctrl-/ → Additional Information → QSO Number popup displayed **"QSO nuber n."**. Corrected the hardcoded literal in `tr4w/src/MainUnit.pas:3420` (`'QSO nuber %u'` → `'QSO number %u'`).

- English-only hardcoded literal (not a `TC_` resource), so no language files affected.
- One-character change, no behavior impact.

The split-mode bug from the same report is tracked separately in TR4W/TR4W-D12#38.