### PR TITLE
Issue 1001: right-click a function key to edit that key's message

### DIFF
--- a/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
+++ b/tr4w/src/lang/TR4W_CONSTS_ESP.PAS
@@ -1312,6 +1312,7 @@ const
 //  RC_SAVEINFOLDER                       = 'Salvar en directorio ''[año][concurso][indicativo] ''';
   RC_CONFFILE                           = 'Fichero configuracion';
   RC_EDITQSO                            = 'Editar QSO';
+  TC_EDITFUNCTIONKEY                    = 'Editar %s Mensaje';
   RC_DELETED                            = '&Borrados';
   RC_DUPE                               = 'Duplicado';
   RC_LOGSEARCH                          = 'Busqueda en el Log';

--- a/tr4w/src/lang/TR4W_CONSTS_SER.pas
+++ b/tr4w/src/lang/TR4W_CONSTS_SER.pas
@@ -727,6 +727,7 @@ const
   RC_ABOUT                              = 'O programu';
   RC_CONFFILE                           = 'Konfiguraciona datoteka';
   RC_EDITQSO                            = 'Izmeni QSO';
+  TC_EDITFUNCTIONKEY                    = 'Izmeni %s Poruka';
   RC_DELETED                            = '&Obrisano';
   RC_DUPE                               = 'Dupla';
 //  RC_LOGSEARCH                          = 'Log search';

--- a/tr4w/src/lang/tr4w_consts_chn.pas
+++ b/tr4w/src/lang/tr4w_consts_chn.pas
@@ -669,6 +669,7 @@ const
   RC_ABOUT                              = 'х≈¶ф¶ќ';
   RC_CONFFILE                           = 'щ≈Ќч-оц÷«фђ¶';
   RC_EDITQSO                            = 'ч-÷ш-—QSO';
+  TC_EDITFUNCTIONKEY                    = 'Edit %s message';
   RC_DELETED                            = 'х»ащўд&D';
   RC_DUPE                               = 'щ‘ўшпп';
   RC_LOGSEARCH                          = 'ц„ехђ„ц–№ч+в';

--- a/tr4w/src/lang/tr4w_consts_cze.pas
+++ b/tr4w/src/lang/tr4w_consts_cze.pas
@@ -721,6 +721,7 @@ const
   RC_ABOUT                              = 'O programu TR4W';
   RC_CONFFILE                           = 'Konfiguraèní soubor';
   RC_EDITQSO                            = 'Edituj QSO';
+  TC_EDITFUNCTIONKEY                    = 'Edituj %s zprávu';
   RC_DELETED                            = '&Smazáno';
   RC_DUPE                               = 'duplicitní';
 //  RC_LOGSEARCH                          = 'Prohledat deník';

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -724,6 +724,7 @@
   RC_ABOUT                              = 'About';
   RC_CONFFILE                           = 'Configuration file';
   RC_EDITQSO                            = 'Edit QSO';
+  TC_EDITFUNCTIONKEY                    = 'Edit %s message';
   RC_DELETED                            = 'Deleted';
   RC_DUPE                               = 'Dupe';
 //  RC_LOGSEARCH                          = 'Log search';

--- a/tr4w/src/lang/tr4w_consts_ger.pas
+++ b/tr4w/src/lang/tr4w_consts_ger.pas
@@ -720,6 +720,7 @@
   RC_ABOUT                              = 'ueber';
   RC_CONFFILE                           = 'Konfigurationsdatei';
   RC_EDITQSO                            = 'Editiere QSO';
+  TC_EDITFUNCTIONKEY                    = 'Editiere %s Nachricht';
   RC_DELETED                            = 'Geloescht';
   RC_DUPE                               = 'Dupe';
 //  RC_LOGSEARCH                          = 'Log search';

--- a/tr4w/src/lang/tr4w_consts_mng.pas
+++ b/tr4w/src/lang/tr4w_consts_mng.pas
@@ -597,6 +597,7 @@ const
   RC_SAVEINFOLDER  			 			= 'Хавтас нээж хадгалах уу  (огноо,тэмцээн, дуудлага)';
   RC_CONFFILE                           = 'Тохируулгын файл';
   RC_EDITQSO                            = 'Холбоогоо засварлах';
+  TC_EDITFUNCTIONKEY                    = 'Edit %s message';
   RC_DELETED                            = '&Устгах';
   RC_DUPE                               = 'Давтагдсан ХОЛБОО!!!';
   RC_LOGSEARCH                          = 'Дуудлага хайх';

