### PR TITLE
Fix WSJT-X ADIF logging: <EOH> must not terminate a record

### DIFF
--- a/tr4w/src/uADIF.pas
+++ b/tr4w/src/uADIF.pas
@@ -349,13 +349,23 @@ begin
       tagBody := Copy(s, p, gtPos - p);
       p := gtPos + 1;  // advance past '>'
 
-      // Terminators
+      // <EOR> terminates a QSO record.  <EOH> only ends the optional
+      // ADIF header (spec IV.A.2: an ADI file is an optional Header,
+      // terminated by <EOH>, followed by one or more <EOR> records; a
+      // headerless file starts straight into records).  A full document
+      // reaches this single-record lexer -- the WSJT-X "Logged ADIF" UDP
+      // message is <adif_ver><programid><EOH><call...><EOR> -- so skip
+      // <EOH> and keep parsing the record that follows rather than
+      // stopping at the header boundary.  Restores the pre-Issue-#887
+      // behaviour, where the inline parser terminated on <EOR> only.
       tagUpper := AnsiUpperCase(tagBody);
-      if (tagUpper = 'EOR') or (tagUpper = 'EOH') then
+      if tagUpper = 'EOR' then
          begin
          Result := True;
          Exit;
          end;
+      if tagUpper = 'EOH' then
+         Continue;
 
       // Parse '<NAME:LEN>' or '<NAME:LEN:TYPE>'
       colonPos := AnsiPos(':', tagBody);

--- a/tr4w/test/unit/uTestADIF.pas
+++ b/tr4w/test/unit/uTestADIF.pas
@@ -28,7 +28,8 @@ type
       procedure Test_SingleField_EORTerminated;
       procedure Test_MultipleFields;
       procedure Test_BareEOR;
-      procedure Test_EOHTreatedSameAsEOR;
+      procedure Test_EOHSkipped_HeaderThenRecord;
+      procedure Test_EOHAlone_NotARecordTerminator;
       procedure Test_NoTerminator_ReturnsFalseButKeepsFields;
       procedure Test_EmptyValue;
       procedure Test_MultilineRecord;
@@ -149,14 +150,41 @@ begin
    CheckEquals(0, Length(fields), 'no fields');
 end;
 
-procedure TADIFLexerTests.Test_EOHTreatedSameAsEOR;
+procedure TADIFLexerTests.Test_EOHSkipped_HeaderThenRecord;
 var
    fields : TADIFFieldList;
 begin
-   BeginTest('Test_EOHTreatedSameAsEOR');
-   CheckTrue(ParseADIFFieldsList('<PROGRAMID:4>TR4W<EOH>', fields),
-             'EOH is also a valid terminator');
-   CheckEquals(1, Length(fields), 'one header field');
+   BeginTest('Test_EOHSkipped_HeaderThenRecord');
+   // ADIF IV.A.2: an optional Header (terminated by <EOH>) precedes one
+   // or more <EOR> records.  WSJT-X sends exactly this shape, so the
+   // single-record lexer must skip <EOH> and keep parsing the record
+   // that follows -- the call/grid must survive the header boundary.
+   // Regression guard for Issue #887: the lexer used to stop at <EOH>,
+   // which dropped every WSJT-X-logged QSO.
+   CheckTrue(ParseADIFFieldsList(
+      '<PROGRAMID:6>WSJT-X<EOH>'#13#10 +
+      '<CALL:4>W7CT <GRIDSQUARE:4>DN41<EOR>', fields),
+      'header + record -> reaches EOR -> True');
+   CheckEquals(3, Length(fields), 'header field + two record fields');
+   CheckEquals('PROGRAMID', fields[0].Name, 'header field kept (sets FromWSJTX)');
+   CheckEquals('WSJT-X', fields[0].Value, 'programid value');
+   CheckEquals('CALL', fields[1].Name, 'record field parsed after <EOH>');
+   CheckEquals('W7CT', fields[1].Value, 'call survives the header boundary');
+   CheckEquals('GRIDSQUARE', fields[2].Name, 'grid field name');
+   CheckEquals('DN41', fields[2].Value, 'grid survives the header boundary');
+end;
+
+procedure TADIFLexerTests.Test_EOHAlone_NotARecordTerminator;
+var
+   fields : TADIFFieldList;
+begin
+   BeginTest('Test_EOHAlone_NotARecordTerminator');
+   // <EOH> ends a header, not a record.  With no following <EOR> there
+   // is no complete record, so Result is False -- the header field is
+   // still extracted (forgiving, same as the no-terminator case).
+   CheckFalse(ParseADIFFieldsList('<PROGRAMID:4>TR4W<EOH>', fields),
+              'EOH alone is not a record terminator -> False');
+   CheckEquals(1, Length(fields), 'header field still extracted');
    CheckEquals('PROGRAMID', fields[0].Name, 'name');
    CheckEquals('TR4W', fields[0].Value, 'value');
 end;
