### PR TITLE
PostUnit asm removal batch 2: first-call reports + notes list (Part of #998)

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -4054,7 +4054,6 @@ label
 var
   Note                                  : PChar;
   Minutes, Hour                         : integer;
-  nNumberOfBytesToWrite                 : integer;
 begin
   MakeReportFileName('Notes.txt');
   if not OpenLogFile then Exit;
@@ -4074,18 +4073,11 @@ begin
       Minutes := TempRXData.tSysTime.qtMinute;
       Hour := TempRXData.tSysTime.qtHour;
       Note := @TempRXData.Prefix;
-      asm
-      push Note
-      push Minutes
-      push Hour
-      end;
-      tGetDateFormat(TempRXData.tSysTime);
-      asm
-      push eax
-      end;
-      nNumberOfBytesToWrite := wsprintf(wsprintfBuffer, '%s %02u:%02u: %s'#13#10);
-      asm add esp,24 end;
-      sWriteFile(tReportFileWrite, wsprintfBuffer, nNumberOfBytesToWrite);
+      // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+      // %s=date, %02u=Hour, %02u=Minutes, %s=Note (%02u -> %.2u zero-pad).
+      sWriteFileFromString(tReportFileWrite,
+        SysUtils.Format('%s %.2u:%.2u: %s'#13#10,
+          [string(tGetDateFormat(TempRXData.tSysTime)), Hour, Minutes, string(Note)]));
     end;
 
     goto 1;

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -3636,12 +3636,9 @@ end;
 procedure PrintFirstCountryMultiplierCallsigns;
 
 var
-  Lines, Count, CountryIndex            : integer;
-  TempString                            : ShortString;
+  Lines, CountryIndex                   : integer;
   Prefix                                : string;
   FileWrite                             : Text;
-  Band                                  : BandType;
-  p                                     : PChar;
 begin
 
   MakeReportFileName('firstcallineachcountry.txt');
@@ -3676,24 +3673,17 @@ begin
         Lines := 5;
       end;
 
-      for Band := Band10 downto Band160 do
-      begin
-        p := @CountryMultTotals^[Band, CountryIndex].FirstCall[1];
-        asm
-               push p
-        end;
-      end;
-//      Prefix := ctyGetCountryID(CountryIndex);
       Prefix := CTY.ctyTable[CountryIndex].ID;
-      asm
-               push Prefix
-      end;
-      Count := wsprintf(@TempString[1], '%-6s %-11s %-11s %-11s %-11s %-11s %-11s');
-      asm add esp,36
-      end;
-      SetLength(TempString, Count);
-
-      WriteLn(FileWrite, TempString);
+      // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+      // %-6s=Prefix, then the FirstCall for bands 160/80/40/20/15/10.
+      WriteLn(FileWrite, SysUtils.Format('%-6s %-11s %-11s %-11s %-11s %-11s %-11s',
+        [Prefix,
+         string(PChar(@CountryMultTotals^[Band160, CountryIndex].FirstCall[1])),
+         string(PChar(@CountryMultTotals^[Band80,  CountryIndex].FirstCall[1])),
+         string(PChar(@CountryMultTotals^[Band40,  CountryIndex].FirstCall[1])),
+         string(PChar(@CountryMultTotals^[Band20,  CountryIndex].FirstCall[1])),
+         string(PChar(@CountryMultTotals^[Band15,  CountryIndex].FirstCall[1])),
+         string(PChar(@CountryMultTotals^[Band10,  CountryIndex].FirstCall[1]))]));
       inc(Lines);
     end;
 

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -3747,11 +3747,10 @@ end;
 procedure PrintFirstZoneMultiplierCallsigns;
 
 var
-  Lines, Count, MaxNumberOfZones, ZoneIndex: integer;
+  Lines, MaxNumberOfZones, ZoneIndex    : integer;
   TempString                            : Str80;
   FileWrite                             : Text;
   Band                                  : BandType;
-  p                                     : PChar;
 begin
 
   OpenFileForWrite(FileWrite, ReportsFilename);
@@ -3794,24 +3793,16 @@ begin
       WriteLn(FileWrite, '---- --------    --------    --------    --------    --------    --------');
       Lines := 5;
     end;
-    SetLength(TempString, 80);
-
-    for Band := Band10 downto Band160 do
-    begin
-      p := @CountryMultTotals^[Band, ZoneIndex].FirstCall[1];
-      asm
-               push p
-      end;
-    end;
-    asm
-            push ZoneIndex
-    end;
-
-    Count := wsprintf(@TempString[1],
-      '%-4u %-11s %-11s %-11s %-11s %-11s %-11s');
-    asm add esp,36
-    end;
-    SetLength(TempString, Count);
+    // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+    // %-4u=ZoneIndex, then the FirstCall for bands 160/80/40/20/15/10.
+    TempString := SysUtils.Format('%-4u %-11s %-11s %-11s %-11s %-11s %-11s',
+      [ZoneIndex,
+       string(PChar(@CountryMultTotals^[Band160, ZoneIndex].FirstCall[1])),
+       string(PChar(@CountryMultTotals^[Band80,  ZoneIndex].FirstCall[1])),
+       string(PChar(@CountryMultTotals^[Band40,  ZoneIndex].FirstCall[1])),
+       string(PChar(@CountryMultTotals^[Band20,  ZoneIndex].FirstCall[1])),
+       string(PChar(@CountryMultTotals^[Band15,  ZoneIndex].FirstCall[1])),
+       string(PChar(@CountryMultTotals^[Band10,  ZoneIndex].FirstCall[1]))]);
       {
                Str(ZoneIndex: 3, TempString);
 


### PR DESCRIPTION
Part of #998 (inline-asm removal for the Delphi 12 / 64-bit migration). Batch 2 — three more PostUnit report routines converted from the manual cdecl `wsprintf` push idiom to standard `SysUtils.Format`, dropping the PChar buffer and the orphaned `asm add esp,N` cleanup in each.

### Routines (one commit each)
| Routine | Report | Format |
|---|---|---|
| `PrintFirstCountryMultiplierCallsigns` | `firstcallineachcountry.txt` | `%-6s` + 6×`%-11s` (prefix + bands 160/80/40/20/15/10) |
| `PrintFirstZoneMultiplierCallsigns` | `FirstCallInEachZone.txt` | `%-4u` + 6×`%-11s` (zone + 6 bands) |
| `MakeNotesList` | `Notes.txt` | `%s %.2u:%.2u: %s` (date / hour / min / note) |

### Notes
- cdecl arg order verified per routine (reverse-of-push). In `MakeNotesList` the first arg is `tGetDateFormat`'s result (the `push eax`), which is `PChar` (TF.pas:115), cast via `string(...)`.
- C `%02u` zero-pad → Delphi `%.2u`.
- Nil-safe: `PChar` args passed as `string(p)` (nil → '').
- Unused locals removed in each routine.

### Validation
- FullBuild: 817 unit tests pass; tr4w.exe + server build clean.
- **Output-diff validated** against a release build — all three report files byte-equivalent to the asm version.

Follows the same template as batch 1 (#1013).