### PR TITLE
Issue 1006: fix duplicate/unclosable Send Keyboard Input dialog + idle-close delay

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -3294,6 +3294,12 @@ begin
     menu_ctrl_sendkeyboardinput:
       // if (ActiveMode = CW) or (ActiveMode = Digital) then
       begin
+        // Issue #1006: if a Send Keyboard Input dialog is already open, do not
+        // open a second one. Clicking a (send from keyboard) function-key button
+        // re-enters here while the dialog is up -- the modal disables only the
+        // main window, not the function-key window -- and the nested modal plus
+        // the single SendKeyboardWindow handle leaves the dialog unclosable.
+        if SendKeyboardInputDialogOpen then Exit;
         focus := GetFocus;
         if ActiveMode = CW then
           if not CWEnable then

--- a/tr4w/src/uSendKeyboard.pas
+++ b/tr4w/src/uSendKeyboard.pas
@@ -40,6 +40,7 @@ uses
 function SendKeyboardCWDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): BOOL; stdcall;
 function NewSendKeyboardEditProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lParam): UINT; stdcall;
 procedure CloseSendKeyboardInputDialog(StopSending: boolean);
+function SendKeyboardInputDialogOpen: boolean;
 
 implementation
 uses
@@ -59,7 +60,6 @@ begin
   case Msg of
     WM_INITDIALOG:
       begin
-
         Windows.SetWindowText(hwnddlg, RC_SENDINGCW);
         tWM_SETFONT(CreateEdit(ES_LEFT or ES_AUTOHSCROLL or ES_UPPERCASE, 5, 5, 380, 26, hwnddlg, 101), MainWindowEditFont);
         CreateButton(BS_DEFPUSHBUTTON, CLOSE_WORD, 390, 5, 60, hwnddlg, 102);
@@ -178,7 +178,12 @@ begin
   newpos := 0;
   ControlAMode := False;
   tAutoSendMode := False;
-  if StopSending then
+  // Only tear down the keyer/port if CW is actually being sent. When idle, the
+  // keying line is already low and the WinKeyer buffer already empty, so
+  // FlushCWBuffer (TurnOffActivePort + wkClearBuffer) is pure no-op work that
+  // can cost ~300ms of serial/port teardown. CWStillBeingSent is keyer-mode
+  // aware (CWByCAT / WinKeyer / YCCC / CPU keyer). Issue #1006.
+  if StopSending and CWStillBeingSent then
   begin
     CPUKeyer.FlushCWBuffer;
   end;
@@ -187,6 +192,15 @@ begin
 {$IFEND}
 
   EndDialog(SendKeyboardWindow, 0);
+  SendKeyboardWindow := 0;   // Issue #1006: keep the open/closed flag honest
+end;
+
+// Issue #1006: true while the Send Keyboard Input dialog is open, so callers can
+// avoid opening a second (nested) instance that the single SendKeyboardWindow
+// handle cannot unwind.
+function SendKeyboardInputDialogOpen: boolean;
+begin
+  Result := SendKeyboardWindow <> 0;
 end;
 
 end.


### PR DESCRIPTION
## Summary

Fixes #1006. Clicking a `(send from keyboard)` function-key button with the mouse could open a second, nested **Send Keyboard Input** dialog that then couldn't be closed (the modal disables only the main window, not the function-key window, so the button re-enters the open handler; the single `SendKeyboardWindow` handle can't unwind the nesting). Pressing the key instead self-toggles, so only the mouse path hung.

This PR also removes a ~300 ms delay on every Close.

## Changes

**`uSendKeyboard.pas`**
- Reset `SendKeyboardWindow := 0` after `EndDialog` so the open/closed state is accurate; add `SendKeyboardInputDialogOpen` accessor.
- **Gate the keyer/port teardown:** only call `CPUKeyer.FlushCWBuffer` when CW is actually being sent (`CWStillBeingSent`). When idle, the keying line is already low and the WinKeyer buffer empty, so `FlushCWBuffer` (`TurnOffActivePort` + `wkClearBuffer`) was ~300 ms of pure no-op serial/port teardown on every Close. Diagnosed via timing logs: the entire close delay was in that call, and it's skipped on the keyboard-close (`StopSending=False`) path.

**`MainUnit.pas`**
- `menu_ctrl_sendkeyboardinput` bails if a dialog is already open, preventing the nested second instance.

## Testing
- Unit tests 817/0; ENG + server build clean.
- Maintainer-verified: re-entry no longer hangs; **idle close is now instant**; **close while CW is keying still aborts the CW** (teardown runs, as intended); keyboard F10 toggle unchanged.