### PR TITLE
Icom network radio discovery on the Discover button (#853)

### DIFF
--- a/tr4w/src/uCAT.pas
+++ b/tr4w/src/uCAT.pas
@@ -35,7 +35,9 @@ uses
   LogK1EA,
   Tree,
   Classes,
-  uK4Discovery;
+  uK4Discovery,
+  uIcomNetworkDiscovery,
+  uIcomNetworkTypes;
 
 procedure CloseCATAndKeyerForThisRadio;
 function CATDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
@@ -109,14 +111,55 @@ begin
       end;
 end;
 
+// Issue #853 -- run the right discovery engine for the radio type and copy the
+// discovered IP addresses into Found.  Keeps the per-engine record types
+// (PK4DiscoveredRadio vs PDiscoveredRadio) out of the dialog flow.  The caller
+// has already confirmed rt is discoverable (K4 or an Icom network model).
+procedure DiscoverNetworkRadios(rt: InterfacedRadioType; Found: TStringList);
+var
+  list : TList;
+  i    : Integer;
+begin
+  if rt = K4 then
+     begin
+     list := TK4Discovery.DiscoverRadios(3000);
+     try
+        for i := 0 to list.Count - 1 do
+           begin
+           Found.Add(PK4DiscoveredRadio(list[i])^.IPAddress);
+           end;
+     finally
+        for i := 0 to list.Count - 1 do
+           begin
+           Dispose(PK4DiscoveredRadio(list[i]));
+           end;
+        list.Free;
+     end;
+     end
+  else if RadioParametersArray[rt].rt = rtICOM then
+     begin
+     list := TIcomNetworkDiscovery.DiscoverRadios(3000);
+     try
+        for i := 0 to list.Count - 1 do
+           begin
+           Found.Add(PDiscoveredRadio(list[i])^.IPAddress);
+           end;
+     finally
+        for i := 0 to list.Count - 1 do
+           begin
+           Dispose(PDiscoveredRadio(list[i]));
+           end;
+        list.Free;
+     end;
+     end;
+end;
+
 // Issue #853 -- run network discovery for the radio type currently selected in
 // the RADIO ONE/TWO dialog and, on a single hit, write its IP into the IP edit
-// (control 130).  Kept in its own procedure (Delphi 7 codegen hygiene -- avoids
-// adding inline logic to the long dialog proc).  K4 only for now; Flex/Icom
-// discovery wire in at the type check below.
+// (control 130).  Dispatches to K4 or Icom discovery via DiscoverNetworkRadios.
 procedure RunNetworkDiscoveryForRadio(hwnddlg: HWND);
 var
-  radios       : TList;
+  found        : TStringList;
   i            : Integer;
   msg          : string;
   savedCursor  : HCURSOR;
@@ -126,24 +169,26 @@ begin
   rt := InterfacedRadioType(tCB_GETCURSEL(hwnddlg, 121));
   radioName := InterfacedRadioTypeSA[rt];
 
-  if rt <> K4 then
+  // Discoverable types: the K4, and any Icom network model (rtICOM).
+  if (rt <> K4) and (RadioParametersArray[rt].rt <> rtICOM) then
      begin
      Format(wsprintfBuffer, TC_DISCOVER_NOT_AVAILABLE, PChar(radioName));
      showwarning(wsprintfBuffer);
      Exit;
      end;
 
-  savedCursor := SetCursor(LoadCursor(0, IDC_WAIT));
-  EnableWindowFalse(hwnddlg, 140);
+  found := TStringList.Create;
   try
-     radios := TK4Discovery.DiscoverRadios(3000);
-  finally
-     EnableWindowTrue(hwnddlg, 140);
-     SetCursor(savedCursor);
-  end;
+     savedCursor := SetCursor(LoadCursor(0, IDC_WAIT));
+     EnableWindowFalse(hwnddlg, 140);
+     try
+        DiscoverNetworkRadios(rt, found);
+     finally
+        EnableWindowTrue(hwnddlg, 140);
+        SetCursor(savedCursor);
+     end;
 
-  try
-     if radios.Count = 0 then
+     if found.Count = 0 then
         begin
         Format(wsprintfBuffer, TC_DISCOVER_NONE_FOUND, PChar(radioName));
         showwarning(wsprintfBuffer);
@@ -151,26 +196,23 @@ begin
      else
         begin
         // Fill the IP edit (130) from the first (or only) radio found.
-        Windows.SetDlgItemText(hwnddlg, 130,
-           PChar(PK4DiscoveredRadio(radios[0])^.IPAddress));
+        Windows.SetDlgItemText(hwnddlg, 130, PChar(found[0]));
         // Issue #968 -- discovery gives us the IP but not the port; fill the
-        // model default (K4 -> 9200) so the radio is immediately connectable.
+        // model default (K4=9200, Icom=50001, ...) so the radio is connectable.
         ApplyDefaultNetworkPort(hwnddlg);
-        if radios.Count > 1 then
+        if found.Count > 1 then
            begin
            Format(wsprintfBuffer, TC_DISCOVER_MULTI_FOUND, PChar(radioName));
            msg := string(wsprintfBuffer) + #13#10;
-           for i := 0 to radios.Count - 1 do
-              msg := msg + #13#10 +
-                 TK4Discovery.Hostname(PK4DiscoveredRadio(radios[i])^) + '  (' +
-                 PK4DiscoveredRadio(radios[i])^.IPAddress + ')';
+           for i := 0 to found.Count - 1 do
+              begin
+              msg := msg + #13#10 + found[i];
+              end;
            showwarning(PChar(msg));
            end;
         end;
   finally
-     for i := 0 to radios.Count - 1 do
-        Dispose(PK4DiscoveredRadio(radios[i]));
-     radios.Free;
+     found.Free;
   end;
 end;
 

--- a/tr4w/src/uIcomNetworkDiscovery.pas
+++ b/tr4w/src/uIcomNetworkDiscovery.pas
@@ -9,15 +9,14 @@ unit uIcomNetworkDiscovery;
   Usage:
     var Radios: TList;
     Radios := TIcomNetworkDiscovery.DiscoverRadios(3000);
-    // Process TDiscoveredRadio records from Radios
-    // Caller must free the list and its items
+    // each item is a PDiscoveredRadio; the caller frees the items + the list.
 }
 
 interface
 
 uses
   Windows, SysUtils, Classes,
