### PR TITLE
Issue #965: TWO RADIO MODE becomes the sole radio-mode setting

### DIFF
--- a/tr4w/src/Version.pas
+++ b/tr4w/src/Version.pas
@@ -18,7 +18,7 @@ http://www.gnu.org/licenses/gpl-3.0.txt
 unit version;
 interface
 const
-  TR4W_CURRENTVERSION_NUMBER            = '4.148.2';
+  TR4W_CURRENTVERSION_NUMBER            = '4.148.3';
 
   TR4W_CURRENTVERSION                   = 'TR4W v.' + TR4W_CURRENTVERSION_NUMBER; //  {$IF MMTTYMODE} + '_mmtty'{$IFEND};//{$IF LANG <> 'ENG'} + ' [' + LANG + ']'{$IFEND}{$IF MMTTYMODE} + '_mmtty'{$IFEND};
 

--- a/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
+++ b/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
@@ -339,13 +339,13 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Grabando DVP. Pulse ESCAPE o RETURN para parar.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R desactiva le modo de radio unica = True';
+  TC_ALTRCOMMANDDISABLED                = 'El comando Alt-R requiere TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Sin mensaje CQ programado en la MEMORIA CQ AltF1.';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = '%s es un duplicado.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D desactivado por SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'El comando Alt-D requiere TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Ha recuperado la ultima entrada borrada del log!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Ha borrado la ultima entrada del log!!  Use Alt-Y para recuperarla.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = '¿Quiere salir del programa?';

--- a/tr4w/src/lang/TR4W_CONSTS_SER.pas
+++ b/tr4w/src/lang/TR4W_CONSTS_SER.pas
@@ -353,14 +353,14 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Snimanje DVP. Pritisni ESCAPE ili ENTER za prekid.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R komanda iskljucena u liniji SINGLE RADIO MODE = TRUE';
+  TC_ALTRCOMMANDDISABLED                = 'Alt-R komanda zahteva TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Nije isprogramirana CQ poruka u CQ MEMORY AltF1.';
   TC_THIS_FILE_DOES_NOT_EXIST           = 'Ova datoteka ne postiji. Napraviti praznu datoteku za editovanje?';
 
   {LOGSUBS2}
 
 //  TC_WASADUPE                           = '%s je bila dupla.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D komanda iskljucena saglasno liniji SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Alt-D komanda zahteva TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Vratio si poslednju obrisanu vezu iz dnevnika!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Obrisao si poslednju vezu iz dnevnika! Pritisni Alt-Y za njeno vracanje.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Da li zelis da napustis program?';

--- a/tr4w/src/lang/tr4w_consts_chn.pas
+++ b/tr4w/src/lang/tr4w_consts_chn.pas
@@ -335,14 +335,14 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Recording DVP. Press ESCAPE or RETURN to stop.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R Command disabled by single Radio Mode = True';
+  TC_ALTRCOMMANDDISABLED                = 'Alt-R command requires TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'No CQ message programmed into CQ MEMORY AltF1.';
   TC_THIS_FILE_DOES_NOT_EXIST           = 'This file does not exist. Create an empty file for editing?';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = '%s was a dupe.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D command disabled by SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Alt-D command requires TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'You have restored the last deleted log entry!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'You have deleted the last log entry!!  Use Alt-Y to restore it.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Do you really want to exit the program?';

--- a/tr4w/src/lang/tr4w_consts_cze.pas
+++ b/tr4w/src/lang/tr4w_consts_cze.pas
@@ -351,13 +351,13 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Nahrává se DVP. Stiskni ESC nebo RETURN pro ukonèení.';
-  TC_ALTRCOMMANDDISABLED                = 'Pøíkaz Alt-R je blokován volbou SINGLE RADIO MODE = TRUE';
+  TC_ALTRCOMMANDDISABLED                = 'Pøíkaz Alt-R vyžaduje TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'V pamìti CQ [AltF1] není naprogramována žádná MSG.';
 
   {LOGSUBS2}
 
 //  TC_WASADUPE                           = '%s bylo duplicitní.';
