### PR TITLE
Issue #23: Ctrl-V in DX cluster field + cluster I/O threading refactor, crash fix, connect UX

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -211,6 +211,7 @@ procedure ImportFromADIF;
 procedure StartNewContest;
 procedure CheckQuestionMark;
 function Get101Window(h: HWND): HWND;
+function TelnetWantsClipboardKey(const aMsg: TMsg): boolean;   // Issue #23
 procedure InvertBooleanCommand(Command: PBoolean);
 procedure RunExplorer(Command: PChar);
 procedure OpenInDefaultTextEditor(FileName: PChar);   // Issue #986
@@ -8186,6 +8187,39 @@ begin
      Format(cmdBuf, 'Notepad %s', FileName);
      WinExec(cmdBuf, SW_SHOWNORMAL);
      end;
+end;
+
+// Issue #23 -- let the DX Cluster window's command field handle the standard
+// clipboard/edit keys (Ctrl-C/V/X, plus Select-All/Undo) itself, instead of the
+// main accelerator table stealing them (Ctrl-V = Execute Config File, Ctrl-C =
+// Clear Mult Sheet).  Returns True when aMsg is one of those keystrokes AND
+// focus is inside the telnet (cluster) window, so the main loop can skip
+// TranslateAccelerator and let the keystroke reach the edit via DispatchMessage.
+// Deliberately scoped to the telnet window only for now so other windows can be
+// vetted separately before extending this behavior.
+function TelnetWantsClipboardKey(const aMsg: TMsg): boolean;
+var
+   hTelnet: HWND;
+begin
+   Result := False;
+   if aMsg.message <> WM_KEYDOWN then Exit;
+   if (GetKeyState(VK_CONTROL) and $8000) = 0 then Exit;   // Ctrl not held
+   case aMsg.wParam of
+      Ord('A'), Ord('C'), Ord('V'), Ord('X'), Ord('Z'): ;   // clipboard / edit keys
+   else
+      Exit;
+   end;
+
+   hTelnet := tr4w_WindowsArray[tw_TELNETWINDOW_INDEX].WndHandle;
+   if hTelnet = 0 then Exit;
+   if aMsg.hwnd = hTelnet then
+      begin
+      Result := True;
+      end
+   else if IsChild(hTelnet, aMsg.hwnd) then
+      begin
+      Result := True;
+      end;
 end;
 
 procedure RunOptionsDialog(f: CFGFunc);

--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -2769,6 +2769,7 @@ var
   TR4W_HAMLIB_DEBUG                     : boolean;
   TR4W_HAMLIB_ASYNC_ONLY                : boolean;  // Disable heartbeat — async callbacks only (testing)
   TR4W_HAMLIB_TRACE                     : boolean;  // Enable HamLib internal trace → target/hamlib_trace.log
+  TR4W_TELNET_DEBUG                     : boolean;  // Issue #23 — log all DX cluster I/O + telnet-window writes (INFO, gated)
 
   TR4W_LC_FILENAME                      : PChar = 'LUCONSZ.TTF';
 

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -6,7 +6,7 @@
  const
   TC_TRANSLATION_LANGUAGE               = 'ENGLISH';
   TC_TRANSLATION_AUTHOR                 = 'N4AF';
-  TC_TRANSLATOR_EMAIL                   = 'tr4w@qrz.ru';
+  TC_TRANSLATOR_EMAIL                   = 'ny4i@ny4i.com';
   TC_WAGWarn                            = 'Warning: Out of WAG allowed frequency range';
   TC_FREQ                               = 'Freq';
   TC_POINTS                             = 'Pts';
@@ -184,7 +184,7 @@
   {UTELNET}
 
   TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Freeze'#0'Clear'#0'100'#0#0;
-  TC_YOURNOTCONNECTEDTOTHEINTERNET      = 'YOUR NOT CONNECTED TO THE INTERNET!';
+  TC_YOURNOTCONNECTEDTOTHEINTERNET      = 'YOU ARE NOT CONNECTED TO THE INTERNET!';
   TC_GETHOST                            = 'GET HOST..';
   TC_SERVER                             = 'SERVER: %s';
   TC_HOST                               = 'HOST  : %s';