--- a/tr4w/src/lang/tr4w_consts_pol.pas
+++ b/tr4w/src/lang/tr4w_consts_pol.pas
@@ -667,6 +667,7 @@ const
   RC_ABOUT                              = 'Na temat';
   RC_CONFFILE                           = 'Plik konfiguracyjny';
   RC_EDITQSO                            = 'Edytuj QSO';
+  TC_EDITFUNCTIONKEY                    = 'Edytuj %s WiadomoÜö';
   RC_DELETED                            = '&Usuniúte';
   RC_DUPE                               = 'Powtºrka';
   RC_LOGSEARCH                          = 'Wyszukiwanie w logu';

--- a/tr4w/src/lang/tr4w_consts_rom.pas
+++ b/tr4w/src/lang/tr4w_consts_rom.pas
@@ -684,6 +684,7 @@ const
   RC_ABOUT                              = 'Despre';
   RC_CONFFILE                           = 'Fisier de configurare';
   RC_EDITQSO                            = 'Editeaza QSO';
+  TC_EDITFUNCTIONKEY                    = 'Editeaza %s Mesaj';
   RC_DELETED                            = '&Sters';
   RC_DUPE                               = 'Dubla';
   RC_LOGSEARCH                          = 'Cauta in log';

--- a/tr4w/src/lang/tr4w_consts_rus.pas
+++ b/tr4w/src/lang/tr4w_consts_rus.pas
@@ -680,6 +680,7 @@ const
   RC_ABOUT                              = 'О программе';
   RC_CONFFILE                           = 'Файл конфигурации';
   RC_EDITQSO                            = 'Редактирование связи';
+  TC_EDITFUNCTIONKEY                    = 'Редактирование %s Сообщение';
   RC_DELETED                            = '&Удалена';
   RC_DUPE                               = 'Повтор';
   RC_LOGSEARCH                          = 'Поиск в логе';

--- a/tr4w/src/lang/tr4w_consts_ukr.pas
+++ b/tr4w/src/lang/tr4w_consts_ukr.pas
@@ -682,6 +682,7 @@ TC_TELNET                             = 'Connect'#0'Disconnect'#0'Commands'#0'Fr
   RC_ABOUT                              = 'Про програму';
   RC_CONFFILE                           = 'Файл конфігурації';
   RC_EDITQSO                            = 'Редагування зв`язку';
+  TC_EDITFUNCTIONKEY                    = 'Редагування %s Повідомлення';
   RC_DELETED                            = '&Видалена';
   RC_DUPE                               = 'Повтор';
   RC_LOGSEARCH                          = 'Пошук у лозі';

--- a/tr4w/src/uAltP.pas
+++ b/tr4w/src/uAltP.pas
@@ -83,6 +83,11 @@ var
   ReminderDlgHandle                     : HWND;
   AltPListView                          : HWND;
   LastSelectedMessage                   : integer;
+  // Row to pre-select when the dialog next opens (0 = F1, the historical
+  // default). A caller -- e.g. right-click on a function-key button -- sets
+  // this just before OpenListOfMessages to jump straight to that key; the
+  // dialog consumes and resets it on WM_INITDIALOG. Issue #1001.
+  InitialAltPSelection                  : integer;
 
 implementation
 uses MainUnit;
@@ -106,7 +111,10 @@ begin
 
     WM_INITDIALOG:
       begin
-        LastSelectedMessage := 0;
+        // Honor a caller-requested initial row (Issue #1001), then reset to the
+        // default so a subsequent plain open (Alt-P) lands on F1 as before.
+        LastSelectedMessage := InitialAltPSelection;
+        InitialAltPSelection := 0;
         AltWnd := hwnddlg;
 //        AltPListView := Get101Window(hwnddlg);
 

--- a/tr4w/src/uFunctionKeys.pas
+++ b/tr4w/src/uFunctionKeys.pas
@@ -39,6 +39,8 @@ utils_text,
 function FunctionKeysWindowDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
 procedure ShowFMessages(VirtualKey: Byte);
 procedure GetButtonByRDblClick(h: HWND);
+procedure EditFunctionKeyMessage(h: HWND);
+procedure ShowFunctionKeyContextMenu(h: HWND);
 
 const
   ButtonsColor                          : array[112..123] of tcolor =
