### PR TITLE
Update repo URLs after org transfer to TR4W/TR4W

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Place at .github/workflows/release.yml in n4af/tr4w
+# Place at .github/workflows/release.yml in TR4W/TR4W
 #
 # Triggers:
 #   1. Tag push v4.X.Y       -> English-only build + ENG installer

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,4 +1,4 @@
-# Place at .github/workflows/version-guard.yml in n4af/tr4w
+# Place at .github/workflows/version-guard.yml in TR4W/TR4W
 #
 # Purpose:
 #   Guard against tr4w/src/Version.pas being dropped or corrupted by a merge.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 **This is a developer-level document with far more technical detail than is needed for most users of TR4W.** While you are welcome to read it for the internals of how it all works, if you are just interested in the changes that may affect how you use TR4W, the RELEASE NOTES may be of more value to you. You can find those [here](/RELEASE_NOTES.md).
 
 > TRLOG 4 Windows — Free Amateur Radio Contest Logging Application  
-> Repository: [github.com/n4af/TR4W](https://github.com/n4af/TR4W)  
+> Repository: [github.com/TR4W/TR4W](https://github.com/TR4W/TR4W)  
 > Generated: 2026-03-19
 
 ## Contributors
@@ -1319,7 +1319,7 @@ The repository was first committed on April 25, 2014 at version 4.30.3 by Howard
 
 ---
 
-*This changelog was generated from the Git commit history of the [n4af/TR4W](https://github.com/n4af/TR4W) repository on March 19, 2026.*
+*This changelog was generated from the Git commit history of the [TR4W/TR4W](https://github.com/TR4W/TR4W) repository on March 19, 2026.*
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -932,4 +932,4 @@ Key individual releases in this period include version 4.195 (February 2010), wh
 
 ---
 
-*This changelog was generated from the Git commit history of the [n4af/TR4W](https://github.com/n4af/TR4W) repository. Repository: [github.com/n4af/TR4W](https://github.com/n4af/TR4W)*
+*This changelog was generated from the Git commit history of the [TR4W/TR4W](https://github.com/TR4W/TR4W) repository. Repository: [github.com/TR4W/TR4W](https://github.com/TR4W/TR4W)*

--- a/TR4W_ISSUE_ANALYSIS.md
+++ b/TR4W_ISSUE_ANALYSIS.md
@@ -1,7 +1,7 @@
 # TR4W: Open Issues Analysis & Work Planning
 
 > Cross-reference of open GitHub issues against commits, PRs, and triage status  
-> Repository: [github.com/n4af/TR4W](https://github.com/n4af/TR4W)  
+> Repository: [github.com/TR4W/TR4W](https://github.com/TR4W/TR4W)  
 > Original analysis: 2026-03-14 | **Last updated: 2026-04-15**
 
 ---
@@ -27,17 +27,17 @@ These were flagged in the original analysis but remain open. They need a human v
 
 | Issue | Title | Status | Notes |
 |-------|-------|--------|-------|
-| [#688](https://github.com/n4af/TR4W/issues/688) | Lock bandmap window while updating to prevent flashing | **Open — likely resolved** | PR #869 (merged 2026-04-13) specifically addressed this: 250ms coalesced refresh timer, `WS_EX_COMPOSITED`, `RDW_NOERASE`. Band map flicker greatly reduced per PR description. Close after confirming in a build. |
-| [#87](https://github.com/n4af/TR4W/issues/87) | SCP-like behavior for Section names | Open | Commit said "getting ready for" — still unverified. |
-| [#800](https://github.com/n4af/TR4W/issues/800) | CW Speed Sync not following K4 | Open | Commit `ad86674b` said "minus issue 800" — K4 CW sync still unresolved. Issue #871 (WinKeyer extra space) is related but distinct. |
-| [#383](https://github.com/n4af/TR4W/issues/383) | Status line message when radio connection lost | Open | Reconnection work added detection infrastructure; verify if status bar actually shows disconnect message. |
-| [#735](https://github.com/n4af/TR4W/issues/735) | Direct log via TCP to ACLog | Open | Factory framework has `lt_ACLog` stub — check `uExternalLogger.pas` for actual send logic. |
-| [#736](https://github.com/n4af/TR4W/issues/736) | HRD support for external logger | Open | Same as #735 — factory has `lt_HRD`, verify implementation vs. stub. |
-| [#766](https://github.com/n4af/TR4W/issues/766) | Exception when editing contact with external logger | Open | Exception handling was added broadly — test by editing a contact with logger connected. |
-| [#703](https://github.com/n4af/TR4W/issues/703) | K4 network doesn't reset split on bandmap click | Open | Split handling rewritten in factory pattern. Test on current build. |
-| [#121](https://github.com/n4af/TR4W/issues/121) | S&P mode entered on Icom in split mode | Open | New `TIcomRadioBase` CI-V implementation is completely new. Test on IC-7300/7610/9700. |
-| [#415](https://github.com/n4af/TR4W/issues/415) | Translation updates 2020-July | Open | WAGWarn item was done; verify remaining 3 (`TC_CANNOTOPENLOG`, `TC_LOGNOTPRESENT`, `TC_IMPORTFILENOTFOUND`). |
-| [#396](https://github.com/n4af/TR4W/issues/396) | Applied merge by mistake | Open | This was a 2020 incident, not an active bug. **Close as resolved.** |
+| [#688](https://github.com/TR4W/TR4W/issues/688) | Lock bandmap window while updating to prevent flashing | **Open — likely resolved** | PR #869 (merged 2026-04-13) specifically addressed this: 250ms coalesced refresh timer, `WS_EX_COMPOSITED`, `RDW_NOERASE`. Band map flicker greatly reduced per PR description. Close after confirming in a build. |
+| [#87](https://github.com/TR4W/TR4W/issues/87) | SCP-like behavior for Section names | Open | Commit said "getting ready for" — still unverified. |
+| [#800](https://github.com/TR4W/TR4W/issues/800) | CW Speed Sync not following K4 | Open | Commit `ad86674b` said "minus issue 800" — K4 CW sync still unresolved. Issue #871 (WinKeyer extra space) is related but distinct. |
+| [#383](https://github.com/TR4W/TR4W/issues/383) | Status line message when radio connection lost | Open | Reconnection work added detection infrastructure; verify if status bar actually shows disconnect message. |
+| [#735](https://github.com/TR4W/TR4W/issues/735) | Direct log via TCP to ACLog | Open | Factory framework has `lt_ACLog` stub — check `uExternalLogger.pas` for actual send logic. |
+| [#736](https://github.com/TR4W/TR4W/issues/736) | HRD support for external logger | Open | Same as #735 — factory has `lt_HRD`, verify implementation vs. stub. |
+| [#766](https://github.com/TR4W/TR4W/issues/766) | Exception when editing contact with external logger | Open | Exception handling was added broadly — test by editing a contact with logger connected. |
+| [#703](https://github.com/TR4W/TR4W/issues/703) | K4 network doesn't reset split on bandmap click | Open | Split handling rewritten in factory pattern. Test on current build. |
+| [#121](https://github.com/TR4W/TR4W/issues/121) | S&P mode entered on Icom in split mode | Open | New `TIcomRadioBase` CI-V implementation is completely new. Test on IC-7300/7610/9700. |
+| [#415](https://github.com/TR4W/TR4W/issues/415) | Translation updates 2020-July | Open | WAGWarn item was done; verify remaining 3 (`TC_CANNOTOPENLOG`, `TC_LOGNOTPRESENT`, `TC_IMPORTFILENOTFOUND`). |
+| [#396](https://github.com/TR4W/TR4W/issues/396) | Applied merge by mistake | Open | This was a 2020 incident, not an active bug. **Close as resolved.** |
 
 ---
 
@@ -49,72 +49,72 @@ Count: **~95 open issues**. The `Triaged` label should only be applied after a d
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#877](https://github.com/n4af/TR4W/issues/877) | POTA parser does not accept free-form info like state or name | enhancement, POTA, Triaged |
-| [#871](https://github.com/n4af/TR4W/issues/871) | Extra Space Inserted Between Callsign and Report (AUTO SEND CHARACTER COUNT) | Triaged |
+| [#877](https://github.com/TR4W/TR4W/issues/877) | POTA parser does not accept free-form info like state or name | enhancement, POTA, Triaged |
+| [#871](https://github.com/TR4W/TR4W/issues/871) | Extra Space Inserted Between Callsign and Report (AUTO SEND CHARACTER COUNT) | Triaged |
 
 ### Bugs
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#818](https://github.com/n4af/TR4W/issues/818) | NewContest dialog asks for MY STATE on non-state contests | bug, Triaged |
-| [#807](https://github.com/n4af/TR4W/issues/807) | 9A (Croatian) DX awarding zero points | bug, Triaged |
-| [#800](https://github.com/n4af/TR4W/issues/800) | CW Speed Sync not following K4 | bug, Radio Control, Triaged |
-| [#788](https://github.com/n4af/TR4W/issues/788) | NextBandMap still displays deleted spot | bug, Triaged |
-| [#784](https://github.com/n4af/TR4W/issues/784) | Next Bandmap fails to clear Initial Exchange field | bug, Triaged |
-| [#766](https://github.com/n4af/TR4W/issues/766) | Exception when editing contact with external logger | bug, External Logger, Triaged |
-| [#740](https://github.com/n4af/TR4W/issues/740) | BAND MAP CALL WINDOW feature does not seem to work | bug, Triaged |
-| [#726](https://github.com/n4af/TR4W/issues/726) | PostUnit: remaining MyExchange handlers in GenerateMyExchange | bug, Triaged |
-| [#716](https://github.com/n4af/TR4W/issues/716) | Random access violation using multi-network | bug, Multi-network, Triaged |
-| [#709](https://github.com/n4af/TR4W/issues/709) | Croatian DX counting multipliers wrong | bug, Triaged |
-| [#683](https://github.com/n4af/TR4W/issues/683) | Orion and Omni mode change ALT-M does not work | bug, Radio Control, Triaged |
-| [#680](https://github.com/n4af/TR4W/issues/680) | CW port already open after APPLY/OK in Radio setup | bug, Triaged |
-| [#505](https://github.com/n4af/TR4W/issues/505) | In S&P, after sending call via ENTER, F1 does not send call again | bug, Radio Control, Triaged |
-| [#459](https://github.com/n4af/TR4W/issues/459) | Extra characters show up after save backup log | bug, Triaged |
-| [#435](https://github.com/n4af/TR4W/issues/435) | Implement Kenwood TS990/TS890 Mode properly | bug, Radio Control, Triaged |
-| [#426](https://github.com/n4af/TR4W/issues/426) | DVK recording and volume fail to function | bug, Triaged |
-| [#417](https://github.com/n4af/TR4W/issues/417) | NA SPRINT: QTHString not cleared when exchange in State/name/# order | bug, ADIF, Triaged |
-| [#121](https://github.com/n4af/TR4W/issues/121) | S&P mode entered on Icom in split mode | bug, Triaged |
+| [#818](https://github.com/TR4W/TR4W/issues/818) | NewContest dialog asks for MY STATE on non-state contests | bug, Triaged |
+| [#807](https://github.com/TR4W/TR4W/issues/807) | 9A (Croatian) DX awarding zero points | bug, Triaged |
+| [#800](https://github.com/TR4W/TR4W/issues/800) | CW Speed Sync not following K4 | bug, Radio Control, Triaged |
+| [#788](https://github.com/TR4W/TR4W/issues/788) | NextBandMap still displays deleted spot | bug, Triaged |
+| [#784](https://github.com/TR4W/TR4W/issues/784) | Next Bandmap fails to clear Initial Exchange field | bug, Triaged |
+| [#766](https://github.com/TR4W/TR4W/issues/766) | Exception when editing contact with external logger | bug, External Logger, Triaged |
+| [#740](https://github.com/TR4W/TR4W/issues/740) | BAND MAP CALL WINDOW feature does not seem to work | bug, Triaged |
+| [#726](https://github.com/TR4W/TR4W/issues/726) | PostUnit: remaining MyExchange handlers in GenerateMyExchange | bug, Triaged |
+| [#716](https://github.com/TR4W/TR4W/issues/716) | Random access violation using multi-network | bug, Multi-network, Triaged |
+| [#709](https://github.com/TR4W/TR4W/issues/709) | Croatian DX counting multipliers wrong | bug, Triaged |
+| [#683](https://github.com/TR4W/TR4W/issues/683) | Orion and Omni mode change ALT-M does not work | bug, Radio Control, Triaged |
+| [#680](https://github.com/TR4W/TR4W/issues/680) | CW port already open after APPLY/OK in Radio setup | bug, Triaged |
+| [#505](https://github.com/TR4W/TR4W/issues/505) | In S&P, after sending call via ENTER, F1 does not send call again | bug, Radio Control, Triaged |
+| [#459](https://github.com/TR4W/TR4W/issues/459) | Extra characters show up after save backup log | bug, Triaged |
+| [#435](https://github.com/TR4W/TR4W/issues/435) | Implement Kenwood TS990/TS890 Mode properly | bug, Radio Control, Triaged |
+| [#426](https://github.com/TR4W/TR4W/issues/426) | DVK recording and volume fail to function | bug, Triaged |
+| [#417](https://github.com/TR4W/TR4W/issues/417) | NA SPRINT: QTHString not cleared when exchange in State/name/# order | bug, ADIF, Triaged |
+| [#121](https://github.com/TR4W/TR4W/issues/121) | S&P mode entered on Icom in split mode | bug, Triaged |
 
 ### Bandmap
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#835](https://github.com/n4af/TR4W/issues/835) | When clicking spot in band map, send UDP lookup message | Band Map, External Logger, Triaged |
-| [#747](https://github.com/n4af/TR4W/issues/747) | After selecting bandmap, auto tab to exchange window | Band Map, Triaged |
-| [#705](https://github.com/n4af/TR4W/issues/705) | Copy spot from bandmap to clipboard in pasteable format | enhancement, Band Map, Triaged |
-| [#699](https://github.com/n4af/TR4W/issues/699) | In QSO Party, flag county in spot as mult in band map | enhancement, DX Cluster, Triaged |
-| [#688](https://github.com/n4af/TR4W/issues/688) | Lock bandmap window while updating to prevent flashing | Band Map, Triaged — **likely resolved by PR #869, needs close** |
+| [#835](https://github.com/TR4W/TR4W/issues/835) | When clicking spot in band map, send UDP lookup message | Band Map, External Logger, Triaged |
+| [#747](https://github.com/TR4W/TR4W/issues/747) | After selecting bandmap, auto tab to exchange window | Band Map, Triaged |
+| [#705](https://github.com/TR4W/TR4W/issues/705) | Copy spot from bandmap to clipboard in pasteable format | enhancement, Band Map, Triaged |
+| [#699](https://github.com/TR4W/TR4W/issues/699) | In QSO Party, flag county in spot as mult in band map | enhancement, DX Cluster, Triaged |
+| [#688](https://github.com/TR4W/TR4W/issues/688) | Lock bandmap window while updating to prevent flashing | Band Map, Triaged — **likely resolved by PR #869, needs close** |
 
 ### Radio Control
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#856](https://github.com/n4af/TR4W/issues/856) | Implement polymorphic KeepAlive for factory radio objects | enhancement, Triaged |
-| [#854](https://github.com/n4af/TR4W/issues/854) | Rename tNetObject to FactoryRadio throughout codebase | enhancement, Triaged |
-| [#853](https://github.com/n4af/TR4W/issues/853) | Implement radio discovery dialog for network radios | Radio Control, Triaged |
-| [#852](https://github.com/n4af/TR4W/issues/852) | Add Icom 7700 to network radio implementation | Radio Control, Triaged |
-| [#850](https://github.com/n4af/TR4W/issues/850) | Selective Use of 07 D2 Logic for Icom 9700 | Radio Control, Triaged |
-| [#781](https://github.com/n4af/TR4W/issues/781) | Add SPAN commands for PAN adapter function key | enhancement, Radio Control, Triaged |
-| [#703](https://github.com/n4af/TR4W/issues/703) | K4 network doesn't reset split on bandmap click | Radio Control, Triaged |
-| [#683](https://github.com/n4af/TR4W/issues/683) | Orion and Omni ALT-M mode change does not work | bug, Radio Control, Triaged |
-| [#623](https://github.com/n4af/TR4W/issues/623) | Fix Ten Tec Omni VI (564) breaking change | Radio Control, Triaged |
-| [#449](https://github.com/n4af/TR4W/issues/449) | Make Flex its own radio type in uRadioPolling | enhancement, Radio Control, Triaged |
-| [#448](https://github.com/n4af/TR4W/issues/448) | Implement TCP and UDP protocol for Flex radios | enhancement, Networking, Radio Control, Triaged |
-| [#436](https://github.com/n4af/TR4W/issues/436) | Add rig control for TS890 | enhancement, New Radio Request, Triaged |
-| [#383](https://github.com/n4af/TR4W/issues/383) | Status line message when radio connection is lost | Radio Control, Triaged |
-| [#315](https://github.com/n4af/TR4W/issues/315) | Detect data mode on IC-9100 | Radio Control, Triaged |
+| [#856](https://github.com/TR4W/TR4W/issues/856) | Implement polymorphic KeepAlive for factory radio objects | enhancement, Triaged |
+| [#854](https://github.com/TR4W/TR4W/issues/854) | Rename tNetObject to FactoryRadio throughout codebase | enhancement, Triaged |
+| [#853](https://github.com/TR4W/TR4W/issues/853) | Implement radio discovery dialog for network radios | Radio Control, Triaged |
+| [#852](https://github.com/TR4W/TR4W/issues/852) | Add Icom 7700 to network radio implementation | Radio Control, Triaged |
+| [#850](https://github.com/TR4W/TR4W/issues/850) | Selective Use of 07 D2 Logic for Icom 9700 | Radio Control, Triaged |
+| [#781](https://github.com/TR4W/TR4W/issues/781) | Add SPAN commands for PAN adapter function key | enhancement, Radio Control, Triaged |
+| [#703](https://github.com/TR4W/TR4W/issues/703) | K4 network doesn't reset split on bandmap click | Radio Control, Triaged |
+| [#683](https://github.com/TR4W/TR4W/issues/683) | Orion and Omni ALT-M mode change does not work | bug, Radio Control, Triaged |
+| [#623](https://github.com/TR4W/TR4W/issues/623) | Fix Ten Tec Omni VI (564) breaking change | Radio Control, Triaged |
+| [#449](https://github.com/TR4W/TR4W/issues/449) | Make Flex its own radio type in uRadioPolling | enhancement, Radio Control, Triaged |
+| [#448](https://github.com/TR4W/TR4W/issues/448) | Implement TCP and UDP protocol for Flex radios | enhancement, Networking, Radio Control, Triaged |
+| [#436](https://github.com/TR4W/TR4W/issues/436) | Add rig control for TS890 | enhancement, New Radio Request, Triaged |
+| [#383](https://github.com/TR4W/TR4W/issues/383) | Status line message when radio connection is lost | Radio Control, Triaged |
+| [#315](https://github.com/TR4W/TR4W/issues/315) | Detect data mode on IC-9100 | Radio Control, Triaged |
 
 ### New Radio Requests
 
 | Issue | Title |
 |-------|-------|
-| [#844](https://github.com/n4af/TR4W/issues/844) | Add Support for RigSelect Pro Switching Box |
-| [#817](https://github.com/n4af/TR4W/issues/817) | Add support for Yaesu FTX-1F |
-| [#778](https://github.com/n4af/TR4W/issues/778) | Add support for Yaesu FTX-1F (duplicate of #817) |
-| [#767](https://github.com/n4af/TR4W/issues/767) | Add discovery protocol for network-connected K4 radios |
-| [#446](https://github.com/n4af/TR4W/issues/446) | Add support for Expert Electronics TCI interface |
-| [#436](https://github.com/n4af/TR4W/issues/436) | Add rig control for TS890 |
-| [#431](https://github.com/n4af/TR4W/issues/431) | Add support for DXLab Suite Commander as radio |
+| [#844](https://github.com/TR4W/TR4W/issues/844) | Add Support for RigSelect Pro Switching Box |
+| [#817](https://github.com/TR4W/TR4W/issues/817) | Add support for Yaesu FTX-1F |
+| [#778](https://github.com/TR4W/TR4W/issues/778) | Add support for Yaesu FTX-1F (duplicate of #817) |
+| [#767](https://github.com/TR4W/TR4W/issues/767) | Add discovery protocol for network-connected K4 radios |
+| [#446](https://github.com/TR4W/TR4W/issues/446) | Add support for Expert Electronics TCI interface |
+| [#436](https://github.com/TR4W/TR4W/issues/436) | Add rig control for TS890 |
+| [#431](https://github.com/TR4W/TR4W/issues/431) | Add support for DXLab Suite Commander as radio |
 
 > **Note:** #817 and #778 are duplicates — one should be closed.
 
@@ -122,105 +122,105 @@ Count: **~95 open issues**. The `Triaged` label should only be applied after a d
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#820](https://github.com/n4af/TR4W/issues/820) | Add new YUK Canadian section | Contest Exchange, Triaged |
-| [#810](https://github.com/n4af/TR4W/issues/810) | WSJT-X: convert grid to state when contest requires it | enhancement, WSJT-X, Triaged |
-| [#808](https://github.com/n4af/TR4W/issues/808) | 9A (Croatian) double points enhancement | enhancement, Triaged |
-| [#802](https://github.com/n4af/TR4W/issues/802) | Score display not showing all info for ARRL 10 Meter | Triaged |
-| [#799](https://github.com/n4af/TR4W/issues/799) | ARRL 10m: Mult needs for AZ show all bands | enhancement, Triaged |
-| [#797](https://github.com/n4af/TR4W/issues/797) | Scoring change Russian 160 (RU3AX Memorial) | enhancement, Triaged |
-| [#416](https://github.com/n4af/TR4W/issues/416) | NAQP: accept state and name in either order | enhancement, Triaged |
-| [#460](https://github.com/n4af/TR4W/issues/460) | Allow entry of Precedence then number | enhancement, Triaged |
-| [#461](https://github.com/n4af/TR4W/issues/461) | Sweepstakes: prefill spot comment with section | enhancement, good first issue, Triaged |
+| [#820](https://github.com/TR4W/TR4W/issues/820) | Add new YUK Canadian section | Contest Exchange, Triaged |
+| [#810](https://github.com/TR4W/TR4W/issues/810) | WSJT-X: convert grid to state when contest requires it | enhancement, WSJT-X, Triaged |
+| [#808](https://github.com/TR4W/TR4W/issues/808) | 9A (Croatian) double points enhancement | enhancement, Triaged |
+| [#802](https://github.com/TR4W/TR4W/issues/802) | Score display not showing all info for ARRL 10 Meter | Triaged |
+| [#799](https://github.com/TR4W/TR4W/issues/799) | ARRL 10m: Mult needs for AZ show all bands | enhancement, Triaged |
+| [#797](https://github.com/TR4W/TR4W/issues/797) | Scoring change Russian 160 (RU3AX Memorial) | enhancement, Triaged |
+| [#416](https://github.com/TR4W/TR4W/issues/416) | NAQP: accept state and name in either order | enhancement, Triaged |
+| [#460](https://github.com/TR4W/TR4W/issues/460) | Allow entry of Precedence then number | enhancement, Triaged |
+| [#461](https://github.com/TR4W/TR4W/issues/461) | Sweepstakes: prefill spot comment with section | enhancement, good first issue, Triaged |
 
 ### New Contest / DOM Requests
 
 | Issue | Title |
 |-------|-------|
-| [#829](https://github.com/n4af/TR4W/issues/829) | Updated DOM file of UBA DX Contest |
-| [#789](https://github.com/n4af/TR4W/issues/789) | Add changes to 2025 RSGB Contests |
-| [#776](https://github.com/n4af/TR4W/issues/776) | Add URC DX RTTY contest |
-| [#745](https://github.com/n4af/TR4W/issues/745) | Contest name change: TESLA → HF-TESLA |
-| [#692](https://github.com/n4af/TR4W/issues/692) | DARC-WAE: Add total QTCs to Summary.txt |
-| [#602](https://github.com/n4af/TR4W/issues/602) | Contest score board fails to accept overlay category |
-| [#434](https://github.com/n4af/TR4W/issues/434) | Grids.dom does not include all locators in WWDIGI |
-| [#386](https://github.com/n4af/TR4W/issues/386) | TAC rule change |
+| [#829](https://github.com/TR4W/TR4W/issues/829) | Updated DOM file of UBA DX Contest |
+| [#789](https://github.com/TR4W/TR4W/issues/789) | Add changes to 2025 RSGB Contests |
+| [#776](https://github.com/TR4W/TR4W/issues/776) | Add URC DX RTTY contest |
+| [#745](https://github.com/TR4W/TR4W/issues/745) | Contest name change: TESLA → HF-TESLA |
+| [#692](https://github.com/TR4W/TR4W/issues/692) | DARC-WAE: Add total QTCs to Summary.txt |
+| [#602](https://github.com/TR4W/TR4W/issues/602) | Contest score board fails to accept overlay category |
+| [#434](https://github.com/TR4W/TR4W/issues/434) | Grids.dom does not include all locators in WWDIGI |
+| [#386](https://github.com/TR4W/TR4W/issues/386) | TAC rule change |
 
 ### ADIF / Cabrillo / Logging
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#819](https://github.com/n4af/TR4W/issues/819) | Export TR4W-specific fields and import from N1MM | enhancement, ADIF, Triaged |
-| [#774](https://github.com/n4af/TR4W/issues/774) | Make ADIF and Cabrillo contest name configurable in CFG | ADIF, Cabrillo, Triaged |
-| [#750](https://github.com/n4af/TR4W/issues/750) | Add ability to mark a QSO as X-QSO | enhancement, Cabrillo, UDP Broadcast, Triaged |
-| [#473](https://github.com/n4af/TR4W/issues/473) | Cabrillo CATEGORY mismatch — ask to update | enhancement, Cabrillo, Triaged |
-| [#483](https://github.com/n4af/TR4W/issues/483) | Check if MyGrid is put in Contact Record | question, Cabrillo, Triaged |
+| [#819](https://github.com/TR4W/TR4W/issues/819) | Export TR4W-specific fields and import from N1MM | enhancement, ADIF, Triaged |
+| [#774](https://github.com/TR4W/TR4W/issues/774) | Make ADIF and Cabrillo contest name configurable in CFG | ADIF, Cabrillo, Triaged |
+| [#750](https://github.com/TR4W/TR4W/issues/750) | Add ability to mark a QSO as X-QSO | enhancement, Cabrillo, UDP Broadcast, Triaged |
+| [#473](https://github.com/TR4W/TR4W/issues/473) | Cabrillo CATEGORY mismatch — ask to update | enhancement, Cabrillo, Triaged |
+| [#483](https://github.com/TR4W/TR4W/issues/483) | Check if MyGrid is put in Contact Record | question, Cabrillo, Triaged |
 
 ### External Logger / UDP
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#836](https://github.com/n4af/TR4W/issues/836) | PathFinder DDE: exchange not cleared on message receipt | Triaged |
-| [#835](https://github.com/n4af/TR4W/issues/835) | Clicking bandmap spot should send UDP lookup message | Band Map, External Logger, Triaged |
-| [#768](https://github.com/n4af/TR4W/issues/768) | Add SentExchange to Contact UDP broadcast | enhancement, Modern Delphi, UDP Broadcast, Triaged |
-| [#736](https://github.com/n4af/TR4W/issues/736) | Add HRD support to external logger via TCP/IP | enhancement, External Logger, Triaged |
-| [#735](https://github.com/n4af/TR4W/issues/735) | Direct log via TCP to ACLog | enhancement, External Logger, Triaged |
-| [#718](https://github.com/n4af/TR4W/issues/718) | Receive UDP Contact messages from non-TR4W programs | enhancement, UDP Broadcast, Triaged |
+| [#836](https://github.com/TR4W/TR4W/issues/836) | PathFinder DDE: exchange not cleared on message receipt | Triaged |
+| [#835](https://github.com/TR4W/TR4W/issues/835) | Clicking bandmap spot should send UDP lookup message | Band Map, External Logger, Triaged |
+| [#768](https://github.com/TR4W/TR4W/issues/768) | Add SentExchange to Contact UDP broadcast | enhancement, Modern Delphi, UDP Broadcast, Triaged |
+| [#736](https://github.com/TR4W/TR4W/issues/736) | Add HRD support to external logger via TCP/IP | enhancement, External Logger, Triaged |
+| [#735](https://github.com/TR4W/TR4W/issues/735) | Direct log via TCP to ACLog | enhancement, External Logger, Triaged |
+| [#718](https://github.com/TR4W/TR4W/issues/718) | Receive UDP Contact messages from non-TR4W programs | enhancement, UDP Broadcast, Triaged |
 
 ### Multi-network / Server
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#770](https://github.com/n4af/TR4W/issues/770) | Add operator to Network window display | Multi-network, Triaged |
-| [#717](https://github.com/n4af/TR4W/issues/717) | Display QSOs by each operator | enhancement, Triaged |
-| [#716](https://github.com/n4af/TR4W/issues/716) | Random access violation using multi-network | bug, Multi-network, Triaged |
-| [#574](https://github.com/n4af/TR4W/issues/574) | Investigate peer network (no TR4WSERVER) | Multi-network, Triaged |
-| [#532](https://github.com/n4af/TR4W/issues/532) | Add discovery protocol for TR4W/TR4WSERVER | enhancement, Multi-network, Triaged |
+| [#770](https://github.com/TR4W/TR4W/issues/770) | Add operator to Network window display | Multi-network, Triaged |
+| [#717](https://github.com/TR4W/TR4W/issues/717) | Display QSOs by each operator | enhancement, Triaged |
+| [#716](https://github.com/TR4W/TR4W/issues/716) | Random access violation using multi-network | bug, Multi-network, Triaged |
+| [#574](https://github.com/TR4W/TR4W/issues/574) | Investigate peer network (no TR4WSERVER) | Multi-network, Triaged |
+| [#532](https://github.com/TR4W/TR4W/issues/532) | Add discovery protocol for TR4W/TR4WSERVER | enhancement, Multi-network, Triaged |
 
 ### WSJT-X / Digital
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#810](https://github.com/n4af/TR4W/issues/810) | Convert grid to state for WSJT-X when contest requires | enhancement, WSJT-X, Triaged |
-| [#769](https://github.com/n4af/TR4W/issues/769) | WSJT-X log: station ID letter not put in log | WSJT-X, Triaged |
-| [#465](https://github.com/n4af/TR4W/issues/465) | Implement TinyFSK Protocol for Mortty FSK interface | enhancement, RTTY, Triaged |
-| [#444](https://github.com/n4af/TR4W/issues/444) | Add extendedMode of FST4 | enhancement, WSJT-X, Triaged |
+| [#810](https://github.com/TR4W/TR4W/issues/810) | Convert grid to state for WSJT-X when contest requires | enhancement, WSJT-X, Triaged |
+| [#769](https://github.com/TR4W/TR4W/issues/769) | WSJT-X log: station ID letter not put in log | WSJT-X, Triaged |
+| [#465](https://github.com/TR4W/TR4W/issues/465) | Implement TinyFSK Protocol for Mortty FSK interface | enhancement, RTTY, Triaged |
+| [#444](https://github.com/TR4W/TR4W/issues/444) | Add extendedMode of FST4 | enhancement, WSJT-X, Triaged |
 
 ### UI / General Enhancements
 
 | Issue | Title | Labels |
 |-------|-------|--------|
-| [#783](https://github.com/n4af/TR4W/issues/783) | Real-time contest logging support for hamscore.com | enhancement, Triaged |
-| [#780](https://github.com/n4af/TR4W/issues/780) | Option to download latest TRMASTER file | enhancement, Triaged |
-| [#772](https://github.com/n4af/TR4W/issues/772) | Send real-time messages to ClubLog | enhancement, Online Scorebook, Triaged |
-| [#758](https://github.com/n4af/TR4W/issues/758) | Date-aware contest selection dropdown | enhancement, Triaged |
-| [#756](https://github.com/n4af/TR4W/issues/756) | Output a webpage with contest info | Triaged |
-| [#755](https://github.com/n4af/TR4W/issues/755) | Add support for automatic self-spotting | Triaged |
-| [#749](https://github.com/n4af/TR4W/issues/749) | Indicate if frequency is out of band for station call | Triaged |
-| [#748](https://github.com/n4af/TR4W/issues/748) | Add beam heading to bandmap status bar for spot | Triaged |
-| [#739](https://github.com/n4af/TR4W/issues/739) | Return all open windows to primary monitor | enhancement, Triaged |
-| [#732](https://github.com/n4af/TR4W/issues/732) | Send UDP command to PSTRotator for rotor control | Rotor Control, Triaged |
-| [#730](https://github.com/n4af/TR4W/issues/730) | ContestOnlineScore: only half of band-specific QSOs shown | Online Scorebook, Triaged |
-| [#719](https://github.com/n4af/TR4W/issues/719) | Investigate SQLite 3 instead of flat file log | Modern Delphi, Triaged |
-| [#668](https://github.com/n4af/TR4W/issues/668) | Option to enforce callsign validity on entry | Triaged |
-| [#645](https://github.com/n4af/TR4W/issues/645) | FM mode anomaly | Triaged |
-| [#584](https://github.com/n4af/TR4W/issues/584) | Set soundcard per radio for DVK (2-radio) | enhancement, Two Radio, DVK, Triaged |
-| [#485](https://github.com/n4af/TR4W/issues/485) | Summary report should use fixed font for table | Triaged |
-| [#479](https://github.com/n4af/TR4W/issues/479) | Add 60M band | enhancement, Triaged |
-| [#420](https://github.com/n4af/TR4W/issues/420) | Reconnect to DX cluster | Triaged |
-| [#418](https://github.com/n4af/TR4W/issues/418) | Documentation updates | Documentation, Triaged |
-| [#415](https://github.com/n4af/TR4W/issues/415) | Translation updates 2020-July | Translation, Triaged |
-| [#391](https://github.com/n4af/TR4W/issues/391) | Two more telnet clusters to trcluster.dat | DX Cluster, Triaged |
-| [#390](https://github.com/n4af/TR4W/issues/390) | Configurable path for Log File Directory | enhancement, Triaged |
-| [#384](https://github.com/n4af/TR4W/issues/384) | MP3 recorder not working in newer OS | Triaged |
+| [#783](https://github.com/TR4W/TR4W/issues/783) | Real-time contest logging support for hamscore.com | enhancement, Triaged |
+| [#780](https://github.com/TR4W/TR4W/issues/780) | Option to download latest TRMASTER file | enhancement, Triaged |
+| [#772](https://github.com/TR4W/TR4W/issues/772) | Send real-time messages to ClubLog | enhancement, Online Scorebook, Triaged |
+| [#758](https://github.com/TR4W/TR4W/issues/758) | Date-aware contest selection dropdown | enhancement, Triaged |
+| [#756](https://github.com/TR4W/TR4W/issues/756) | Output a webpage with contest info | Triaged |
+| [#755](https://github.com/TR4W/TR4W/issues/755) | Add support for automatic self-spotting | Triaged |
+| [#749](https://github.com/TR4W/TR4W/issues/749) | Indicate if frequency is out of band for station call | Triaged |
+| [#748](https://github.com/TR4W/TR4W/issues/748) | Add beam heading to bandmap status bar for spot | Triaged |
+| [#739](https://github.com/TR4W/TR4W/issues/739) | Return all open windows to primary monitor | enhancement, Triaged |
+| [#732](https://github.com/TR4W/TR4W/issues/732) | Send UDP command to PSTRotator for rotor control | Rotor Control, Triaged |
+| [#730](https://github.com/TR4W/TR4W/issues/730) | ContestOnlineScore: only half of band-specific QSOs shown | Online Scorebook, Triaged |
+| [#719](https://github.com/TR4W/TR4W/issues/719) | Investigate SQLite 3 instead of flat file log | Modern Delphi, Triaged |
+| [#668](https://github.com/TR4W/TR4W/issues/668) | Option to enforce callsign validity on entry | Triaged |
+| [#645](https://github.com/TR4W/TR4W/issues/645) | FM mode anomaly | Triaged |
+| [#584](https://github.com/TR4W/TR4W/issues/584) | Set soundcard per radio for DVK (2-radio) | enhancement, Two Radio, DVK, Triaged |
+| [#485](https://github.com/TR4W/TR4W/issues/485) | Summary report should use fixed font for table | Triaged |
+| [#479](https://github.com/TR4W/TR4W/issues/479) | Add 60M band | enhancement, Triaged |
+| [#420](https://github.com/TR4W/TR4W/issues/420) | Reconnect to DX cluster | Triaged |
+| [#418](https://github.com/TR4W/TR4W/issues/418) | Documentation updates | Documentation, Triaged |
+| [#415](https://github.com/TR4W/TR4W/issues/415) | Translation updates 2020-July | Translation, Triaged |
+| [#391](https://github.com/TR4W/TR4W/issues/391) | Two more telnet clusters to trcluster.dat | DX Cluster, Triaged |
+| [#390](https://github.com/TR4W/TR4W/issues/390) | Configurable path for Log File Directory | enhancement, Triaged |
+| [#384](https://github.com/TR4W/TR4W/issues/384) | MP3 recorder not working in newer OS | Triaged |
 
 ### Housekeeping — Should Be Closed
 
 | Issue | Title | Reason |
 |-------|-------|--------|
-| [#688](https://github.com/n4af/TR4W/issues/688) | Lock bandmap while updating | PR #869 merged 2026-04-13 directly addressed this — close after confirming in build |
-| [#778](https://github.com/n4af/TR4W/issues/778) | Add support for Yaesu FTX-1F | **Duplicate of #817** — close as duplicate |
-| [#396](https://github.com/n4af/TR4W/issues/396) | Applied merge by mistake | 2020 incident, revert was committed — close as resolved |
-| [#383](https://github.com/n4af/TR4W/issues/383) | Status line when radio connection lost | Reconnection infrastructure added; verify if visible to user and close |
+| [#688](https://github.com/TR4W/TR4W/issues/688) | Lock bandmap while updating | PR #869 merged 2026-04-13 directly addressed this — close after confirming in build |
+| [#778](https://github.com/TR4W/TR4W/issues/778) | Add support for Yaesu FTX-1F | **Duplicate of #817** — close as duplicate |
+| [#396](https://github.com/TR4W/TR4W/issues/396) | Applied merge by mistake | 2020 incident, revert was committed — close as resolved |
+| [#383](https://github.com/TR4W/TR4W/issues/383) | Status line when radio connection lost | Reconnection infrastructure added; verify if visible to user and close |
 
 ---
 

--- a/docs/ICOM_NETWORK_DELPHI_REFERENCE.md
+++ b/docs/ICOM_NETWORK_DELPHI_REFERENCE.md
@@ -825,5 +825,5 @@ end;
 ## References
 
 - wfview project (open source Icom network control): https://gitlab.com/eliggett/wfview
-- TR4W Icom CI-V wiki: https://github.com/n4af/TR4W/wiki/Icom-CI-V-Information
+- TR4W Icom CI-V wiki: https://github.com/TR4W/TR4W/wiki/Icom-CI-V-Information
 - Icom CI-V Reference Manuals (per radio model, from Icom website)

--- a/docs/ICOM_NETWORK_PROTOCOL_GUIDE.md
+++ b/docs/ICOM_NETWORK_PROTOCOL_GUIDE.md
@@ -979,5 +979,5 @@ wfview is the most mature open-source implementation. When something doesn't wor
 
 - wfview project (open source): https://gitlab.com/eliggett/wfview
 - Icom CI-V Reference Manuals (per radio model): Available from Icom's website
-- TR4W implementation (Delphi 7): https://github.com/n4af/TR4W
-- TR4QT implementation (Qt/C++): https://github.com/n4af/TR4QT
+- TR4W implementation (Delphi 7): https://github.com/TR4W/TR4W
+- TR4QT implementation (Qt/C++): https://github.com/ny4i/TR4QT

--- a/docs/ICOM_NETWORK_SPEC.md
+++ b/docs/ICOM_NETWORK_SPEC.md
@@ -706,5 +706,5 @@ ICOM NETWORK PASSWORD = pass
 
 - Protocol reference: `docs/ICOM_NETWORK_DELPHI_REFERENCE.md`
 - wfview project: https://gitlab.com/eliggett/wfview
-- TR4W Icom CI-V wiki: https://github.com/n4af/TR4W/wiki/Icom-CI-V-Information
+- TR4W Icom CI-V wiki: https://github.com/TR4W/TR4W/wiki/Icom-CI-V-Information
 - Existing codebase: `uRadioIcomBase.pas`, `uNetRadioBase.pas`, `uRadioFactory.pas`

--- a/docs/MANUAL_UPDATE_SUMMARY.md
+++ b/docs/MANUAL_UPDATE_SUMMARY.md
@@ -69,24 +69,24 @@ Two defects were found in `commands_help_eng.ini` that should be corrected:
 
 ## Wiki Pages Published
 
-All content was published to the [TR4W GitHub Wiki](https://github.com/n4af/TR4W/wiki) in a single commit on March 20, 2026. The original v4.01 PDF remains available at https://tr4w.net/TR4W_Reference_Manual_4.01.pdf for historical reference.
+All content was published to the [TR4W GitHub Wiki](https://github.com/TR4W/TR4W/wiki) in a single commit on March 20, 2026. The original v4.01 PDF remains available at https://tr4w.net/TR4W_Reference_Manual_4.01.pdf for historical reference.
 
 | Wiki Page | Status | Notes |
 |-----------|--------|-------|
-| [Home](https://github.com/n4af/TR4W/wiki) | Updated | Added Reference Manual TOC |
-| [System Requirements](https://github.com/n4af/TR4W/wiki/System-Requirements) | New | Updated OS list to Win 7/10/11 |
-| [Program Installation](https://github.com/n4af/TR4W/wiki/Program-Installation) | New | Updated URLs and version refs |
-| [Supported Transceivers](https://github.com/n4af/TR4W/wiki/Supported-Transceivers) | New | Merged with existing wiki table; added Icom network, K4 Direct, HamLib |
-| [Supported Contests](https://github.com/n4af/TR4W/wiki/Supported-Contests) | New | All original + new contests since 2014 |
-| [Program Windows and Hot Keys](https://github.com/n4af/TR4W/wiki/Program-Windows-and-Hot-Keys) | New | All keyboard shortcut tables |
-| [Interface Circuits](https://github.com/n4af/TR4W/wiki/Interface-Circuits) | New | Serial/parallel port pinouts; circuit diagrams reference original PDF |
-| [Configuration Statements Overview](https://github.com/n4af/TR4W/wiki/Configuration-Statements-Overview) | New | Statements added/dropped vs TR Log |
-| [Configuration Statements](https://github.com/n4af/TR4W/wiki/Configuration-Statements) | New | All 357 parameters; 54 new ones marked `[NEW]` |
-| [Using Saved Configuration Statements](https://github.com/n4af/TR4W/wiki/Using-Saved-Configuration-Statements) | New | Step-by-step config file management |
-| [HamLib Rig Control](https://github.com/n4af/TR4W/wiki/HamLib-Rig-Control) | New | Full setup guide and all HamLib parameters |
-| [WSJT-X Integration](https://github.com/n4af/TR4W/wiki/WSJT-X-Integration) | New | FT8/FT4 setup, radio TCP server, JT-Alert compatibility |
-| [UDP Broadcasts](https://github.com/n4af/TR4W/wiki/UDP-Broadcasts) | New | All 15 UDP parameters, compatible apps, multi-computer example |
-| [External Logger Integration](https://github.com/n4af/TR4W/wiki/External-Logger-Integration) | New | DXKeeper TCP setup; ACLog/HRD noted as planned |
+| [Home](https://github.com/TR4W/TR4W/wiki) | Updated | Added Reference Manual TOC |
+| [System Requirements](https://github.com/TR4W/TR4W/wiki/System-Requirements) | New | Updated OS list to Win 7/10/11 |
+| [Program Installation](https://github.com/TR4W/TR4W/wiki/Program-Installation) | New | Updated URLs and version refs |
+| [Supported Transceivers](https://github.com/TR4W/TR4W/wiki/Supported-Transceivers) | New | Merged with existing wiki table; added Icom network, K4 Direct, HamLib |
+| [Supported Contests](https://github.com/TR4W/TR4W/wiki/Supported-Contests) | New | All original + new contests since 2014 |
+| [Program Windows and Hot Keys](https://github.com/TR4W/TR4W/wiki/Program-Windows-and-Hot-Keys) | New | All keyboard shortcut tables |
+| [Interface Circuits](https://github.com/TR4W/TR4W/wiki/Interface-Circuits) | New | Serial/parallel port pinouts; circuit diagrams reference original PDF |
+| [Configuration Statements Overview](https://github.com/TR4W/TR4W/wiki/Configuration-Statements-Overview) | New | Statements added/dropped vs TR Log |
+| [Configuration Statements](https://github.com/TR4W/TR4W/wiki/Configuration-Statements) | New | All 357 parameters; 54 new ones marked `[NEW]` |
+| [Using Saved Configuration Statements](https://github.com/TR4W/TR4W/wiki/Using-Saved-Configuration-Statements) | New | Step-by-step config file management |
+| [HamLib Rig Control](https://github.com/TR4W/TR4W/wiki/HamLib-Rig-Control) | New | Full setup guide and all HamLib parameters |
+| [WSJT-X Integration](https://github.com/TR4W/TR4W/wiki/WSJT-X-Integration) | New | FT8/FT4 setup, radio TCP server, JT-Alert compatibility |
+| [UDP Broadcasts](https://github.com/TR4W/TR4W/wiki/UDP-Broadcasts) | New | All 15 UDP parameters, compatible apps, multi-computer example |
+| [External Logger Integration](https://github.com/TR4W/TR4W/wiki/External-Logger-Integration) | New | DXKeeper TCP setup; ACLog/HRD noted as planned |
 | `_Sidebar.md` | New | Persistent navigation sidebar on every wiki page |
 
 **Total:** 15 files, ~5,200 lines of Markdown added.
@@ -111,5 +111,5 @@ The following files were used as primary sources during this analysis and are pr
 - [ ] Fix the `RADIO ONE SCORE` description in `commands_help_eng.ini`
 - [ ] Add DVK (voice keyer) usage guide to the wiki — the DVP → DVK rename is documented but there is no setup walkthrough
 - [ ] Document the Contest Online ScoreBoard (COSB) configuration
-- [ ] Keep the [Supported Contests](https://github.com/n4af/TR4W/wiki/Supported-Contests) wiki page updated as new contests are added
+- [ ] Keep the [Supported Contests](https://github.com/TR4W/TR4W/wiki/Supported-Contests) wiki page updated as new contests are added
 - [ ] Consider adding `commands_help_eng.ini` `DESCRIPTION` fields for any parameters that currently have blank descriptions (e.g., `DVK PATH`, `DVK RECORDER`)

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -47,7 +47,7 @@ Sections 6-8 cover tagging and the GitHub-side release flow.
 
 ## 0. Audience and assumptions
 
-- You have **write access** to `n4af/TR4W` on GitHub.
+- You have **write access** to `TR4W/TR4W` on GitHub.
 - You're on Windows with the toolchain installed (Delphi 7, Indy, NSIS, UPX -- see
   section 1).
 - You're working from a clone of the repo (default `C:\TR4W`; Howie uses

--- a/docs/session_context.md
+++ b/docs/session_context.md
@@ -1,13 +1,13 @@
 # TR4W Dialog System — Session Context & Analysis
 **Date:** March 16–23, 2026  
 **Contributor:** toms@bettersoftwaresolutions.com (NY4I / Tom)  
-**Repo:** n4af/TR4W  
+**Repo:** TR4W/TR4W  
 
 ---
 
 ## Project Background
 
-TR4W is a ham radio contest logging software hosted at the GitHub repo **n4af/TR4W**. The project is written in **Delphi 7** using a Petzold-style Win32 message loop (no standard VCL main form). NY4I (Tom, 362 commits) and N4AF (Howie, 318 commits) are the primary contributors.
+TR4W is a ham radio contest logging software hosted at the GitHub repo **TR4W/TR4W**. The project is written in **Delphi 7** using a Petzold-style Win32 message loop (no standard VCL main form). NY4I (Tom, 362 commits) and N4AF (Howie, 318 commits) are the primary contributors.
 
 A migration from Delphi 7 to current Delphi (Alexandria) is being planned. A related project, **TR4QT**, is a Qt/C++ port at github.com/ny4i/TR4QT.
 
@@ -84,7 +84,7 @@ The question was raised: *Is it worthwhile to generate a `.RES` definition for t
 
 ## Source Files Analyzed
 
-The following Pascal units were downloaded and analyzed from the n4af/TR4W repository:
+The following Pascal units were downloaded and analyzed from the TR4W/TR4W repository:
 
 | Unit | Purpose |
 |------|---------|
@@ -143,7 +143,7 @@ The following Pascal units were downloaded and analyzed from the n4af/TR4W repos
 | `tr4w_mng.rc` | Decompiled Mongolian RC (1095 lines) | workspace |
 | `tr4w_res_comparison.md` | Full comparison matrix of all 9 language RES files | workspace |
 | `tr4w_dialog_catalog.md` | Complete dialog inventory (code-built vs resource-based) | workspace |
-| `docs/dialog_analysis.md` | Dialog inventory committed to repo | [GitHub — master branch](https://github.com/n4af/TR4W/blob/master/docs/dialog_analysis.md) |
+| `docs/dialog_analysis.md` | Dialog inventory committed to repo | [GitHub — master branch](https://github.com/TR4W/TR4W/blob/master/docs/dialog_analysis.md) |
 
 ---
 
@@ -173,7 +173,7 @@ dialog_y = mweiY * 8
 
 ## Related Documents in `/docs`
 
-- [`dialog_analysis.md`](https://github.com/n4af/TR4W/blob/master/docs/dialog_analysis.md) — Complete dialog inventory with tw_ enum table, modal dialog table, mwe explanation
+- [`dialog_analysis.md`](https://github.com/TR4W/TR4W/blob/master/docs/dialog_analysis.md) — Complete dialog inventory with tw_ enum table, modal dialog table, mwe explanation
 - `NETWORK_RADIO_FACTORY_ANALYSIS.md` — Radio factory network analysis
 - `RADIO_FACTORY_README.md` — Radio factory documentation
 - `RADIO_FACTORY_UPDATE.txt` — Radio factory update notes


### PR DESCRIPTION
## Summary
Repo was transferred from the personal account \`n4af/TR4W\` to the org \`TR4W/TR4W\`. This sweeps the stale repo-path URLs in docs and CI comments to match.

GitHub's transfer redirect means none of these were broken, so this is future-proofing (guards against the old path being squatted later). The one functional change — \`git remote set-url origin\` — was already done locally.

## Changes
- \`n4af/TR4W\` → \`TR4W/TR4W\` across docs, changelogs, and the two CI workflow header comments
- Fixed a **pre-existing** typo: \`n4af/TR4QT\` → \`ny4i/TR4QT\` (that repo never lived under n4af)

## Deliberately untouched
- \`@n4af\` contributor profile links — Howie's personal account, unaffected by the transfer
- No source code touched; only docs + CI comments

## Notes
- 11 files, 153 line swaps (mostly issue-URL references in \`TR4W_ISSUE_ANALYSIS.md\`)
- Reminder: verify org-side settings separately — branch protection, Actions secrets (account-level secrets do **not** follow a transfer), webhooks/deploy keys