-  TC_ALTDCOMMANDDISABLED                = 'Pøíkaz Alt-D je blokován volbou SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Pøíkaz Alt-D vyžaduje TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Poslední smazaný záznam v deníku byl obnoven!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Smazal jsi poslední záznam v deníku!  Stiskni ALT-Y k jeho obnovení.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Chceš skuteènì ukonèit program?';

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -345,14 +345,14 @@
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Recording DVP. Press ESCAPE or RETURN to stop.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R Command disabled by single Radio Mode = True';
+  TC_ALTRCOMMANDDISABLED                = 'Alt-R command requires TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'No CQ message programmed into CQ MEMORY AltF1.';
   TC_THIS_FILE_DOES_NOT_EXIST           = 'This file does not exist. Create an empty file for editing?';
 
   {LOGSUBS2}
 
 //  TC_WASADUPE                           = '%s was a dupe.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D command disabled by SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Alt-D command requires TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'You have restored the last deleted log entry!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'You have deleted the last log entry!!  Use Alt-Y to restore it.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Do you really want to exit the program?';

--- a/tr4w/src/lang/tr4w_consts_ger.pas
+++ b/tr4w/src/lang/tr4w_consts_ger.pas
@@ -343,14 +343,14 @@
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Nehme DVP auf . ESCAPE oder RETURN zum Stoppen druecken.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R Kommando durch Radio Mode = True deaktiviert';
+  TC_ALTRCOMMANDDISABLED                = 'Alt-R Kommando erfordert TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Es ist keine CQ Message in Memory AltF1 eingetragen.';
   TC_THIS_FILE_DOES_NOT_EXIST           = 'Diese Datei existiert nicht. Eine leere Datei zum Bearbeiten anlegen?';
 
   {LOGSUBS2}
 
 //  TC_WASADUPE                           = '%s was a dupe.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D ist deaktiviert durch SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Alt-D Kommando erfordert TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Du hast den zuletzt geloeschten Eintrag wiederhergestellt!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Du hast den letzten Logeintrag geloescht!! Mit Alt-Y wiederherstellen.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Willst du das Programm wirklich beenden?';

--- a/tr4w/src/lang/tr4w_consts_mng.pas
+++ b/tr4w/src/lang/tr4w_consts_mng.pas
@@ -297,11 +297,11 @@ const
 
   {LOGSUBS1}
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'DVP бичиж байна.ESCAPE буюу ENTER дарвал зогсоно';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R команд Single Radio Mode горимыг зогсооно = True';
+  TC_ALTRCOMMANDDISABLED                = 'Alt-R команд TWO RADIO MODE = TRUE шаардлагатай';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'CQ MEMORY AltF1 -д CQ кодыг програмчлаагvй байна';
   {LOGSUBS2}
   TC_WASADUPE                           = '%s давтагдсан холбоо байна';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D команд SINGLE RADIO MODE горимыг хvчингvй болгоно = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Alt-D команд TWO RADIO MODE = TRUE шаардлагатай';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Хамгийн сvvлд устгасан холбоогоо сэргээлээ!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Та сvvлчийн холбоогоо устгалаа!!  Alt-Y ахин дарвал лог руу буцаж орно';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Та програмаас гармаар байна уу?';

--- a/tr4w/src/lang/tr4w_consts_pol.pas
+++ b/tr4w/src/lang/tr4w_consts_pol.pas
@@ -331,13 +331,13 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Zapisywanie wiadomoœci g³osowych. Naciœnij ESCAPE lub RETURN aby zatrzymaæ.';
-  TC_ALTRCOMMANDDISABLED                = 'Polecenie Alt-R deaktywowane przez ustawienie Single Radio Mode = True';
+  TC_ALTRCOMMANDDISABLED                = 'Polecenie Alt-R wymaga TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'CQ - brak zaprogramowanej informacji w pamiêci pod funkcyjnym klawiszem AltF1.';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = '%s by³ powtórzony.';
-  TC_ALTDCOMMANDDISABLED                = 'Polecenie Alt-D deaktywowane przez ustawienie SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Polecenie Alt-D wymaga TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Przywróci³eœ ostatni usuniêty wpis do logu!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Usun¹³eœ ostatni wpis do logu!!  U¿yj Alt-Y aby je przwróciæ.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Czy naprawdê chcesz wyjœæ z programu ?';

--- a/tr4w/src/lang/tr4w_consts_rom.pas
+++ b/tr4w/src/lang/tr4w_consts_rom.pas
@@ -351,14 +351,14 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Inregistrare DVP. Apasa ESCAPE sau RETURN la oprire.';
-  TC_ALTRCOMMANDDISABLED                = 'Comanda Alt-R dezactivata prin -SINGLE RADIO MODE = TRUE';
+  TC_ALTRCOMMANDDISABLED                = 'Comanda Alt-R necesitã TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Nu exista mesaj programat in memoria CQ activata cu AltF1.';
   TC_THIS_FILE_DOES_NOT_EXIST           = 'Acest fisier nu exista. Facem un fisier nou ptr editare?';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = '%s a fost o dubla.';