@@ -276,20 +278,117 @@ begin
   end;
 end;
 
-procedure GetButtonByRDblClick(h: HWND);
+// Resolve which Alt-P editor row the on-screen function-key button `h` maps to,
+// and set the CQ vs S&P target window. The 12 buttons are labelled F1..F12 but
+// display whichever shift bank the window currently shows (plain / Ctrl / Alt),
+// so we read the live modifier state. The editor lists F1..AltF12, hence
+// row = (button - 112) + bank offset (0/12/24). Returns -1 if `h` is not a
+// function-key button. Caller must capture this BEFORE the modifier is released
+// (e.g. before popping a menu). Issue #1001.
+function ResolveFunctionKeyRow(h: HWND): integer;
 var
   i                                     : integer;
+  plus                                  : integer;
 begin
+  Result := -1;
   for i := 112 to 123 do
-    if h = KeysHandles[i] then
-    begin
-      if OpMode = SearchAndPounceOpMode then
-        MesWindow := ExMsgWin
-      else
-        MesWindow := CQMsgWin;
-//      tDialogBox(72, @MemoryProgramDlgProc);
-      OpenListOfMessages;
-    end;
+     begin
+     if h = KeysHandles[i] then
+        begin
+        if OpMode = SearchAndPounceOpMode then
+           MesWindow := ExMsgWin
+        else
+           MesWindow := CQMsgWin;
+        plus := 0;
+        if (GetKeyState(VK_MENU) and $8000) <> 0 then
+           plus := 24
+        else if (GetKeyState(VK_CONTROL) and $8000) <> 0 then
+           plus := 12;
+        Result := (i - 112) + plus;
+        Break;
+        end;
+     end;
+end;
+
+// Open the Alt-P message editor focused on the function key whose button is `h`
+// (mode- and shift-bank-aware). Used by the legacy right-double-click path.
+procedure EditFunctionKeyMessage(h: HWND);
+var
+  row                                   : integer;
+begin
+  row := ResolveFunctionKeyRow(h);
+  if row < 0 then Exit;
+  InitialAltPSelection := row;
+//tDialogBox(72, @MemoryProgramDlgProc);
+  OpenListOfMessages;
+  FrmSetFocus;   // see note in ShowFunctionKeyContextMenu
+end;
+
+procedure GetButtonByRDblClick(h: HWND);
+begin
+  EditFunctionKeyMessage(h);
+end;
+
+// Right-click a function-key button -> show a one-item context menu that opens
+// the editor on that key. The target row is captured NOW (while any Alt/Ctrl
+// modifier is still held) so the bank stays correct even after the user
+// releases the modifier to click the menu. Label is composed from translated
+// words; the key name (e.g. "F3") is not translated. Issue #1001.
+procedure ShowFunctionKeyContextMenu(h: HWND);
+const
+  ID_EDITFKEY                           = 1;
+var
+  row                                   : integer;
+  prefix                                : string;
+  keyName                               : string;
+  caption                               : string;
+  p                                     : integer;
+  hMenu                                 : Windows.HMENU;   // qualified: an 'HMENU' identifier in this unit's scope shadows the type
+  pt                                    : Windows.TPoint;
+  cmd                                   : integer;
+begin
+  row := ResolveFunctionKeyRow(h);
+  if row < 0 then Exit;
+
+  case row div 12 of            // 0 = plain, 1 = Ctrl, 2 = Alt
+     1: prefix := 'Ctrl-F';
+     2: prefix := 'Alt-F';
+  else
+     prefix := 'F';
+  end;
+  keyName := prefix + IntToStr((row mod 12) + 1);   // e.g. 'F3', 'Ctrl-F10' (not translated)
+  // TC_EDITFUNCTIONKEY is the per-language 'Edit %s message' format; substitute
+  // the key name for %s. Pos/Copy avoids a wsprintf varargs call.
+  caption := TC_EDITFUNCTIONKEY;
+  p := Pos('%s', caption);
+  if p > 0 then
+     caption := Copy(caption, 1, p - 1) + keyName + Copy(caption, p + 2, Length(caption));
+
+  hMenu := Windows.CreatePopupMenu;
+  Windows.AppendMenu(hMenu, MF_STRING, ID_EDITFKEY, PChar(caption));
+  Windows.GetCursorPos(pt);
+  // NB: do NOT SetForegroundWindow here -- it fires WM_SETFOCUS, whose handler
+  // calls ShowFMessages(0) and reverts the function-key window to the plain
+  // bank while the menu is up (mismatching an "Edit Ctrl-Fn" label). The app is
+  // already foreground on right-click, so the menu dismisses fine without it
+  // (same as the band-map popup). Issue #1001.
+  cmd := integer(Windows.TrackPopupMenu(hMenu,
+                 TPM_RETURNCMD or TPM_LEFTALIGN or TPM_TOPALIGN or TPM_LEFTBUTTON,
+                 pt.x, pt.y, 0, tr4whandle, nil));
+  Windows.DestroyMenu(hMenu);
+
+  if cmd = ID_EDITFKEY then
+     begin
+     InitialAltPSelection := row;    // captured before the modifier was released
+     OpenListOfMessages;
+     end;
+
+  // Right-clicking the button + showing the menu (and the modal editor) leaves
+  // focus off the Call window. Restore it -- the Ctrl/Alt bank-switch handler in
+  // the main loop only fires when focus is the Call/Exchange window, so without
+  // this those keys stop updating the F-key labels. Mirrors the left-click
+  // (BN_CLICKED) handler above. Issue #1001.
+  FrmSetFocus;
 end;
 
 end.

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -1082,6 +1082,13 @@ begin
         begin
           GetButtonByRDblClick(Msg.HWND);
         end;
