### PR TITLE
release.yml: scope auto-notes to the real previous tag (ignore -all)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,14 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
+      # Full history + tags so the notes step can resolve the previous
+      # tag from git ancestry (checked out first so its clean step does
+      # not wipe the artifacts downloaded below).
+      - name: Checkout (full history + tags for the changelog range)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download installer artifact
         uses: actions/download-artifact@v4
         with:
@@ -306,6 +314,32 @@ jobs:
         shell: powershell
         run: Get-ChildItem -LiteralPath release-files | Format-Table Name, Length, LastWriteTime
 
+      # Generate the changelog body ourselves against the REAL previous
+      # tag. GitHub's built-in generate_release_notes auto-detects the
+      # previous tag via semver and skips '-all' tags (they parse as a
+      # prerelease), which made e.g. v4.148.4 diff against v4.148.2 and
+      # re-list everything already shipped in v4.148.3-all. git describe
+      # walks history instead, so the '-all' suffix no longer matters.
+      - name: Generate release notes (scoped to the real previous tag)
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $tag = $env:GITHUB_REF_NAME
+          $prev = (& git describe --tags --abbrev=0 "$tag^" 2>$null)
+          if ($LASTEXITCODE -ne 0) { $prev = $null }
+          $req = @{ tag_name = $tag }
+          if ($prev) { Write-Host "Previous tag (git ancestry): $prev"; $req.previous_tag_name = $prev }
+          else { Write-Host "No previous tag found; GitHub will auto-detect the range." }
+          [System.IO.File]::WriteAllText("$PWD\notes-request.json", ($req | ConvertTo-Json -Compress), (New-Object System.Text.UTF8Encoding($false)))
+          $resp = & curl.exe -sS -X POST -H "Authorization: Bearer $env:GH_TOKEN" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases/generate-notes" -d "@notes-request.json"
+          $body = ($resp | ConvertFrom-Json).body
+          if (-not $body) { throw "generate-notes returned an empty body. Response: $resp" }
+          [System.IO.File]::WriteAllText("$PWD\release-notes.md", $body, (New-Object System.Text.UTF8Encoding($false)))
+          Write-Host "--- release notes (previous tag: $prev) ---"
+          Write-Host $body
+
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -315,10 +349,11 @@ jobs:
           # context (radio support, breaking changes, etc.) before
           # publishing. Promote to a final release via the GitHub UI.
           draft: true
-          # Auto-generate the changelog body from commits since the
-          # previous tag. The CHANGES.md / RELEASE_NOTES.md sections
-          # for this version can be pasted in during the draft review.
-          generate_release_notes: true
+          # Body is generated in the previous step against the real
+          # previous tag (git ancestry), so the '-all' suffix no longer
+          # widens the range. CHANGES.md / RELEASE_NOTES.md sections can
+          # still be pasted in during the draft review.
+          body_path: release-notes.md
           # Attach all installer(s) AND the VT report so users can
           # download both from the release page.
           files: |


### PR DESCRIPTION
## Problem

The draft-release step uses `generate_release_notes: true` with no explicit `previous_tag`, so GitHub auto-detects the baseline **via semver**. A `-all` suffix (e.g. `v4.148.3-all`) parses as a semver **prerelease** identifier, and GitHub skips prerelease tags when the release tag is stable. So `v4.148.4`'s notes were diffed against the previous *non*-`all` tag, `v4.148.2` — re-listing everything already shipped in `v4.148.3-all`.

## Fix

Generate the notes body ourselves against the **real** previous tag:

1. `actions/checkout` with `fetch-depth: 0` so tags/history are present.
2. Resolve the previous tag with `git describe --tags --abbrev=0 <tag>^` — git **ancestry**, not semver, so `-all` is irrelevant.
3. Call `releases/generate-notes` with an explicit `previous_tag_name`.
4. Hand the result to `softprops/action-gh-release` via `body_path` (drops `generate_release_notes: true`).

PowerShell 5.1-safe (curl.exe + `ConvertFrom-Json` + BOM-less `.NET` writes), matching the existing VirusTotal-script conventions on the self-hosted runner. Falls back to GitHub auto-detect if there's no previous tag.

## Validation

Core logic verified locally against the live tags:

```
$ git describe --tags --abbrev=0 v4.148.4^
v4.148.3-all

$ gh api .../releases/generate-notes -f tag_name=v4.148.4 -f previous_tag_name=v4.148.3-all --jq .body
## What's Changed
* Issue #973 ... (#974)
* Fix WSJT-X ADIF logging: <EOH> ... (#975)
* WSJT-X logging: fix Computer ID + operator-mismatch warning (#977)
**Full Changelog**: .../compare/v4.148.3-all...v4.148.4
```

→ exactly the three `4.148.4` PRs, no `4.148.3` bleed-through.

**Note:** the workflow wiring (checkout, the API step on the runner, `body_path`) only executes on a real tag push, so it gets its full end-to-end test on the next release tag.