@@ -337,7 +365,8 @@ begin
    Test_SingleField_EORTerminated;
    Test_MultipleFields;
    Test_BareEOR;
-   Test_EOHTreatedSameAsEOR;
+   Test_EOHSkipped_HeaderThenRecord;
+   Test_EOHAlone_NotARecordTerminator;
    Test_NoTerminator_ReturnsFalseButKeepsFields;
 
    Test_EmptyValue;


### PR DESCRIPTION
## Summary

WSJT-X-logged QSOs have not been logging in TR4W since **2026-05-11**. Root cause is a regression in the ADIF lexer.

WSJT-X's "Logged ADIF" UDP message is a complete ADI document — an optional header terminated by `<EOH>`, then the QSO record terminated by `<EOR>` (ADIF spec IV.A.2):

```
<adif_ver:5>3.1.0 <programid:6>WSJT-X <EOH>
<call:4>W7CT <gridsquare:4>DN41 ... <band:3>20m <freq:9>14.080788 ... <EOR>
```

The single-record lexer `uADIF.ParseADIFFieldsList` stopped at the first `<EOH>` **or** `<EOR>`, so it parsed only the header fields (`adif_ver`, `programid`), halted at `<EOH>`, and never read the record's `CALL`/`GRIDSQUARE`/`BAND`/`FREQ`. Downstream the callsign and exchange were empty, `ParametersOkay` exited early, and the QSO silently failed to log.

**Proof from a user log:** `ParametersOkay` received `freq = 14080000` (a band default), not the ADIF's `14.080788` → `14080788` — the record's frequency was never parsed.

## Regression provenance (Issue #887, 2026-05-11)

- `dd471f2` — *"uADIF: extract ADIF field-list lexer + unit tests"* — introduced the `<EOH>` co-terminator (`uADIF.pas:354`).
- `417eada` — *"uADIF: field-name mapping + ImportADIFFromString"* — rewired `MainUnit.ParseADIFRecord` to call that lexer.

The pre-#887 inline parser terminated on `<EOR>` only — it parsed straight through the header. The extraction unintentionally changed the termination rule.

## Fix (`tr4w/src/uADIF.pas`)

`<EOR>` (or end of input) terminates a record; `<EOH>` is **skipped** so parsing continues into the record that follows. Restores the pre-#887 behaviour and keeps the header's `programid` field (so `FromWSJTX` is still set). Handles both headerful (WSJT-X) and headerless ADIF. The multi-record splitter already strips the header itself and is unaffected.

## Tests (`tr4w/test/unit/uTestADIF.pas`)

Replaced `Test_EOHTreatedSameAsEOR` — which had locked in the broken behaviour — with:
- **`Test_EOHSkipped_HeaderThenRecord`** — a header + record document; asserts `CALL`/`GRIDSQUARE` survive the `<EOH>` boundary (the regression guard).
- **`Test_EOHAlone_NotARecordTerminator`** — `<EOH>` with no following `<EOR>` is not a record terminator.

**817 / 817 unit tests pass.**

## Verification

FullBuild green (app, server, test harness). Confirmed on the air: an ARRL-DIGI WSJT-X QSO now logs in TR4W.
