### PR TITLE
Issue #978: follow WSJT-X dial frequency to set band when no radio defined

### DIFF
--- a/tr4w/src/trdos/LOGEDIT.PAS
+++ b/tr4w/src/trdos/LOGEDIT.PAS
@@ -159,6 +159,7 @@ procedure AddQTCToQTCBuffer(var QTCBuffer: LogEntryArray; QTCString: Str80;
 //procedure BandDown;
 //procedure BandUp;
 procedure BandDownOrUp(Direction: DirectionType);
+procedure GoToBand(NewBand: BandType);
 procedure CleanUpDisplay;
 function DetermineQTCNumberAndQuanity(InputString: Str80; var QTCNumber:
   integer; var Quantity: integer): boolean;
@@ -333,6 +334,40 @@ begin
       Result := MaxSerialSent[AllBands] + 1;
 end;
 
+// Shared display refresh after the active band changes.  Both the Alt-B
+// band step (BandDownOrUp) and the WSJT-X "follow the dial frequency"
+// path (GoToBand) use this so the two stay in sync.
+procedure RefreshAfterBandChange;
+begin
+  if QSOByBand then
+    CallsignsList.DisplayDupeSheet(ActiveRadioPtr);
+  if MultByBand then
+    VisibleLog.ShowRemainingMultipliers;
+  BandMapBand := ActiveBand;
+  DisplayBandMap;
+  ShowSpotInfo;
+  if QSONumberByBand then
+    DisplayNextQSONumber;
+end;
+
+// Jump straight to a specific band (e.g. WSJT-X dial frequency when no
+// radio is defined), mirroring the Alt-B band-change refresh and the same
+// multi-band gate.  Mode is intentionally left unchanged for now.
+procedure GoToBand(NewBand: BandType);
+begin
+  if (NewBand = NoBand) or (NewBand = ActiveBand) then
+    Exit;
+  if (not MultipleBandsEnabled) and (TotalContacts <> 0) then
+    Exit;
+  PutRadioOutOfSplit(ActiveRadio); // n4af 4.46.5
+  ActiveBand := NewBand;
+  // Repaint the band indicator + totals-row highlight (UpdateRadio=False:
+  // there is no radio to tune).  This is the same call uRadioPolling makes
+  // from its worker thread when a connected radio changes band.
+  DisplayBandMode(ActiveBand, ActiveMode, False);
+  RefreshAfterBandChange;
+end;
+
 procedure BandDownOrUp(Direction: DirectionType);
 begin
 
@@ -349,15 +384,7 @@ begin
     begin
       PutRadioOutOfSplit(ActiveRadio); // n4af 4.46.5
       BandChange(ActiveBand, Direction);
-      if QSOByBand then
-        CallsignsList.DisplayDupeSheet(ActiveRadioPtr);
-      if MultByBand then
-        VisibleLog.ShowRemainingMultipliers;
-      BandMapBand := ActiveBand;
-      DisplayBandMap;
-      ShowSpotInfo;
-      if QSONumberByBand then
-        DisplayNextQSONumber;
+      RefreshAfterBandChange;
     end;
   end;
 end;

--- a/tr4w/src/uWSJTX.pas
+++ b/tr4w/src/uWSJTX.pas
@@ -442,6 +442,24 @@ begin
               Unpack(AData, index, DECall);
               Unpack(AData, index, DEGrid);
               Unpack(AData, index, DXGrid);
+
+              // Issue #978: with no radio defined, follow the WSJT-X dial
+              // frequency to set the active band (band only, and only on an
+              // actual change).  GoToBand applies the same multi-band gate
+              // and display refresh as an Alt-B band change.
+              if (ActiveRadioPtr.RadioModel = NoInterfacedRadio) and
+                 (ActiveRadioPtr.tNetObject = nil) then
+                begin
+                GetBandMapBandModeFromFrequency(frequency, TempBand, TempMode);
+                if (TempBand <> NoBand) and (TempBand <> ActiveBand) then
+                  begin
+                  logger.debug('[uWSJTX] No radio defined; following WSJT-X to band '
+                    + string(BandStringsArray[TempBand]) + ' (' + IntToStr(frequency)
+                    + ' Hz)');
+                  GoToBand(TempBand);
+                  end;
+                end;
+
               if logger.IsTraceEnabled then
                 begin
                 logger.trace('[uWSJTX] WSJTX Status>>> Frequency: ' +


### PR DESCRIPTION
Closes #978

## Summary

When **no radio is defined**, TR4W now follows the WSJT-X dial frequency to set the active band — so an operator running WSJT-X with no CAT/network rig stays on the right band in TR4W. Behaves like an Alt-B band change (band only).

## Behavior

- **Gate:** only when no radio is defined — `ActiveRadioPtr.RadioModel = NoInterfacedRadio` **and** `ActiveRadioPtr.tNetObject = nil` (no serial CAT *and* no network rig). With any radio defined, it does nothing.
- **Same multi-band gate as Alt-B:** only changes band when `MULTIPLE BANDS` is enabled or there are no QSOs yet.
- **Band only** — mode is left unchanged (room to expand later).
- Fires on an **actual band change** only.

## Implementation

- **`trdos/LOGEDIT.PAS`**
  - Extracted the Alt-B refresh sequence into `RefreshAfterBandChange` (dupe sheet, multipliers, band map, spot info, next-QSO-number).
  - Added `GoToBand(NewBand)`: jumps straight to a band with the same multi-band gate, then `DisplayBandMode(ActiveBand, ActiveMode, False)` (repaints the band indicator + totals-row highlight; `UpdateRadio=False` since there's no radio to tune) and `RefreshAfterBandChange`.
  - `BandDownOrUp` now reuses `RefreshAfterBandChange` — **Alt-B behavior is unchanged** (pure extraction).
- **`uWSJTX.pas`** — in the `WSJTX_MESSAGETYPE_STATUSV` handler: gate on no-radio-defined, derive the band from the dial frequency with `GetBandMapBandModeFromFrequency` (the same call the Decode path uses), and `GoToBand` on a change. Logs the follow at DEBUG.

Runs on the WSJT-X UDP worker thread — consistent with the rest of that handler, and with `uRadioPolling.pas:3198`, which makes the identical worker-thread `DisplayBandMode` call when a connected radio changes band.

## Testing

Built green (`FullBuild.ps1`). Verified on hardware: with Radio 1 = NONE and WSJT-X running, switching WSJT-X across 40/20/15m moves TR4W's band indicator, totals-row highlight, and band map. With a radio defined, TR4W does not follow. (Diagnosed and fixed live — the first pass updated `ActiveBand`/band map but not the band indicator; adding `DisplayBandMode` resolved it.)
