### PR TITLE
Issue #976: Cabrillo category compliance + dialog/export fixes

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -753,7 +753,7 @@ type
   tLogLevels = (llNone, llFatal, llError, llWarn, llInfo, llDebug, llTrace);
   tCategoryAssisted = (caNONASSISTED, caASSISTED);
   tCategoryBand = (cbALL, cb160M, cb80M, cb40M, cb20M, cb15M, cb10M, cb6M, cb2M, cb222, cb432, cb902, cb12G);
-  tCategoryMode = (cmCW, cmDIGITAL, cmRTTY, cmSSB, cmMIXED);
+  tCategoryMode = (cmCW, cmDIGITAL, cmRTTY, cmSSB, cmMIXED, cmFM); // Issue #976: FM added (appended; existing cmDIGITAL/cmRTTY string swap left as a separate follow-up)
   tCertificate = (Yes, No);
   tCategoryOperator = (coSINGLEOP, coMULTIOP, coCHECKLOG);
   tCategoryPower = (cpHIGH, cpLOW, cpQRP);
@@ -764,11 +764,11 @@ const
   tLogLevelsSA                          : array[tLogLevels] of PChar = ('NONE' ,'FATAL', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE');
   tCategoryAssistedSA                   : array[tCategoryAssisted] of PChar = ('NON-ASSISTED', 'ASSISTED');
   tCategoryBandSA                       : array[tCategoryBand] of PChar = ('ALL', '160M', '80M', '40M', '20M', '15M', '10M', '6M', '2M', '222', '432', '902', '1.2G');
-  tCategoryModeSA                       : array[tCategoryMode] of PChar = ('CW', 'RTTY', 'DIGI', 'SSB', 'MIXED');    // 4.90.14
+  tCategoryModeSA                       : array[tCategoryMode] of PChar = ('CW', 'RTTY', 'DIGI', 'SSB', 'MIXED', 'FM');    // 4.90.14; FM added Issue #976
   tCertificateSA                        : array[tCertificate] of PChar = ('Yes', 'No');
   tCategoryOperatorSA                   : array[tCategoryOperator] of PChar = ('SINGLE-OP', 'MULTI-OP', 'CHECKLOG');
   tCategoryPowerSA                      : array[tCategoryPower] of PChar = ('HIGH', 'LOW', 'QRP');
-  tCategoryTransmitterSA                : array[tCategoryTransmitter] of PChar = ('ONE', 'M/S', 'LIMITED', 'UNLIMITED', 'SWL');
+  tCategoryTransmitterSA                : array[tCategoryTransmitter] of PChar = ('ONE', 'TWO', 'LIMITED', 'UNLIMITED', 'SWL');
 
 var
   CategoryAssisted                      : tCategoryAssisted;

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -251,10 +251,10 @@ const
 //  NumberBandCategories                  = 13;
 //  NumberPowerCategories                 = 3;
 //  NumberModeCategories                  = 4;
-  NumberOverlayCategories               = 5;
+  NumberOverlayCategories               = 6;
   NumberAssistedCategories              = 2;
-  NumberStationCategories               = 7;
-  NumberTimeCategories                  = 3;
+  NumberStationCategories               = 11;
+  NumberTimeCategories                  = 4;
   NumberTransmitterCategories           = 5;
   NumberCertificateCategories           = 2;
   NumberSections                        = 81;
@@ -282,6 +282,7 @@ const
  }
   TimeCategory                          : array[0..NumberTimeCategories - 1] of PChar = (
     '6-HOURS',
+    '8-HOURS',
     '12-HOURS',
     '24-HOURS'
     );