--- a/tr4w/src/uCFG.pas
+++ b/tr4w/src/uCFG.pas
@@ -362,6 +362,7 @@ const
    + 1 {HAMSCORE SEND CONTACT INFO}  // Issue #931
    + 1 {MY ITU ZONE}  // Issue #930 -- explicit override of CTY.DAT default for multi-zone countries
    + 2 {PSTROTATOR IP ADDRESS + PSTROTATOR UDP PORT}  // Issue #732
+   + 1 {TELNET DEBUG}  // Issue #23
    ;
 
    // Note if crAddress says pointer(NN), then it is calling a function at position NN in the an array
@@ -807,6 +808,7 @@ const
 // (crCommand: 'TAIL END KEY';                  crAddress: @TailEndKey;                     crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctChar; crNetwork: 1),         // n4af 4.41.5
  //(crCommand: 'TAIL END MESSAGE';              crAddress: @TailEndMessage;                 crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 3; crKind: ckNormal;  cfFunc: cfAll; crType: ctMessage; crNetwork: 1),
 // (crCommand: 'TAIL END SSB MESSAGE';          crAddress: @TailEndPhoneMessage;            crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:0 ; crP:0; crJ: 3; crKind: ckNormal;  cfFunc: cfAll; crType: ctMessage; crNetwork: 1),
+ (crCommand: 'TELNET DEBUG';                  crAddress: @TR4W_TELNET_DEBUG;              crMin:0;  crMax:0;       crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal;  cfFunc: cfAll; crType: ctBoolean; crNetwork: 0),   // Issue #23
  (crCommand: 'TELNET SERVER';                 crAddress: @TelnetServer;                   crMin:0;  crMax:255;     crS: csNew; crA: 0; crC:0 ; crP:0; crJ: 1; crKind: ckNormal;   cfFunc: cfAll; crType: ctString; crNetwork: 1),
  (crCommand: 'TEN MINUTE RULE';               crAddress: pointer(18);                     crMin:0;  crMax:0;       crS: csOld; crA: 0; crC:1 ; crP:0; crJ: 0; crKind: ckList; cfFunc: cfAll; crType: ctOther; crNetwork: 1),
  (crCommand: 'TOTAL OFF TIME';                crAddress: nil;                             crMin:0;  crMax:0;       crS: csRem; crA: 0; crC:0 ; crP:0; crJ: 0; crKind: ckNormal; cfFunc: cfAll; crType: ctInteger; crNetwork: 1),

--- a/tr4w/src/uTelnet.pas
+++ b/tr4w/src/uTelnet.pas
@@ -76,10 +76,11 @@ var
 procedure SendClientStatus;
 function TelnetWndDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam:
   lParam): BOOL; stdcall;
-procedure ConnectToTelnetCluster;
+function TelnetThreadProc(Param: Pointer): DWORD; stdcall;   // Issue #23 -- DX cluster I/O thread
+procedure StartTelnetConnect;                                // Issue #23 -- main-thread launcher
 procedure Disconnect;
 function TestSocketBuffer: Integer; // Gav 4.44.6
-procedure TelnetConnectionError;
+procedure TelnetConnectionError(wsaErr: integer);            // Issue #23 -- explicit code (marshaled)
 function SendViaTelnetSocket(p: PChar): integer;
 procedure AddStringToTelnetConsole(p: PChar; c: TelnetStringType);
 procedure SaveTelnetWindowSpots;
@@ -210,6 +211,9 @@ var
   OldTelnetFreezeMode: boolean;
   TelnetFreezeMode: boolean;
   TelThreadID: Cardinal;
+  TelThreadHandle: THandle;     // Issue #23 -- kept so we can join the I/O thread before teardown
+  TelnetStopRequested: boolean; // Issue #23 -- set by Disconnect so a thread that is still
+                                // connecting bails out after connect instead of orphaning
   TelnetSock: Cardinal;
   TelToolbar: HWND;
   TelnetListBox: HWND;
@@ -226,6 +230,29 @@ uses uNet,
   uBandmap,
   LogGrid,
   MainUnit;