+
+      WM_RBUTTONDOWN:
+        begin
+          // Issue #1001: right-click a function-key button -> context menu to
+          // edit that key's message (CQ vs S&P aware). No-op elsewhere.
+          ShowFunctionKeyContextMenu(Msg.HWND);
+        end;
 {
       WM_RBUTTONDOWN:
         begin


### PR DESCRIPTION
## Summary

Implements TR4W/TR4W#1001: right-clicking a button in the function-key window opens a one-item context menu (**"Edit &lt;key&gt; message"**) that launches the Alt-P message editor **pre-positioned on that key**, aware of the current operating mode (**CQ vs S&P**) and the shift bank currently shown (plain / Ctrl / Alt).

Most of the plumbing already existed (`GetButtonByRDblClick` opened the editor mode-aware on right-double-click) — this wires up single right-click, makes the editor jump to the clicked key, and adds a proper i18n label.

## Changes

**`uFunctionKeys.pas`**
- `ResolveFunctionKeyRow(h)` — maps a function-key button HWND to the editor row, sets the CQ/S&P target window, and reads the live Alt/Ctrl modifier so the correct bank row is chosen.
- `EditFunctionKeyMessage(h)` — opens the editor for a key (double-click path).
- `ShowFunctionKeyContextMenu(h)` — captures the target row **at click time** (before the modifier is released to click the menu), formats the label from `TC_EDITFUNCTIONKEY`, and opens the editor on selection. Menu API qualified with `Windows.*` (an `HMENU` identifier in scope shadows the type).
- `FrmSetFocus` after the editor closes so the Call window regains focus and Ctrl/Alt bank-switching resumes.

**`uAltP.pas`**
- `InitialAltPSelection` lets a caller pre-select the editor row; `WM_INITDIALOG` honors it then resets to the historical default (F1).

**`tr4w.dpr`**
- `WM_RBUTTONDOWN` on a function-key button → `ShowFunctionKeyContextMenu`.

**i18n**
- New `TC_EDITFUNCTIONKEY = 'Edit %s message'` in all 11 language files (cross-walked from existing translated words; ger uses `Nachricht`, cze `zprávu`, mng/chn fall back to English). The `%s` is the key name (`F3` / `Ctrl-F10` / `Alt-F1`), not translated. Inserted byte-safe; encodings verified intact.

## Out of scope / related
- **#1004** (pre-existing): the Alt/Ctrl bank labels only update while the Call/Exchange field has focus. Confirmed pre-existing on master; the `FrmSetFocus` here brings the right-click flow to parity with the keyboard Alt-P flow, but the underlying focus-gating fix is tracked separately.

## Testing
- Unit tests: **817 passed, 0 failed**.
- Full `FullBuild.ps1 -AllLanguages`: **ENG + 8 languages, 0 failed** (confirms `TC_EDITFUNCTIONKEY` resolves in every built language).
- Manually verified by the maintainer: right-click → edit jumps to the correct key (incl. Ctrl/Alt banks), mode-aware, menu dismisses cleanly.