@@ -301,13 +302,17 @@ const
 }
   StationCategory                       : array[0..NumberStationCategories - 1] of PChar =
     (
+    'DISTRIBUTED',
     'FIXED',
     'MOBILE',
     'PORTABLE',
     'ROVER',
+    'ROVER-LIMITED',
+    'ROVER-UNLIMITED',
     'EXPEDITION',
     'HQ',
-    'SCHOOL'
+    'SCHOOL',
+    'EXPLORER'
     );
 {
   BandCategory                          : array[0..NumberBandCategories - 1] of PChar = (
@@ -340,9 +345,10 @@ const
   OverlayCategory                       : array[0..NumberOverlayCategories - 1] of PChar = (
     'CLASSIC',  //n4af 4.35.4
     'ROOKIE',
-    'NOVICE-TECH',
     'TB-WIRES',
-    'OVER-50');
+    'YOUTH',
+    'NOVICE-TECH',
+    'YL');
 
     Certificate                 : array[0..NumberCertificateCategories - 1] of PChar = (           //N4AF 37.0.1
     'YES',

--- a/tr4w/src/uCbrSum.pas
+++ b/tr4w/src/uCbrSum.pas
@@ -102,10 +102,10 @@ const
     (ctrTag: '_CATEGORY-MODE';          ctrCFG:True;  ctrSave: True; ctrList: True),
     (ctrTag: '_CATEGORY-OPERATOR';      ctrCFG:True;  ctrSave: False; ctrList: True),    // ny4i changed this since we dete3rmine from the log
     (ctrTag: '_CATEGORY-POWER';         ctrCFG:True;  ctrSave: True; ctrList: True),
-    (ctrTag: '_CATEGORY-STATION';       ctrCFG:False; ctrSave: True; ctrList: False),
-    (ctrTag: '_CATEGORY-TIME';          ctrCFG:True;  ctrSave: False; ctrList: True),
+    (ctrTag: '_CATEGORY-STATION';       ctrCFG:False; ctrSave: True; ctrList: True), // Issue #976: now a drop-down
+    (ctrTag: '_CATEGORY-TIME';          ctrCFG:True;  ctrSave: True; ctrList: True),  // Issue #976: persist + restore selection
     (ctrTag: '_CATEGORY-TRANSMITTER';   ctrCFG:False; ctrSave: True; ctrList: False),
-    (ctrTag: '_CATEGORY-OVERLAY';       ctrCFG:True;  ctrSave: False; ctrList:  True),
+    (ctrTag: '_CATEGORY-OVERLAY';       ctrCFG:True;  ctrSave: True; ctrList:  True),  // Issue #976: persist + restore selection
     (ctrTag: '_CERTIFICATE';            ctrCFG:True;  ctrSave: True; ctrList: False),
     (ctrTag: '_OPERATORS';              ctrCFG:True;  ctrSave: True; ctrList: False),
     (ctrTag: '_CLUB';                   ctrCFG:False; ctrSave: True;  ctrList: False),
@@ -216,7 +216,17 @@ begin
             end;
 
             if TempTag in [ctCategoryAssisted..ctCategoryPower] then
-              SendMessage(TempHWND, CB_SETCURSEL, integer(InitialTagsValuesArray[TempTag]^), 0);
+              SendMessage(TempHWND, CB_SETCURSEL, integer(InitialTagsValuesArray[TempTag]^), 0)
+            else if CabrilloTagSArray[TempTag].ctrSave then
+            begin
+              // Issue #976: restore the saved value into ctrSave drop-downs
+              // that are outside the index-based range above (e.g.
+              // CATEGORY-STATION).  GetDlgItemText on exit saves it back.
+              if GetPrivateProfileString(FormatSpecification,
+                  CabrilloTagSArray[TempTag].ctrTag, nil, TempBuffer1,
+                  SizeOf(TempBuffer1), TR4W_INI_FILENAME) > 0 then
+                SendMessage(TempHWND, CB_SELECTSTRING, -1, integer(@TempBuffer1));
+            end;
           end
           else
           begin
@@ -281,7 +291,15 @@ begin
               if CabrilloSummaryProc = nil then
                 goto ExitAndClose
               else
+              begin
+                // Issue #976: after the export callback finishes (it
+                // generates the Cabrillo file, opens it for review, and
+                // prompts for the SuperCheckPartial upload), close the dialog
+                // -- otherwise the user is dropped back at OK/Cancel and has
+                // to hit Cancel to finish a successful export.
                 asm call CabrilloSummaryProc; end;
+                goto ExitAndClose;
+              end;
           2: goto ExitAndClose;
           3:
           //DialogBox(hInstance, MAKEINTRESOURCE(50), hwnddlg, @ErmakDlgProc);

--- a/tr4w/src/uNewContest.pas
+++ b/tr4w/src/uNewContest.pas
@@ -62,7 +62,10 @@ const
   InitialCommandsSA2                    : array[1..CSAS] of PChar = (
     nil,
     nil,
-    'CATEGORY-OVERLAY',
+    // Issue #976: CATEGORY-OVERLAY removed -- it was only a dangling label
+    // (no control was ever created for it).  Restore it as a real drop-down
+    // when the New Contest dialog is rebuilt in modern Delphi.
+    nil,
     'CATEGORY-ASSISTED',
     'CATEGORY-BAND',
     'CATEGORY-MODE',


### PR DESCRIPTION
Closes #976

Brings the contest-category drop-downs and Cabrillo export into spec compliance, and fixes the related dialog/export UX surfaced while testing.

## Category data (`VC.pas`, `trdos/PostUnit.PAS`)

- **CATEGORY-TRANSMITTER:** `tCategoryTransmitterSA` `'M/S'` → `'TWO'` (New Contest dialog).
- **CATEGORY-MODE:** added `FM` (`cmFM` / `'FM'` appended; enum + string array stay aligned). The pre-existing `cmDIGITAL`↔`'RTTY'` string swap is **left as a separate audited follow-up** — other code / saved configs may rely on the current mapping.
- **CATEGORY-TIME:** added `8-HOURS` (`NumberTimeCategories` 3→4).
- **CATEGORY-OVERLAY:** `CLASSIC / ROOKIE / TB-WIRES / YOUTH / NOVICE-TECH / YL` — removed `OVER-50`, added `YOUTH`+`YL` (`NumberOverlayCategories` 5→6).
- **CATEGORY-STATION:** added `DISTRIBUTED / ROVER-LIMITED / ROVER-UNLIMITED / EXPLORER` → 11 types (`NumberStationCategories` 7→11).
- The Russian **`ErmakOverlayCategory`** list is untouched — it's gated behind `if ErmakSpecification` (the Ermak contest framework) and only overrides the overlay dropdown for those contests.

Each array's matching `Number*Categories` constant was bumped in the same edit (the "Number of elements differs from declaration" gotcha).

## Cabrillo Summary dialog (`uCbrSum.pas`)

- **CATEGORY-STATION is now a drop-down** (`ctrList: True`), populated from the corrected `StationCategory`. Added a string-based **saved-value restore** (`GetPrivateProfileString` → `CB_SELECTSTRING`) for `ctrSave` drop-downs that fall outside the existing index-based restore range.
- **CATEGORY-TIME and CATEGORY-OVERLAY now persist** (`ctrSave: True`). They had no program-variable backing (unlike Assisted/Band/Mode/Operator/Power), so without this their selection was never saved.
- **OK auto-closes the dialog after export.** Previously OK ran the export callback (generate file → review → SuperCheckPartial prompt) but left the dialog open, so finishing a *successful* export required clicking **Cancel**. OK now `goto ExitAndClose` after the callback (mirroring Cancel). Standalone "Edit Cabrillo Summary" behaviour is unchanged.

## New Contest dialog (`uNewContest.pas`)

- Removed the **dangling CATEGORY-OVERLAY label** (`InitialCommandsSA2[3]` → `nil`) — it had a label but no control was ever created for it. Left a comment to restore it as a real drop-down when the dialog is rebuilt in modern Delphi.

## Safety

Categories are persisted **by string value** (`GetDlgItemText` → `WritePrivateProfileString`), not by array index — so reordering/removing array entries does not mis-map existing `.cfg` files.

## Testing

Built green (`FullBuild.ps1`). Verified on hardware: dialogs show the corrected values; STATION/TIME/OVERLAY persist across reopen; the export flow closes cleanly after the upload prompt; New Contest overlay label is gone.