+
+// Issue #23 -- DX cluster I/O thread <-> main-thread message protocol.  The
+// cluster thread does ALL blocking network I/O (connect + recv) and never
+// touches UI or shared spot/bandmap state; it only posts these to the telnet
+// window, which does that work on the main (UI) thread.  Declared here so both
+// TelnetWndDlgProc (handler) and TelnetThreadProc (sender) see them.
+const
+  WM_TELNET_MSG         = WM_USER + 250;
+  TELNET_CONNECTED      = 1;   // lParam = 0
+  TELNET_CONNECT_FAILED = 2;   // lParam = WSA error code
+  TELNET_DATA           = 3;   // lParam = PTelnetChunk (handler disposes it)
+  TELNET_CLOSED         = 4;   // lParam = WSA error code (0 = graceful close)
+
+type
+  PTelnetChunk = ^TTelnetChunk;
+  TTelnetChunk = record
+    Len:  integer;
+    Data: array[0..8192] of Char;
+  end;
+
+var
+  PendingTelnetHost: array[0..255] of Char;   // set on the main thread before the I/O thread starts
+  PendingTelnetPort: Word;
 
 // ---------------------------------------------------------------------------
 //  Issue #973 - field substitution in cluster_commands.txt
@@ -484,11 +511,16 @@ var
   TempTextColor: Cardinal;
   TempPoint: TPoint;
   TDIS: PDrawItemStruct;