-  IdUDPClient, IdGlobal, IdSocketHandle,
+  IdUDPClient, IdGlobal, IdSocketHandle, IdStack,
   IdUDPServer,
   uIcomNetworkTypes, Log4D;
 
@@ -34,88 +33,124 @@ var
 
 class function TIcomNetworkDiscovery.DiscoverRadios(TimeoutMs: Integer): TList;
 var
-  UDPClient: TIdUDPClient;
+  clients: TList;
+  client: TIdUDPClient;
   Pkt: TControlPacket;
-  IdBytes: TIdBytes;
+  SendBytes: TIdBytes;
   RecvBuf: TIdBytes;
   RecvLen: Integer;
   PeerIP: string;
   PeerPort: Word;
   StartTime: LongWord;
-  Radio: ^TDiscoveredRadio;
   ResponsePkt: TControlPacket;
+  Radio: PDiscoveredRadio;
+  localIPs: TStrings;
+  ip: string;
+  i, c: Integer;
+  isDuplicate: Boolean;
 begin
   Result := TList.Create;
 
-  UDPClient := TIdUDPClient.Create(nil);
+  // Build the "Are You There" control packet once.
+  FillChar(Pkt, SizeOf(Pkt), 0);
+  Pkt.Len := ICOM_CONTROL_PKT_SIZE;
+  Pkt.PktType := ICOM_PKT_ARE_YOU_THERE;
+  Pkt.Seq := 1;
+  Pkt.SentID := $12345678;   // temporary ID for discovery
+  Pkt.RcvdID := 0;
+  SetLength(SendBytes, SizeOf(Pkt));
+  Move(Pkt, SendBytes[0], SizeOf(Pkt));
+
+  clients := TList.Create;
+  TIdStack.IncUsage;   // ensure the Indy stack so GStack.LocalAddresses is valid
   try
