### PR TITLE
Issue 1010: position exchange cursor after the offending token (FD class/section)

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -4641,6 +4641,25 @@ begin
     method_buffered;
 end;
 
+// Issue #1010: after an exchange-parsing error, drop the caret right after the
+// offending token in the exchange window so the operator can fix it in place
+// instead of arrowing back from end-of-line. No-op if no token was recorded or
+// it isn't found in the current exchange text. Kept as its own procedure (not
+// inlined into the long ParametersOkay) per the Delphi 7 codegen caution.
+procedure PositionExchangeCursorAtErrorToken;
+var
+  p: integer;
+begin
+  if ExchangeErrorToken = '' then
+    Exit;
+  p := Pos(ExchangeErrorToken, ExchangeWindowString);
+  if p > 0 then
+  begin
+    p := (p - 1) + Length(ExchangeErrorToken);   // 0-based caret just past the token
+    Windows.SendMessage(wh[mweExchange], EM_SETSEL, p, p);
+  end;
+end;
+
 function ParametersOkay(Call: CallString;
   ExchangeString: Str40 {CallString};
   Band: BandType;
@@ -4678,6 +4697,7 @@ begin
   LookForOnDeckCall(ExchangeString);
 
   ExchangeErrorMessage := nil;
+  ExchangeErrorToken := '';   // Issue #1010
 
   if NoLog then
   begin
@@ -4847,7 +4867,10 @@ begin
   ParametersOkay := ProcessExchange(ExchangeString, RData);
 
   if ExchangeErrorMessage <> nil then
+  begin
     QuickDisplayError(ExchangeErrorMessage);
+    PositionExchangeCursorAtErrorToken;   // Issue #1010: caret after the offending token
+  end;
 
   if Result = False then
     Exit;

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -432,6 +432,7 @@ var
   EscapeExitsSearchAndPounce: boolean = True;
   ExchangeHasBeenSent: boolean;
   ExchangeErrorMessage: PChar;
+  ExchangeErrorToken: Str40;   // Issue #1010: the offending exchange token, so the caller can place the caret right after it
   ExchangeMemoryFileEnable: boolean;
   ExchangeWindowString: Str40;
   ExternalLoggerAddress: string[255] = '127.0.0.1';
@@ -1312,11 +1313,14 @@ begin
     if not FoundDomesticQTH(RXData) then
     begin
       ExchangeErrorMessage := 'Invalid ARRL Section'; {TC_IMPROPERDOMESITCQTH;}
+      ExchangeErrorToken := RXData.QTHString;   // Issue #1010: caret goes after the bad section
       logger.error('[ProcessClassAndDomesticOrDXQTHExchange] Improper Domestic QTH = Exchange = (%s), DomesticQTH = (%s)', [Exchange, RXData.QTHString]);
       // misspelled in the constants file //ny4i 4.45.3
       Exit; // This was before the above code that flips the values. // ny4i 4.45.3
     end;
     isClassValid := ValidClass(RXData.ceClass);
+    if not isClassValid then
+      ExchangeErrorToken := RXData.ceClass;   // Issue #1010: caret goes after the bad class
     Result := IsClassValid;
   end
   else


### PR DESCRIPTION
## Summary

**Part of TR4W/TR4W-D12#22** (does not close it). When exchange parsing reports an error, the caret was left at end-of-line, forcing the operator to arrow/backspace to the bad item. This adds a **general mechanism** to drop the caret right after the offending token, and wires it for the **Field Day class and section** cases (ARRL **and** Winter FD).

## Changes

**`LOGSTUFF.PAS`**
- New global `ExchangeErrorToken` (the offending exchange token).
- `ProcessClassAndDomesticOrDXQTHExchange` records it: `RXData.QTHString` on an invalid section, `RXData.ceClass` on an invalid class. `ValidClass` validates both ARRL and Winter FD, and the field order is normalized, so this works for either `class section` or `section class` input.

**`MainUnit.pas`**
- Reset `ExchangeErrorToken` at the top of `ParametersOkay`.
- New `PositionExchangeCursorAtErrorToken`: finds the token in the **live** exchange window text (`ExchangeWindowString`) and sets the caret just past it via `EM_SETSEL`. Searching the live text handles the any-order normalization and the leading/trailing-space stripping cleanly. Kept as its own proc (not inlined into the long `ParametersOkay`) per the Delphi 7 codegen caution. No-op if the token wasn't recorded or isn't found, so there is no regression.
- The consumer calls it right after `QuickDisplayError`.

## Scope / why the issue stays open

The infrastructure is general, but only the FD class/section consumers are wired. Other contests use different exchange formats with their own validation points (~18 `ExchangeErrorMessage :=` sites); each can opt in with a one-line `ExchangeErrorToken := <bad token>;` where there is a single clean offending token. TR4W/TR4W-D12#22 remains open to track that.

## Testing
- Unit tests 817/0; ENG + server build clean.
- Maintainer-tested: bad class (`1O SFL`) -> caret after `O`; bad section -> caret after section; reverse order (`SFL 1O`); valid exchange and unrelated errors -> no caret change.