-  TC_ALTDCOMMANDDISABLED                = 'Comanda Alt-D este dezactivata prin -SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Comanda Alt-D necesitã TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Ai refacut ultimul QSO inscris in log !!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Ai sters ultimul QSO inscris in log !! Cu Alt-Y il poti readuce !'; 
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Doresti SIGUR sa parasesti programul ?';

--- a/tr4w/src/lang/tr4w_consts_rus.pas
+++ b/tr4w/src/lang/tr4w_consts_rus.pas
@@ -363,13 +363,13 @@ const
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Запись DVP. Нажмите ESCAPE или RETURN для остановки.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R команда отключена в строке Single Radio Mode = True';
+  TC_ALTRCOMMANDDISABLED                = 'Команда Alt-R требует TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Нет запрограммированного CQ сообщения в CQ MEMORY AltF1.';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = 'Связь с %s уже была.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D команда отключена согласно строке SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Команда Alt-D требует TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Вы восстановили последнюю удаленную связь!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Вы удалили последнюю связь!! Используйте Alt-Y для ее восстановления.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Вы действительно хотите выйти из программы?';

--- a/tr4w/src/lang/tr4w_consts_ukr.pas
+++ b/tr4w/src/lang/tr4w_consts_ukr.pas
@@ -365,13 +365,13 @@ TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Fr
   {LOGSUBS1}
 
   TC_RECORDDVPPRESSESCAPEORRETURNTOSTOP = 'Запис DVP. Натисніть ESCAPE або RETURN, щоб зупинити.';
-  TC_ALTRCOMMANDDISABLED                = 'Alt-R команда вимкнена у рядку Single Radio Mode = True';
+  TC_ALTRCOMMANDDISABLED                = 'Команда Alt-R потребує TWO RADIO MODE = TRUE';
   TC_NOCQMESPROGRAMMEDINTOCQMEMORYALTF1 = 'Немає запрограмованого CQ повідомлення в CQ MEMORY AltF1.';
 
   {LOGSUBS2}
 
   TC_WASADUPE                           = 'Зв`язок з %s вже був.';
-  TC_ALTDCOMMANDDISABLED                = 'Alt-D команда вимкнена відповідно до рядка SINGLE RADIO MODE = TRUE';
+  TC_ALTDCOMMANDDISABLED                = 'Команда Alt-D потребує TWO RADIO MODE = TRUE';
   TC_YOUHAVERESTOREDTHELASTDELETED      = 'Ви відновили останній видалений зв`язок!!';
   TC_YOUHAVEDELETEDTHELASTLOGENTRY      = 'Ви видалили останній зв`язок!! Використовуйте Alt-Y для відновлення.';
   TC_DOYOUREALLYWANTTOEXITTHEPROGRAM    = 'Ви дійсно хочете вийти з програми?';

--- a/tr4w/src/trdos/JCTRL2.PAS
+++ b/tr4w/src/trdos/JCTRL2.PAS
@@ -961,7 +961,7 @@ begin
           else
             DDXState := Off;
     }
-    SRM: InvertBoolean(SingleRadioMode); // := not SingleRadioMode;
+    SRM: InvertBoolean(TwoRadioMode); // #965: SINGLE RADIO MODE is a deprecated alias of TWO RADIO MODE
     SAB: InvertBoolean(SkipActiveBand); // := not SkipActiveBand;
 
     SMC:
@@ -1376,7 +1376,7 @@ begin
           else
             WriteLn(FileWrite, 'TRUE');
     }
-    SRM: WriteLn(FileWrite, SingleRadioMode);
+    SRM: WriteLn(FileWrite, not TwoRadioMode);
     SAB: WriteLn(FileWrite, SkipActiveBand);
     {KK1L: 6.65}
     SAS: WriteLn(FileWrite, CallWindowShowAllSpots);
@@ -1740,7 +1740,7 @@ begin
     SLG: TempStringIsTrue := tLogLogGridlines;
     //    SEN:      if DDXState <> Off then asm inc ebx end;//TempStringIsTrue := True; //TempString := 'TRUE';
 