-    UDPClient.BroadcastEnabled := True;
-    UDPClient.Port := 0;  // Bind to any port
-    UDPClient.ReceiveTimeout := 500;  // 500ms receive timeout for polling loop
+    localIPs := GStack.LocalAddresses;   // GStack-owned -- do NOT free
 
-    // Build "Are You There" packet
-    FillChar(Pkt, SizeOf(Pkt), 0);
-    Pkt.Len := ICOM_CONTROL_PKT_SIZE;
-    Pkt.PktType := ICOM_PKT_ARE_YOU_THERE;
-    Pkt.Seq := 1;
-    Pkt.SentID := $12345678;  // Temporary ID for discovery
-    Pkt.RcvdID := 0;
-
-    // Convert to TIdBytes
-    SetLength(IdBytes, SizeOf(Pkt));
-    Move(Pkt, IdBytes[0], SizeOf(Pkt));
-
-    // Send broadcast on port 50001
-    try
-      UDPClient.SendBuffer('255.255.255.255', ICOM_DEFAULT_CONTROL_PORT, IdBytes);
-      logger.Info('[IcomDiscovery] Sent broadcast discovery on port %d',
-                  [ICOM_DEFAULT_CONTROL_PORT]);
-    except
-      on E: Exception do
-      begin
-        logger.Error('[IcomDiscovery] Failed to send broadcast: %s', [E.Message]);
-        Exit;
-      end;
-    end;
-
-    // Collect responses for TimeoutMs
-    StartTime := GetTickCount;
-    while (GetTickCount - StartTime) < LongWord(TimeoutMs) do
+    // Broadcast the AYT out EACH local IPv4 interface.  A single
+    // 255.255.255.255 send only leaves the default-route NIC, so an Icom on
+    // another subnet is never reached; binding a socket per interface IP makes
+    // the broadcast go out that NIC.  Mirrors the K4 per-interface discovery.
+    for i := 0 to localIPs.Count - 1 do
     begin
+      ip := localIPs[i];
+      if (ip = '') or (ip = '127.0.0.1') or (Pos(':', ip) > 0) then
+         Continue;   // skip blanks, loopback, and IPv6
+
+      client := TIdUDPClient.Create(nil);
       try
-        SetLength(RecvBuf, 1024);
-        RecvLen := UDPClient.ReceiveBuffer(RecvBuf, PeerIP, PeerPort);
-
-        if RecvLen >= SizeOf(TControlPacket) then
-        begin
-          Move(RecvBuf[0], ResponsePkt, SizeOf(TControlPacket));
-
-          if ResponsePkt.PktType = ICOM_PKT_I_AM_HERE then
-          begin
-            New(Radio);
-            Radio^.IPAddress := PeerIP;
-            Radio^.RadioName := '';  // Not available from I Am Here
-            Radio^.CivAddress := 0; // Not available from I Am Here
-            Radio^.RemoteId := ResponsePkt.SentID;
-            Result.Add(Radio);
-
-            logger.Info('[IcomDiscovery] Found radio at %s, remoteId=$%.8x',
-                        [PeerIP, ResponsePkt.SentID]);
-          end;
-        end;
+        client.BoundIP := ip;             // send out this specific interface
+        client.BroadcastEnabled := True;
+        client.ReceiveTimeout := 150;
+        client.SendBuffer('255.255.255.255', ICOM_DEFAULT_CONTROL_PORT, SendBytes);
+        logger.Info('[IcomDiscovery] Sent AYT from %s to 255.255.255.255:%d',
+                    [ip, ICOM_DEFAULT_CONTROL_PORT]);
+        clients.Add(client);
       except
         on E: Exception do
         begin
-          // Timeout or other receive error - continue listening
+          logger.Warn('[IcomDiscovery] Send from %s failed: %s', [ip, E.Message]);
+          client.Free;
         end;
       end;
     end;
 