-  InfoBuffer: array[0..127] of Char;
+  InfoBuffer: array[0..1023] of Char;   // Issue #23 -- LB_GETTEXT has no size limit; must hold the
+                                        // longest list item (error messages run ~230 chars, far past
+                                        // the old 128, overrunning the stack).  AddStringToTelnetConsole
+                                        // caps items to this size so this read can never overrun.
   StringType: TelnetStringType;
   ExpandedClusterCommand: AnsiString;   { Issue #973 }
 const
-  TelnetStringColor: array[TelnetStringType] of tr4wColors = (trGreen, trBlue,
+  // Issue #23 -- tstTR4W (status messages) was green for no real reason; show it
+  // as normal black text.  Errors stay red.
+  TelnetStringColor: array[TelnetStringType] of tr4wColors = (trBlack, trBlue,
     trBlack, trLightGray, trRed, trRed, trBlack);
   //  TelnetStringOffset                    : array[TelnetStringType] of integer = (15, 2, 15, 15, 15, 20, 15);
 begin
@@ -528,42 +560,73 @@ begin
 
     WM_WINDOWPOSCHANGING, WM_EXITSIZEMOVE: DefTR4WProc(Msg, lParam, hwnddlg);
 
-    WM_SOCK:
+    // Issue #23 -- messages from the DX cluster I/O thread (TelnetThreadProc).
+    // All UI and spot/bandmap processing happen here, on the main thread.
+    WM_TELNET_MSG:
       begin
-        i := recv(TelnetSock, TelnetBuffer, SizeOf(TelnetBuffer) - 1, 0);
-        if i < 1 then
-          if WindowsOSversion = VER_PLATFORM_WIN32_NT then
-          begin
-            TelnetConnectionError;
-            Disconnect;
-            Exit;
-          end;
+        case wParam of
+          TELNET_CONNECTED:
+            begin
+              if TR4W_TELNET_DEBUG then
+                 begin
+                 logger.Info('[Telnet] Connected to %s:%d', [PChar(@PendingTelnetHost[0]), PendingTelnetPort]);
+                 end;
+              Format(wsprintfBuffer, '%s%s:%u', TC_CONNECTEDTO,
+                @PendingTelnetHost[0], PendingTelnetPort);
+              AddStringToTelnetConsole(wsprintfBuffer, tstTR4W);
+              Windows.ZeroMemory(@TelnetBuffer, SizeOf(TelnetBuffer));
+              if ConnectionCommand <> '' then
+                 SendViaTelnetSocket(@ConnectionCommand[1])
+              else
+                 SetDlgItemText(hwnddlg, 106, @MyCall[1]);
+              SendClientStatus;
+              EnableTelnetToolbatButtons(True);
+              EnableWindowTrue(hwnddlg, 104);
+            end;
 
-        //   showmessage(@TelnetBuffer);
+          TELNET_CONNECT_FAILED:
+            begin
+              // Issue #23 -- keep the detailed WinSock reason in the log for
+              // diagnostics, but show the operator a short message naming the
+              // host they tried to reach (the raw message is long and unwrapped).
+              logger.Error('[Telnet] Could not connect to %s:%d -- WinSock %d: %s',
+                [PChar(@PendingTelnetHost[0]), PendingTelnetPort, lParam,
+                 SysErrorMessage(lParam)]);
+              Format(wsprintfBuffer, '%s%s:%u', TC_FAILEDTOCONNECTTO,
+                @PendingTelnetHost[0], PendingTelnetPort);
+              AddStringToTelnetConsole(wsprintfBuffer, tstError);
+              Disconnect;
+            end;
 
-        TelnetBuffer[i] := #0;
-        spotcnt := spotcnt + 1;       // beta test alleviate # screen writes
-        if spotcnt = 1 then
-        begin
-          move(TelnetBuffer[0], SpotsBuffer[0], i);
-          spotcnt := spotcnt + 1;
-          exit;
-        end
-        else
-        begin
-          spotcnt := 0;
-          ProcessTelnetString(i);
-          move(SpotsBuffer[0], TelnetBuffer[0], i);
-          ProcessTelnetString(i);
+          TELNET_DATA:
+            begin
+              if lParam <> 0 then
+                 begin
+                 Move(PTelnetChunk(lParam)^.Data[0], TelnetBuffer[0],
+                      PTelnetChunk(lParam)^.Len);
+                 // Issue #23 -- null-terminate like the old recv path did
+                 // (TelnetBuffer[i] := #0); ProcessTelnetString treats it as a
+                 // C string, so without this it reads past Len into stale data.
+                 TelnetBuffer[PTelnetChunk(lParam)^.Len] := #0;
+                 ProcessTelnetString(PTelnetChunk(lParam)^.Len);
+                 Dispose(PTelnetChunk(lParam));
+                 end;
+            end;
 
-       end;                               // end beta
-
-        //Except on E : Exception do
-       //    begin
-           //TLogger.GetInstance.Debug(Format('ProcessTelnet Exception, %s error raised, with message <%s> ',[E.ClassName,E.Message]));
-       //    end;
-        //end;
-
+          TELNET_CLOSED:
+            begin
+              // Ignore if the user already disconnected (TelnetSock cleared);
+              // otherwise this is a server-initiated / network close.
+              if TelnetSock <> 0 then
+                 begin
+                 if lParam <> 0 then
+                    begin
+                    TelnetConnectionError(lParam);
+                    end;
+                 Disconnect;
+                 end;
+            end;
+        end;
       end;
 
     WM_INITDIALOG:
@@ -725,13 +788,7 @@ begin
 {$IFEND}
 
           //          DialogBox(hInstance, MAKEINTRESOURCE(44), hwnddlg, @SpotsFilterDlgProc);
-          200: if TelThreadID = 0 then
-            begin
-              logger.Debug('Calling tCreateThread from TelnetThread');
-              tCreateThread(@ConnectToTelnetCluster, TelThreadID);
-              logger.Debug('Created Telnet (Cluster)  thread with threadid of %d', [TelThreadID]);
-              //              ConnectToTelnetCluster;
-            end;
+          200: StartTelnetConnect;   // Issue #23 -- launch the DX cluster I/O thread
 
           104:
             begin
@@ -814,112 +871,227 @@ begin
   end;
 end;
 
-procedure ConnectToTelnetCluster;
+// Runs on the DX cluster I/O thread.  Connects (blocking), then loops on
+// blocking recv, posting each chunk to the telnet window.  Posts CONNECTED /
+// CONNECT_FAILED / CLOSED for lifecycle.  Does NO UI and touches NO shared
+// contest/bandmap state -- that all happens on the main thread in the handler.
+function TelnetThreadProc(Param: Pointer): DWORD; stdcall;
 var
-
-  StackTelHandle: HWND;
-
-  port: Word;
-  i: integer;
-
-label
-  processed;
+  localSock: DWORD;
+  n:         integer;
+  wnd:       HWND;
+  chunk:     PTelnetChunk;
+  recvBuf:   array[0..8191] of Char;
 begin
+  Result := 0;
+  wnd := tr4w_WindowsArray[tw_TELNETWINDOW_INDEX].WndHandle;
+
+  if TR4W_TELNET_DEBUG then
+     begin
+     logger.Info('[Telnet] Connecting to %s:%d', [PChar(@PendingTelnetHost[0]), PendingTelnetPort]);
+     end;
+
+  if not GetConnection(localSock, PendingTelnetHost, PendingTelnetPort, SOCK_STREAM) then
+     begin
+     PostMessage(wnd, WM_TELNET_MSG, TELNET_CONNECT_FAILED, WSAGetLastError);
+     Exit;
+     end;
+
+  // Issue #23 -- if Disconnect/window-close happened while we were blocked in
+  // connect, bail out now (closing the freshly-connected socket) instead of
+  // publishing it and entering the recv loop -- avoids an orphaned thread/socket.
+  if TelnetStopRequested then
+     begin
+     closesocket(localSock);
+     Exit;
+     end;
+
+  TelnetSock := localSock;   // publish for the send path (main thread); recv uses localSock
+  PostMessage(wnd, WM_TELNET_MSG, TELNET_CONNECTED, 0);
+
+  while True do
+     begin
+     n := recv(localSock, recvBuf, SizeOf(recvBuf) - 1, 0);
+     if n < 1 then
+        begin
+        // 0 = graceful close, < 0 = error (incl. a Disconnect that closed the
+        // socket out from under us).  Report and end the thread.
+        PostMessage(wnd, WM_TELNET_MSG, TELNET_CLOSED, WSAGetLastError);
+        Break;
+        end;
+
+     New(chunk);
+     chunk^.Len := n;
+     Move(recvBuf[0], chunk^.Data[0], n);
+     chunk^.Data[n] := #0;
+     if TR4W_TELNET_DEBUG then
+        begin
+        logger.Info('[Telnet RX %d] %s', [n, PChar(@chunk^.Data[0])]);
+        end;
+     PostMessage(wnd, WM_TELNET_MSG, TELNET_DATA, LPARAM(chunk));
+     end;
+end;
+
+// Runs on the MAIN thread (Connect button).  Reads host:port from the dialog
+// (UI access stays on the UI thread), then spawns the I/O thread.
+procedure StartTelnetConnect;
+var
+  StackTelHandle: HWND;
+  i: integer;
+begin
+  if TelThreadID <> 0 then
+     begin
+     Exit;   // already connecting / connected
+     end;
+
   StackTelHandle := tr4w_WindowsArray[tw_TELNETWINDOW_INDEX].WndHandle;
-  port := 23;
-  i := Windows.GetDlgItemText(StackTelHandle, 102, TempBuffer1,
-    SizeOf(TempBuffer1));
+  PendingTelnetPort := 23;
+  i := Windows.GetDlgItemText(StackTelHandle, 102, TempBuffer1, SizeOf(TempBuffer1));
 
-  while i <> 0 do
-  begin
-    if TempBuffer1[i] = ':' then
-    begin
-      port := pchartoint(@TempBuffer1[i + 1]);
-      TempBuffer1[i] := #0;
-    end;
-    if TempBuffer1[i] = ' ' then //ny4i 4.43.5 plus this bug fix.
-    begin
-      TempBuffer1[i] := #0;
-    end;
-    dec(i);
-  end;
+  // TempBuffer1 is 0-based; scan [length-1 .. 0].  ':' splits host:port; ' '
+  // terminates the host.
+  dec(i);
+  while i >= 0 do
+     begin
+     if TempBuffer1[i] = ':' then
+        begin
+        PendingTelnetPort := pchartoint(@TempBuffer1[i + 1]);
+        TempBuffer1[i] := #0;
+        end;
+     if TempBuffer1[i] = ' ' then
+        begin
+        TempBuffer1[i] := #0;
+        end;
+     dec(i);
+     end;
 
-  if not GetConnection(TelnetSock, TempBuffer1, port, SOCK_STREAM) then
+  Windows.lstrcpyn(PendingTelnetHost, TempBuffer1, SizeOf(PendingTelnetHost));
 
-  begin
-    TelnetConnectionError;
-    TelThreadID := 0;
-    Disconnect;
-    Exit;
-  end;
-
-  AddStringToTelnetConsole(TC_CONNECTED, tstTR4W);
-
-  if WSAAsyncSelect(TelnetSock, StackTelHandle, WM_SOCK, FD_READ or FD_CLOSE) <>
-    0 then
-  begin
-    TelnetConnectionError;
-    Disconnect;
-    Exit;
-  end;
-
-  //  ClusterTypeDetermined := False;
-  Windows.ZeroMemory(@TelnetBuffer, SizeOf(TelnetBuffer));
-  //  Status := SOCK_CLIENT;
-
-  if ConnectionCommand <> '' then
-    SendViaTelnetSocket(@ConnectionCommand[1])
-  else
-    SetDlgItemText(StackTelHandle, 106, @MyCall[1]);
-
-  SendClientStatus;
+  // Issue #23 -- immediate visual feedback so connect is not a black box:
+  // show the attempt in the window and switch the toolbar to the connected
+  // state (grays Connect, enables Disconnect) the instant the user clicks.
+  Format(wsprintfBuffer, '%s%s:%u', TC_CONNECTINGTO, @PendingTelnetHost[0],
+    PendingTelnetPort);
+  AddStringToTelnetConsole(wsprintfBuffer, tstTR4W);
   EnableTelnetToolbatButtons(True);
-  EnableWindowTrue(StackTelHandle, 104);
-  //  tEnableMenuItem(menu_ctrl_sendspot, MF_ENABLED);
-  processed:
 
+  // Issue #23 -- start each session live: a Freeze left on from a previous
+  // connection would silently suppress auto-scroll on reconnect, looking like
+  // the cluster is dead.  Clear the mode and un-press the Freeze toolbar button.
+  TelnetFreezeMode := False;
+  OldTelnetFreezeMode := False;
+  SendMessage(TelToolbar, TB_CHECKBUTTON, 203, 0);
+
+  TelnetStopRequested := False;
+  logger.Debug('Starting DX cluster I/O thread');
+  TelThreadHandle := tCreateThread(@TelnetThreadProc, TelThreadID);
+  logger.Debug('Created DX cluster thread with threadid of %d', [TelThreadID]);
 end;
 
 procedure Disconnect;
 var
   StackTelHandle: HWND;
 begin
+  if TR4W_TELNET_DEBUG then   // Issue #23 -- log every disconnect
+     begin
+     logger.Info('[Telnet] Disconnecting (socket %d)', [TelnetSock]);
+     end;
   StackTelHandle := tr4w_WindowsArray[tw_TELNETWINDOW_INDEX].WndHandle;
+
+  // Issue #23 -- show a disconnect message only if we were actually connected
+  // (TelnetSock <> 0).  A failed connect routes through here too but never
+  // connected, so "DISCONNECTED from" would be wrong there.
+  if TelnetSock <> 0 then
+     begin
+     Format(wsprintfBuffer, '%s%s:%u', TC_DISCONNECTEDFROM, @PendingTelnetHost[0],
+       PendingTelnetPort);
+     AddStringToTelnetConsole(wsprintfBuffer, tstTR4W);
+     end;
+
+  // Tell a still-connecting thread to bail (it checks this after connect, since
+  // we can't unblock its in-progress connect via the socket).
+  TelnetStopRequested := True;
+
+  // Close the socket first -- this unblocks the I/O thread's recv so it can
+  // exit -- then JOIN the thread before any teardown.  Without the join the
+  // main thread tore down (and kept allocating/logging) while the raw I/O
+  // thread was still terminating, which corrupted state and crashed.
   closesocket(TelnetSock);
+  TelnetSock := 0;
+  if TelThreadHandle <> 0 then
+     begin
+     WaitForSingleObject(TelThreadHandle, 5000);
+     CloseHandle(TelThreadHandle);
+     TelThreadHandle := 0;
+     end;
+  TelThreadID := 0;
+
   EnableWindowFalse(StackTelHandle, 104);
   EnableWindowTrue(StackTelHandle, 102);
   EnableTelnetToolbatButtons(False);
-  TelnetSock := 0;
-  TelThreadID := 0;
   //  tEnableMenuItem(menu_ctrl_sendspot, MF_BYCOMMAND + MF_GRAYED);
   SendClientStatus;
 end;
 
-procedure TelnetConnectionError;
+procedure TelnetConnectionError(wsaErr: integer);
+var
+  msg: PChar;
 begin
-  AddStringToTelnetConsole(SysErrorMessage(WSAGetLastError), tstError);
+  // Issue #23 -- log the WinSock error to the general error log always
+  // (independent of TELNET DEBUG) and show it in the telnet window.  The code is
+  // passed in (not read from WSAGetLastError) because it may have been captured
+  // on the I/O thread and marshaled here -- WSAGetLastError is per-thread.
+  msg := SysErrorMessage(wsaErr);
+  logger.Error('[Telnet] WinSock error %d: %s', [wsaErr, msg]);
+  AddStringToTelnetConsole(msg, tstError);
 end;
 
 function SendViaTelnetSocket(p: PChar): integer;
+var
+  sent: integer;
 begin
+  Result := 0;
   if TelnetSock = 0 then
     Exit;
+  if TR4W_TELNET_DEBUG then   // Issue #23
+     begin
+     logger.Info('[Telnet TX] %s', [p]);
+     end;
   AddStringToTelnetConsole(p, tstSend);
-  WinSock2.Send(TelnetSock, wsprintfBuffer, Format(wsprintfBuffer, '%s'#13#10,
-    p), 0);
-  Result := WSAGetLastError;
-  if Result <> 0 then
-    TelnetConnectionError;
+  // Issue #23 -- key off the send() return, not WSAGetLastError (which is only
+  // meaningful after SOCKET_ERROR and can read stale after a successful send,
+  // wrongly tearing down a healthy link).  Always runs on the main thread now,
+  // so a real failure can tear the dead socket down directly (closing it also
+  // unblocks the I/O thread's recv).
+  sent := WinSock2.Send(TelnetSock, wsprintfBuffer,
+    Format(wsprintfBuffer, '%s'#13#10, p), 0);
+  if sent = SOCKET_ERROR then
+  begin
+    Result := WSAGetLastError;
+    TelnetConnectionError(Result);
+    Disconnect;
+  end;
 end;
 
 procedure AddStringToTelnetConsole(p: PChar; c: TelnetStringType);
 var
   Handle: HWND;
+  buf: array[0..1023] of Char;   // Issue #23 -- bound the list item to InfoBuffer's size
 begin
+  if TR4W_TELNET_DEBUG then   // Issue #23 -- every line written to the telnet window
+     begin
+     logger.Info('[Telnet WINDOW t=%d] %s', [Ord(c), p]);
+     end;
+
   Handle := TelnetListBox;
 
+  // Issue #23 -- copy into a bounded buffer first.  The owner-draw handler reads
+  // each item back via LB_GETTEXT (which has no size limit) into a same-sized
+  // stack buffer; capping here guarantees that read can never overrun the stack.
+  Windows.lstrcpyn(buf, p, SizeOf(buf));
+
   SendMessage(Handle, LB_SETITEMDATA, SendMessage(Handle, LB_ADDSTRING, 0,
-    integer(p)), integer(c));
+    integer(@buf)), integer(c));
 
   if TelnetFreezeMode then
     Exit;

--- a/tr4w/src/utils/utils_net.pas
+++ b/tr4w/src/utils/utils_net.pas
@@ -18,15 +18,21 @@ function GetConnection(var socket: DWORD; Host: PChar; port: Cardinal; struct: i
 var
   TempSockaddr                          : sockaddr_in;
   TempHostent                           : Phostent;
+  connErr                               : integer;   // Issue #23
 //  Protocol                              : integer;
 begin
   Result := False;
+  // Issue #23 -- never hand the caller a stale/garbage or already-closed handle
+  // on any failure path.  Every caller tests Result and several closesocket()
+  // unconditionally; INVALID_SOCKET makes that a safe no-op.
+  socket := INVALID_SOCKET;
 
   if not WindowsSocketsInitialised then
     WindowsSocketsInitialised := WSAStartup($0202, WSData) = 0;
+  if not WindowsSocketsInitialised then Exit;   // WinSock unavailable
 
   TempHostent := WinSock2.gethostbyname(Host);
-  if TempHostent = nil then Exit;
+  if TempHostent = nil then Exit;               // name resolution failed
 
   TempSockaddr.sa_family := AF_INET;
   TempSockaddr.sin_addr.S_addr := inet_addr(iNet_ntoa(PInAddr(TempHostent^.h_addr_list^)^));
@@ -34,11 +40,19 @@ begin
 
 //  if struct = SOCK_DGRAM then Protocol := IPPROTO_UDP{IPPROTO_IP} else Protocol := IPPROTO_TCP;
   socket := WinSock2.socket(AF_INET, struct, IPPROTO_IP {Protocol});
+  if socket = INVALID_SOCKET then Exit;          // socket creation failed
 
   Result := WinSock2.Connect(socket, @TempSockaddr, SizeOf(TSockAddrIn)) = 0;
   if not Result then
   begin
+    // Issue #23 -- closesocket() resets WSAGetLastError to 0 (its own success),
+    // wiping the real connect error before the caller can read it (which is why
+    // a failed connect reported "The operation completed successfully").
+    // Capture the connect error and restore it after the cleanup.
+    connErr := WSAGetLastError;
     closesocket(socket);
+    socket := INVALID_SOCKET;                    // closed -- don't expose the dead handle
+    WSASetLastError(connErr);
   end;
 end;
 

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -911,7 +911,12 @@ begin
   while (GetMessage(Msg, 0, 0, 0)) do
   begin
 
-    if TranslateAccelerator(tr4whandle, tr4w_accelerators, Msg) <> 0 then
+    // Issue #23 -- when a clipboard/edit key (Ctrl-C/V/X/A/Z) is pressed with
+    // the DX Cluster command field focused, skip the main accelerator table so
+    // the keystroke reaches the field (e.g. Ctrl-V pastes) instead of firing
+    // Execute Config File / Clear Mult Sheet.
+    if (not TelnetWantsClipboardKey(Msg)) and
+       (TranslateAccelerator(tr4whandle, tr4w_accelerators, Msg) <> 0) then
     begin
       asm nop end;
       goto NoTransMess;


### PR DESCRIPTION
Closes #23.

Two commits in one PR.

## 1. Ctrl-V / clipboard keys in the DX Cluster command field (the #23 ask)
The global accelerator table (Ctrl-V = Execute Config File, Ctrl-C = Clear Mult Sheet) stole the standard clipboard/edit keys before the focused field saw them, so paste/copy/cut didn't work in the cluster command combobox (only right-click Paste did). `TelnetWantsClipboardKey` (MainUnit) returns True when **Ctrl-C/V/X/A/Z** is pressed with focus inside the telnet window; the main loop (`tr4w.dpr`) skips `TranslateAccelerator` for those so the keystroke reaches the edit natively. Scoped to the telnet window only.

## 2. DX cluster I/O on its own thread, crash fix, connect UX
**Threading** — the cluster now does all blocking network I/O (connect + recv) on a dedicated thread that posts results to the telnet window; all UI and spot/bandmap processing stay on the main thread. Replaces the old inverted model (connect on a throwaway worker that poked UI; recv on the main thread via `WSAAsyncSelect`/`WM_SOCK`). Thread is joined on teardown; a stop flag bails a still-connecting thread on window close.

**Crash fix** — `WM_DRAWITEM` read list items via `LB_GETTEXT` into a 128-byte buffer; a long error line (~230 chars) overran the stack and corrupted an adjacent `AnsiString` -> AV in `_LStrClr`. `InfoBuffer` enlarged and `AddStringToTelnetConsole` caps each item, protecting every `LB_GETTEXT` reader (also fixes a latent overrun in `SaveTelnetWindowSpots`). Restored the `TelnetBuffer` null terminator.

**GetConnection** (`utils_net`) — reset the socket to `INVALID_SOCKET` on every failure path, check `WSAStartup`/`socket()`, and preserve the real connect error across `closesocket` via `WSASetLastError` (a failed connect previously reported "operation completed successfully").

**Diagnostics / UX** — new `TELNET DEBUG` config flag gating INFO logging of RX/TX/window/connect/disconnect; WinSock errors always to the error log with the correct code. Connect gives immediate feedback (status line + Connect grays / Disconnect enables); connect/connected/disconnected/failed messages reuse `TC_` constants for i18n; status text is black (was green); Freeze resets per connection. Plus an ENG consts typo fix.

## Testing
- Ctrl-V/C/X paste/copy/cut in the cluster command field; main-window Ctrl-V/Ctrl-C unchanged.
- Connect success/failure/timeout (correct error + friendly message), disconnect, server-side drop, window close while connected.
- Crash repro (long timeout error) no longer crashes; confirmed root cause with the debugger (`_LStrClr` on corrupted `AnsiString`).
- DX-cluster simulator at ~32 spots/sec: no bandmap flashing, correct thread split (RX on I/O thread, parse/window on main), freeze + disconnect clean.
- Built clean across all 9 languages.
