### PR TITLE
Issue 1007: ignore function-key right-click while Alt/Ctrl is held

### DIFF
--- a/tr4w/src/uFunctionKeys.pas
+++ b/tr4w/src/uFunctionKeys.pas
@@ -347,6 +347,16 @@ var
   pt                                    : Windows.TPoint;
   cmd                                   : integer;
 begin
+  // Issue #1007: ignore right-click while Alt or Ctrl is held. The window is
+  // showing the Alt-F/Ctrl-F bank then, and popping the menu + the FrmSetFocus
+  // that follows would flash the labels back to plain (WM_SETFOCUS ->
+  // ShowFMessages(0)). Right-click edits the plain F-keys only; edit the
+  // Alt-F/Ctrl-F messages via the Alt-P editor.
+  if ((GetKeyState(VK_MENU) and $8000) <> 0)    or
+     ((GetKeyState(VK_CONTROL) and $8000) <> 0) then
+     begin
+     Exit;
+     end;
   row := ResolveFunctionKeyRow(h);
   if row < 0 then Exit;
 


### PR DESCRIPTION
## Summary

Fixes TR4W/TR4W#1007. When the function-key window is showing the **Alt-F / Ctrl-F** bank (because Alt/Ctrl is held), right-clicking a key flashed the labels back to the plain F1-F12 bank on every click.

## Cause

The right-click edit feature (#1001) is bank-aware. After the context menu, `ShowFunctionKeyContextMenu` calls `FrmSetFocus` to restore Call-window focus, which fires `WM_SETFOCUS -> ShowFMessages(0)` (`tr4w.dpr:398`) and repaints the plain bank.

## Fix

Ignore right-click on a function-key button while Alt or Ctrl is held (one guard at the top of `ShowFunctionKeyContextMenu`). Right-click then only edits the plain F-keys shown by default — no menu, no focus restore, no flash. Editing Alt-F/Ctrl-F messages remains available via the Alt-P editor.

## Testing
- Unit tests 817/0; ENG + server build clean.
- Maintainer-verified: Alt+right-click no longer flashes; normal right-click still opens the plain edit menu.

## Related
- Follow-up to TR4W/TR4W#1001.
- The deeper "Alt/Ctrl bank doesn't track the modifier" behavior (#1004) is pre-existing (menu-mode interception) and deferred to the Delphi 12 conversion — out of scope here.