-    logger.Info('[IcomDiscovery] Discovery complete, found %d radio(s)',
-                [Result.Count]);
+    // Collect "I Am Here" replies across all interface sockets for TimeoutMs.
+    StartTime := GetTickCount;
+    while (clients.Count > 0) and ((GetTickCount - StartTime) < LongWord(TimeoutMs)) do
+    begin
+      for c := 0 to clients.Count - 1 do
+      begin
+        client := TIdUDPClient(clients[c]);
+        try
+          SetLength(RecvBuf, 1024);
+          RecvLen := client.ReceiveBuffer(RecvBuf, PeerIP, PeerPort);
 
+          if RecvLen >= SizeOf(TControlPacket) then
+          begin
+            Move(RecvBuf[0], ResponsePkt, SizeOf(TControlPacket));
+            if ResponsePkt.PktType = ICOM_PKT_I_AM_HERE then
+            begin
+              isDuplicate := False;
+              for i := 0 to Result.Count - 1 do
+                 begin
+                 if PDiscoveredRadio(Result[i])^.IPAddress = PeerIP then
+                    begin
+                    isDuplicate := True;
+                    Break;
+                    end;
+                 end;
+
+              if not isDuplicate then
+              begin
+                New(Radio);
+                Radio^.IPAddress := PeerIP;
+                Radio^.RadioName := '';   // not carried in "I Am Here"
+                Radio^.CivAddress := 0;
+                Radio^.RemoteId := ResponsePkt.SentID;
+                Result.Add(Radio);
+                logger.Info('[IcomDiscovery] Found radio at %s, remoteId=$%.8x',
+                            [PeerIP, ResponsePkt.SentID]);
+              end;
+            end;
+          end;
+        except
+          on E: Exception do
+          begin
+            // ReceiveTimeout on this socket -- move to the next interface.
+          end;
+        end;
+      end;
+    end;
+
+    logger.Info('[IcomDiscovery] Discovery complete: %d interface(s) probed, %d radio(s) found',
+                [clients.Count, Result.Count]);
   finally
-    FreeAndNil(UDPClient);
+    for c := 0 to clients.Count - 1 do
+       begin
+       TIdUDPClient(clients[c]).Free;
+       end;
+    clients.Free;
+    TIdStack.DecUsage;
   end;
 end;
 

--- a/tr4w/src/uIcomNetworkTypes.pas
+++ b/tr4w/src/uIcomNetworkTypes.pas
@@ -339,6 +339,7 @@ type
     CivAddress: Byte;
     RemoteId:   LongWord;
   end;
+  PDiscoveredRadio = ^TDiscoveredRadio;
 
   // TX sequence buffer entry — stores sent packets for radio's retransmit requests
   TSeqBufEntry = record


### PR DESCRIPTION
## Summary

Adds **Icom** network radio discovery to the inline Discover button (#853), building on the K4 discovery infrastructure already merged (#969). Selecting an Icom network model + TCP/IP and clicking Discover finds the radio on the LAN and fills its IP + default port (50001).

## Changes

- **`uIcomNetworkDiscovery.pas`** — rewrote `DiscoverRadios` to broadcast the Icom "Are You There" packet out **every local interface** (per-NIC bind via `GStack.LocalAddresses`, `IncUsage`/`DecUsage`, IP de-dup), mirroring the K4 engine. It was a single `255.255.255.255` send that only leaves the default-route NIC, so an Icom on another subnet was missed — the same multi-subnet bug we fixed for K4.
- **`uIcomNetworkTypes.pas`** — added `PDiscoveredRadio` (`^TDiscoveredRadio`), parallel to `PK4DiscoveredRadio`.
- **`uCAT.pas`** — new `DiscoverNetworkRadios` dispatch helper that runs the right engine (K4 or Icom) and returns the discovered IPs, keeping the per-engine record types out of the dialog flow. The Discover guard lifts from "K4 only" to **K4 or any `rtICOM`** model. The Icom default port (50001) and the radio-type-parameterized messages were already in place from the K4 work.

## Testing

- IC-7760 on hardware — discovery finds the radio and fills IP + port correctly.
- More Icom models to be spot-checked later; no reason to hold.
- ENG builds clean (first real compile of `uIcomNetworkDiscovery`).

Refs TR4W/TR4W-D12#30.