-    SRM: TempStringIsTrue := SingleRadioMode;
+    SRM: TempStringIsTrue := not TwoRadioMode;
     SAB: TempStringIsTrue := SkipActiveBand;
 
     {KK1L: 6.65}

--- a/tr4w/src/trdos/JCtrl1.pas
+++ b/tr4w/src/trdos/JCtrl1.pas
@@ -1419,7 +1419,7 @@ begin
     }
 
     SRM:
-      if SingleRadioMode = True then
+      if not TwoRadioMode then
         RESULT := SRM1
       else
         RESULT := SRM2;

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -565,7 +565,6 @@ var
   ShortIntegers: boolean;
   ShowQSOStatusCall: CallString;
   //  ShowSearchAndPounce                   : boolean;
-  SingleRadioMode: boolean;
   SkipActiveBand: boolean;
   SpaceBarDupeCheckEnable: boolean = True;
   StartSendingNowKey: Char = '''';

--- a/tr4w/src/trdos/LOGSUBS1.PAS
+++ b/tr4w/src/trdos/LOGSUBS1.PAS
@@ -159,7 +159,7 @@ begin // 1
     TempChar := Message[1];
 
     if TempChar = ControlA then
-      if not SingleRadioMode then
+      if TwoRadioMode then
       begin // 3
         if ActiveRadio = RadioOne then
         begin // 4
@@ -175,7 +175,7 @@ begin // 1
       end; // 2
 
     if TempChar = ControlB then
-      if not SingleRadioMode then      
+      if TwoRadioMode then      
       begin
        SetUpToSendOnInactiveRadio;
        if autosendenable then
@@ -507,7 +507,7 @@ procedure SwapRadios;
 
 begin
   DebugMsg('>>>>Entering SWAPRADIOS');
-  if SingleRadioMode then
+  if not TwoRadioMode then
   begin
     QuickDisplay(TC_ALTRCOMMANDDISABLED);
     //      Wait(3000); {KK1L: 6.71}
@@ -630,7 +630,7 @@ var
   TimeOut: Byte;
 
 begin
-  if SingleRadioMode then
+  if not TwoRadioMode then
   begin
     TwoRadioState := TwoRadiosDisabled;
     Exit;
@@ -1135,7 +1135,7 @@ end;
 procedure DualingCQs;
 
 begin
-  if SingleRadioMode then
+  if not TwoRadioMode then
     Exit;
 
   {KK1L: 6.73 Added mode to GetCQMemoryString}

--- a/tr4w/src/trdos/LOGSUBS2.PAS
+++ b/tr4w/src/trdos/LOGSUBS2.PAS
@@ -425,7 +425,7 @@ var
   isDupe                                : boolean;
 
 begin
-  if SingleRadioMode then
+  if not TwoRadioMode then
   begin
     QuickDisplay(TC_ALTDCOMMANDDISABLED);
     Exit;

--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -774,7 +774,6 @@ var
   SearchAndPounceMode                   : boolean;
   SelectedColors                        : ColorRecord;
   SendAltDSpotsToPacket                 : boolean;
-  SingleRadioMode                       : boolean;
   SCount                                : integer = 0;
   SpecialCommand                        : SpecialCommandType {= NoSpecialCommand};
   SplitFreq                             : LONGINT;

--- a/tr4w/src/trdos/LogCfg.pas
+++ b/tr4w/src/trdos/LogCfg.pas
@@ -534,6 +534,10 @@ begin
   if ConfigFileName = cfgCFG then ClearDomesticCountryList;
   LineNumberInConfigFile := 0;
   CurrentConfigFile := ConfigFileName;
+  // Issue #965 -- reset per file so TWO RADIO MODE "wins" only within a single
+  // file; a later-loaded contest .cfg can still override the mode set by the ini.
+  TwoRadioModeWasSet := False;
+  logger.Info('[Config] Loading %s', [CFGFilesArray[ConfigFileName]]);
   EnumerateLinesInFile(CFGFilesArray[ConfigFileName], EnmuCFGFile, True);
 
   // STOPGAP: Re-read ctPassword fields with original case from the INI file.

--- a/tr4w/src/trdos/LogCfg.pas
+++ b/tr4w/src/trdos/LogCfg.pas
@@ -103,7 +103,8 @@ var
    CMD: ShortString;
    I: Integer;
 begin
-   if FileString^[1] in [';', '[', '_'] then Exit;
+   // Same comment/section markers as EnmuCFGFile (;  #  [  _) -- keep in sync.
+   if FileString^[1] in [';', '#', '[', '_'] then Exit;
 
    GetRidOfPrecedingSpaces(FileString^);
    GetRidOfPostcedingSpaces(FileString^);
@@ -741,7 +742,11 @@ var
   CMD                                   : ShortString;
  begin
 
-  if FileString^[1] in [';', '[', '_'] then Exit;
+  // Lines whose FIRST character (column 1, before any spaces are stripped) is a
+  // comment/section marker are ignored:  ;  and  #  are comments,  [  is a
+  // section header,  _  is an internal marker.  Kept in sync with the same test
+  // in RestoreCFGPasswordCase so both passes treat comments identically.
+  if FileString^[1] in [';', '#', '[', '_'] then Exit;
 
   GetRidOfPrecedingSpaces(FileString^);
   GetRidOfPostcedingSpaces(FileString^);

--- a/tr4w/src/uBandmap.pas
+++ b/tr4w/src/uBandmap.pas
@@ -241,7 +241,7 @@ begin
               BandColor := clred ;
 
              if (Spot.FBand = InactiveRadioPtr.BandMemory) and TwoRadioMode or
-                (Spot.FBand = BandmapBand) and SingleRadioMode  then
+                (Spot.FBand = BandmapBand) and (not TwoRadioMode)  then
                   BandColor := clblue
              else
                   BandColor := clsilver;

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -323,10 +323,15 @@ var
    WSJTXRadioControlEnabled: boolean = false;
    SpotCollectorEnabled: boolean = false;
    CTYUpdateCheckOnStartup: boolean = true;
+   // Issue #965 -- TRUE once a TWO RADIO MODE line has been parsed in the current
+   // config file.  Reset per file in LogCfg.ReadInConfigFile so a contest .cfg can
+   // still override the mode set by tr4w.ini.  Used to make TWO RADIO MODE win over
+   // a (deprecated) SINGLE RADIO MODE line appearing later in the SAME file.
+   TwoRadioModeWasSet: boolean = false;
 
 const
 
-   CommandsArraySize = 416 {RadioOneCWSpeedSync} + 1 {RadioTwoCWSpeedSync}     // 4.91.3
+   CommandsArraySize = 415 {RadioOneCWSpeedSync} + 1 {RadioTwoCWSpeedSync}     // 4.91.3
    + 1 {RadioOneCWByCAT} + 1 {RadioTwoCWByCAT} //ny4i // 4.44.5
    + 9 {UDPBroadcast Variables} + 4 {New UDP Broadcasst Ports}
    + 1 {ServerAutoSynchronizeLogOnConnect - Issue #912}
@@ -781,7 +786,6 @@ const
  (crCommand: 'SHOW TYPED CALLSIGN';           crAddress: @tShowTypedCallsign;             crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;   cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'SIMULATOR ENABLE';              crAddress: nil;                             crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal; cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'SINGLE BAND SCORE';             crAddress: pointer(25);                     crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:1 ; crP:0; crJ: 2; crKind: ckList; cfFunc: cfAll; crType: ctBand; crNetwork: 1),
- (crCommand: 'SINGLE RADIO MODE';             crAddress: @SingleRadioMode;                crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 0),
  (crCommand: 'SKIP ACTIVE BAND';              crAddress: @SkipActiveBand;                 crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
  (crCommand: 'SLASH MARK CHAR';               crAddress: @SlashMarkChar;                  crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctChar; crNetwork: 1),
  (crCommand: 'SPACE BAR DUPE CHECK ENABLE';   crAddress: @SpaceBarDupeCheckEnable;        crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 1),
@@ -1001,6 +1005,49 @@ begin
          Result := True;
          Exit;
          end;
+      end;
+
+   // Issue #965 -- TWO RADIO MODE is the sole mode knob.  Remember that it was
+   // specified in THIS config file so a (deprecated) SINGLE RADIO MODE line below
+   // cannot flip the mode back -- TWO RADIO MODE wins.  We do NOT Exit here: the
+   // command table below applies the actual boolean value to TwoRadioMode.
+   if pshortstring(Command)^ = 'TWO RADIO MODE' then
+      begin
+      if CustomCMD[1] in ['T', 'F'] then
+         begin
+         TwoRadioModeWasSet := True;
+         logger.Info('[RadioMode] TWO RADIO MODE = %s -- this file decides the mode; any SINGLE RADIO MODE line in this file is ignored', [CustomCMD]);
+         end;
+      end;
+
+   // Issue #965 -- SINGLE RADIO MODE is the deprecated inverse of TWO RADIO MODE.
+   // Kept parseable so existing .cfg files still load (Option A): TRUE => single
+   // => TwoRadioMode False; FALSE => two-radio => TwoRadioMode True.  But if THIS
+   // file already specified TWO RADIO MODE, that wins and SINGLE RADIO MODE here is
+   // inert (still consumed so it is not flagged as an unknown command).
+   if pshortstring(Command)^ = 'SINGLE RADIO MODE' then
+      begin
+      if CustomCMD[1] in ['T', 'F'] then
+         begin
+         if not TwoRadioModeWasSet then
+            begin
+            TwoRadioMode := CustomCMD[1] = 'F';
+            if TwoRadioMode then
+               begin
+               logger.Info('[RadioMode] SINGLE RADIO MODE = %s applied (deprecated alias) -- TwoRadioMode now TRUE (two-radio/SO2R)', [CustomCMD]);
+               end
+            else
+               begin
+               logger.Info('[RadioMode] SINGLE RADIO MODE = %s applied (deprecated alias) -- TwoRadioMode now FALSE (single radio)', [CustomCMD]);
+               end;
+            end
+         else
+            begin
+            logger.Info('[RadioMode] SINGLE RADIO MODE = %s IGNORED -- TWO RADIO MODE already set in this file (TWO RADIO MODE wins)', [CustomCMD]);
+            end;
+         Result := True;
+         end;
+      Exit;
       end;
 
    //logger.trace('Searching for %s',[Command]);


### PR DESCRIPTION
## Issue #965 — Remove Single Radio Mode setting in options

Collapses the conflicting `SINGLE RADIO MODE` / `TWO RADIO MODE` flags into a single knob, per the agreed plan (Howie N4AF + NY4I) on the issue.

### What changed

**`TWO RADIO MODE` is now the sole mode setting** (`dd67e37`)
- `TRUE` = two-radio / SO2R, `FALSE` = single radio (the default).
- `SINGLE RADIO MODE` is kept only as a **deprecated parse-alias** so existing `.cfg` files still load (`TRUE` ⇒ single ⇒ `TwoRadioMode` False; `FALSE` ⇒ two-radio).
- **Fixes a latent bug:** `SingleRadioMode` was declared twice (`LOGSTUFF.PAS` + `LOGWIND.PAS`) — two separate globals, so the CFG write could target a different variable than the readers. Both declarations removed; all readers re-pointed to `not TwoRadioMode`.

**`TWO RADIO MODE` wins, per config file** (load-precedence, beyond the original plan)
- New per-file `TwoRadioModeWasSet` flag (uCFG), reset at the start of each file load in `LogCfg.ReadInConfigFile`.
- If a file specifies `TWO RADIO MODE`, a later (deprecated) `SINGLE RADIO MODE` line in the **same file** is inert — `TWO RADIO MODE` decides.
- Because the flag resets per file, a contest `.cfg` can still override the mode set by `tr4w.ini`.
- **INFO logging** of the per-file mode decision (a `[Config] Loading <file>` banner plus an applied/ignored `[RadioMode] …` line) to make a user's mode-conflict reproducible from `tr4w.log`.

**Non-ENG wording** (`1610f62`)
- `TC_ALTRCOMMANDDISABLED` / `TC_ALTDCOMMANDDISABLED` reworded to reference `TWO RADIO MODE = TRUE` in all 10 non-English `tr4w_consts_*.pas` files (the config keyword stays English; only the surrounding text is translated). Edited byte-safely per file codepage so existing Cyrillic/diacritic content is preserved.

**`#` comment character** (`af9854d`) — unrelated, folded in at maintainer request
- `EnmuCFGFile` and `RestoreCFGPasswordCase` now also skip lines whose first column is `#`, alongside the existing `;` `[` `_`. A `#` in column 1 previously produced an "invalid statement in config file" error. Both file-passes kept in sync; inline `#` placeholders to the right of `=` are unaffected.

### Validation
- All 9 built languages compile (ENG + RUS/SER/MNG/CZE/ROM/GER/UKR/ESP).
- Unit tests pass (809 / 0).
- `target/cluster_commands.txt` (runtime data) deliberately excluded.

### Notes
- Touches legacy `trdos/` core, so on-air testing of single vs two-radio behaviour and loading an old `.cfg` with `SINGLE RADIO MODE = TRUE` is recommended.

Closes #965
