### PR TITLE
release.yml: fetch tags-only in release job (survive case-only branch refs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,13 +290,33 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      # Full history + tags so the notes step can resolve the previous
-      # tag from git ancestry (checked out first so its clean step does
-      # not wipe the artifacts downloaded below).
-      - name: Checkout (full history + tags for the changelog range)
+      # Checkout at the tag with the DEFAULT shallow fetch: actions/checkout
+      # then fetches only the single triggering ref and never pulls
+      # refs/heads/*. That matters on the self-hosted Windows runner
+      # (case-insensitive NTFS, 'files' ref backend): two branch names that
+      # differ only in case -- e.g. Issue861PLus vs Issue861Plus -- cannot
+      # both be stored on disk, and a previous `fetch-depth: 0` (which fetches
+      # EVERY head) aborted the entire release job on that collision
+      # ("references that only differ in casing" -> the retry's --unshallow
+      # then failed "on a complete repository"). The notes step only needs
+      # TAGS + history for `git describe`, not branch heads, so the next step
+      # fetches tags explicitly. Checked out first so its clean step does not
+      # wipe the artifacts downloaded below.
+      - name: Checkout source at the tag
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Fetch tags + history for the changelog range
+        shell: powershell
+        run: |
+          # Fetch ONLY refs/tags/* (never refs/heads/*), so a case-only
+          # branch-name collision can never break the release again. A very
+          # large --depth fully deepens history whether the repo is currently
+          # shallow or already complete -- unlike --unshallow, which errors
+          # ("does not make sense") once a prior fetch has completed the repo.
+          # git describe needs the ancestry from the tag back to the previous
+          # tag, and the previous tag's ref itself, both of which this provides.
+          git fetch --prune --no-tags --depth=2147483647 origin "+refs/tags/*:refs/tags/*"
+          if ($LASTEXITCODE -ne 0) { throw "Tag fetch failed with exit code $LASTEXITCODE" }
 
       - name: Download installer artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

The **v4.148.5** tag push failed the **Create draft GitHub Release** job at its very first step — `actions/checkout@v4` with `fetch-depth: 0`:

```
error: You're on a case-insensitive filesystem, and the remote you are
trying to fetch from has references that only differ in casing.
...
fatal: --unshallow on a complete repository does not make sense
```

`fetch-depth: 0` fetches **every** `refs/heads/*` in addition to tags. The remote had two branches differing only in case — `Issue861PLus` and `Issue861Plus` (both merged Issue-861 leftovers). On the self-hosted Windows runner (case-insensitive NTFS, default `files` ref backend) git cannot store both refs on disk, so the fetch aborted; checkout's retry then hit `--unshallow on a complete repository does not make sense` and the whole release job died.

The two colliding branches have since been deleted, which unblocked v4.148.5. This PR makes the workflow **immune to the failure mode** so a future case-only branch name can't break a release.

## Fix

The notes step (added in #979) only needs **tags + history** for `git describe`, not branch heads. So:

1. Replace `fetch-depth: 0` with the **default shallow checkout** — `actions/checkout` then fetches only the single triggering ref and **never pulls `refs/heads/*`**.
2. Add an explicit step that fetches **tags only**:
   ```
   git fetch --prune --no-tags --depth=2147483647 origin "+refs/tags/*:refs/tags/*"
   ```
   - Only `refs/tags/*` is fetched → no branch heads → no case-collision surface.
   - A large `--depth` fully deepens history whether the repo is currently shallow or already complete — unlike `--unshallow`, which errors once a prior fetch has completed the repo (the secondary failure above).

## Validation

Core git logic verified locally against the live tags:

- `git describe --tags --abbrev=0 v4.148.5^` → `v4.148.4` (the notes step's previous-tag resolution still works).
- `git fetch --no-tags --dry-run origin "+refs/tags/*:refs/tags/*"` → exit 0 (refspec well-formed).

**Note:** like #979, the full workflow wiring only executes on a real tag push, so it gets its true end-to-end test on the next release tag.