### PR TITLE
PostUnit asm removal batch 3: band-change + EDI/CSV export (Part of #998)

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -2076,23 +2076,6 @@ procedure ExportToCSV;              //n4af 04/18/14 new procedure added
 label
   1;
 
-var
- 
-  tCallStringLength                     : Cardinal;
-
-  tBandString                           : PChar;
-  tBandStringLength                     : Cardinal;
-
-  tModeString                           : PChar;
-  tModeStringLength                     : Cardinal;
-
-  tRSTSendStringLength                  : Cardinal;
-  tRSTRcvdStringLength                  : Cardinal;
-
-  tContestName                          : PChar;
-  tContestNamelength                    : Cardinal;
-  nNumberOfBytesToWrite                 : Cardinal;
-
 begin
 
   lstrcpy(tReportsFilename, TR4W_LOG_FILENAME);
@@ -2119,80 +2102,26 @@ begin
   begin
     if GoodLookingQSO then
     begin
-      tContestName := ContestTypeSA[Contest];
-      tContestNamelength := Windows.lstrlen(tContestName);
-
-      tCallStringLength := length(TempRXData.Callsign);
-
-      tBandString := ADIFBANDSTRINGSARRAY[TempRXData.Band];
-      tBandStringLength := Windows.lstrlen(tBandString);
-     
-          //          if TempRXData.ceFMMode then TempMode := FM else TempMode := TempRXData.Mode;
-      tModeString := ADIFModeString[TempRXData.Mode];
-      tModeStringLength := Windows.lstrlen(tModeString);
-
-      if TempRXData.RSTSent > 99 then tRSTSendStringLength := 3 else tRSTSendStringLength := 2;
-      if TempRXData.RSTReceived > 99 then tRSTRcvdStringLength := 3 else tRSTRcvdStringLength := 2;
-
-     asm
-        push tContestName
-     //   mov eax,dword ptr tContestNamelength
-      //  push eax
-
-        xor eax,eax
-       mov ax, word ptr TempRXData.RSTReceived
-        push eax
-    //    push tRSTRcvdStringLength
-
-       xor eax,eax
-        mov ax, word ptr TempRXData.RSTSent
-        push eax
-    //    push tRSTSendStringLength
-
-        movzx eax,TempRXData.tSysTime.qtSecond
-        push eax
-
-        movzx eax,TempRXData.tSysTime.qtMinute
-        push eax
-
-        movzx eax,TempRXData.tSysTime.qtHour
-        push eax
-
-        movzx eax,TempRXData.tSysTime.qtDay
-        push eax
-
-        movzx eax,TempRXData.tSysTime.qtMonth
-        push eax
-
-        movzx eax,TempRXData.tSysTime.qtYear
-        add eax,2000
-        push eax
-
-        push tModeString
-    //    mov eax,dword ptr tModeStringLength
-    //    push eax
-
-        push tBandString
-    //    mov eax,dword ptr tBandStringLength
-    //    push eax
-
-        lea  eax,TempRXData.Callsign+1
-        push eax
-  //       mov eax,dword ptr tCallStringLength
-   //      push eax
-
+      // Issue #998: asm-push wsprintf -> SysUtils.Format, written INSIDE the
+      // GoodLookingQSO guard.  The old write sat outside the guard and re-emitted
+      // the stale buffer for skipped/deleted/non-QSO records; now only good QSOs
+      // are written.  cdecl arg order: callsign, band, mode, year, month, day,
+      // hour, minute, second, rst-sent, rst-rcvd, contest name.  %02d -> %.2d.
+      sWriteFileFromString(tReportFileWrite, SysUtils.Format(
+        '%s,%s,%s,%u%.2d%.2d,%.2d%.2d%.2d,%u,%u,%s'#13#10,
+        [string(PChar(@TempRXData.Callsign[1])),
+         string(ADIFBANDSTRINGSARRAY[TempRXData.Band]),
+         string(ADIFModeString[TempRXData.Mode]),
+         TempRXData.tSysTime.qtYear + 2000,
+         TempRXData.tSysTime.qtMonth,
+         TempRXData.tSysTime.qtDay,
+         TempRXData.tSysTime.qtHour,
+         TempRXData.tSysTime.qtMinute,
+         TempRXData.tSysTime.qtSecond,
+         TempRXData.RSTSent,
+         TempRXData.RSTReceived,
+         string(ContestTypeSA[Contest])]));
       end;
-
-      nNumberOfBytesToWrite := wsprintf(CABRILLO_BUFFER,
-        '%s,%s,%s,%u%02d%02d,%02d%02d%02d,%u,%u,%s');
-
-
-      end;
-
-      sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
-
-      sWriteFile(tReportFileWrite, #13#10, 2);
-     //  sWriteFile(tReportFileWrite, #13#10);
     goto 1;
    end;
   

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1727,9 +1727,6 @@ procedure ExportToEDIByBand(Band: BandType);
 label
   1;
 var
-  nNumberOfBytesToWrite                 : Cardinal;
-  p                                     : PChar;
-  TempInteger                           : integer;
   TempTag                               : CabrilloTags;
 const
   EDI_ModeCodes                         : array[ModeType] of integer = (2, 7, 1, 0, 0, 6);
@@ -1760,19 +1757,9 @@ begin
   Windows.GetDlgItemText(CreateCabrilloWindow, integer(ctName) + 200, @TempBuffer1, SizeOf(TempBuffer1));
   Windows.GetDlgItemText(CreateCabrilloWindow, integer(ctCategoryOperator) + 200, @TempBuffer2, SizeOf(TempBuffer2));
 
-  TempInteger := QSOTotals[Band, Both];
-  p := EDIFBANDSTRINGSARRAY[Band];
-  asm
-  push TempInteger
-  push offset TempBuffer2
-  push offset wsprintfBuffer
-  push offset TempBuffer1
-  push p
-  push offset MyGrid[1]
-  push offset MyCall[1]
-  push offset ContestName[1]
-  end;
-  nNumberOfBytesToWrite := wsprintf(CABRILLO_BUFFER,
+  // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+  // ContestName, MyCall, MyGrid, BandString, Name, Address, Section, QSOcount.
+  sWriteFileFromString(tReportFileWrite, SysUtils.Format(
     '[REG1TEST;1]'#13#10 +
     'TName=%s'#13#10 +
     'PCall=%s'#13#10 +
@@ -1781,10 +1768,15 @@ begin
     'RName=%s'#13#10 +
     'PAdr1=%s'#13#10 +
     'PSect=%s'#13#10 +
-    '[QSORecords;%u]'#13#10
-    );
-  asm add esp,40 end;
-  sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
+    '[QSORecords;%u]'#13#10,
+    [string(PChar(@ContestName[1])),
+     string(PChar(@MyCall[1])),
+     string(PChar(@MyGrid[1])),
+     string(EDIFBANDSTRINGSARRAY[Band]),
+     string(PChar(@TempBuffer1)),
+     string(PChar(@wsprintfBuffer)),
+     string(PChar(@TempBuffer2)),
+     QSOTotals[Band, Both]]));
 
   ReadVersionBlock;
   1:
@@ -1793,74 +1785,27 @@ begin
     if GoodLookingQSO then
     begin
       if TempRXData.Band <> Band then goto 1;
-      TempInteger := EDI_ModeCodes[TempRXData.Mode];
-
-      p := EDI_DupeArray[TempRXData.ceDupe];
-      asm
-      push p
-      end;
-
-      p := EDI_NewArray[TempRXData.DXMult];
-      asm
-      push p
-      end;
-
-      p := EDI_NewArray[TempRXData.DomesticMult];
-      asm
-      push p
-
-      xor eax, eax
-      mov ax, TempRXData.QSOPoints
-      push eax
-
-      push offset TempRXData.QTHString[1]
-
-      push TempRXData.NumberReceived
-
-      xor eax, eax
-      mov ax, TempRXData.RSTReceived
-      push eax
-
-      push TempRXData.NumberSent
-
-      xor eax, eax
-      mov ax, TempRXData.RSTSent
-      push eax
-
-      push TempInteger
-
-      push offset TempRXData.Callsign[1]
-
-      xor eax, eax
-      mov al, TempRXData.tSysTime.qtMinute
-      push eax
-
-      xor eax, eax
-      mov al, TempRXData.tSysTime.qtHour
-      push eax
-
-      xor eax, eax
-      mov al, TempRXData.tSysTime.qtDay
-      push eax
-
-      xor eax, eax
-      mov al, TempRXData.tSysTime.qtMonth
-      push eax
-
-      xor eax, eax
-      mov al, TempRXData.tSysTime.qtYear
-      push eax
-      end;
-
-      nNumberOfBytesToWrite := wsprintf(CABRILLO_BUFFER,
-        '%02d%02d%02d;' + {date}
-        '%02d%02d;' + {time}
+      // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+      // date (Year/Month/Day), time (Hour/Minute), callsign, mode code,
+      // rst-sent, sent-qso#, rst-rcvd, rcvd-qso#, rcvd-WWL, qso-points,
+      // new-WWL, new-DXCC, dupe.  %02d -> %.2d (always non-negative here).
+      // The new/dupe flag arrays are nil when false -> string(nil) = '' (EDI
+      // blank field).
+      //
+      // The two QSO-number fields were C '%03d' = zero-pad to WIDTH 3 with the
+      // sign counted in the width (-1 -> "-01").  Delphi '%.3d' pads DIGITS
+      // (-1 -> "-001"), which differs for negatives (the "no serial" sentinel
+      // is -1).  We reproduce C semantics with '%.*d' and precision = 3 minus
+      // the sign character, supplied as an argument before each value.
+      sWriteFileFromString(tReportFileWrite, SysUtils.Format(
+        '%.2d%.2d%.2d;' + {date}
+        '%.2d%.2d;' + {time}
         '%s;' + {callsign}
         '%d;' + {mode code}
         '%d;' + {rst sent}
-        '%03d;' + {sent qso number}
+        '%.*d;' + {sent qso number (C %03d)}
         '%d;' + {rst received}
-        '%03d;' + {received qso number}
+        '%.*d;' + {received qso number (C %03d)}
         ';' + {Received Exchange}
         '%s;' + {Received WWL}
         '%d;' + {QSO points}
@@ -1868,10 +1813,23 @@ begin
         '%s;' + {New-WWL}
         '%s;' + {New-DXCC}
         '%s' + {Duplicate-QSO}
-        #13#10
-        );
-      asm add esp,72 end;
-      sWriteFile(tReportFileWrite, CABRILLO_BUFFER, nNumberOfBytesToWrite);
+        #13#10,
+        [TempRXData.tSysTime.qtYear,
+         TempRXData.tSysTime.qtMonth,
+         TempRXData.tSysTime.qtDay,
+         TempRXData.tSysTime.qtHour,
+         TempRXData.tSysTime.qtMinute,
+         string(PChar(@TempRXData.Callsign[1])),
+         EDI_ModeCodes[TempRXData.Mode],
+         TempRXData.RSTSent,
+         3 - Ord(TempRXData.NumberSent < 0), TempRXData.NumberSent,
+         TempRXData.RSTReceived,
+         3 - Ord(TempRXData.NumberReceived < 0), TempRXData.NumberReceived,
+         string(PChar(@TempRXData.QTHString[1])),
+         TempRXData.QSOPoints,
+         string(EDI_NewArray[TempRXData.DomesticMult]),
+         string(EDI_NewArray[TempRXData.DXMult]),
+         string(EDI_DupeArray[TempRXData.ceDupe])]));
 
     end;
     goto 1;

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -3924,8 +3924,7 @@ var
   FirstQSO                              : boolean;
   QSONumber, NumberBandChanges, NumberTwoXmtrQSOs, LastBandChangeQSO: integer;
   FileWrite                             : HWND;
-  P1, P2, p3, p4, sr                    : PChar;
-  lpNumberOfBytesWritten                : Cardinal;
+  sr                                    : PChar;
 begin
   if not OpenLogFile then Exit;
   MakeReportFileName('BandChange.txt');
@@ -3977,26 +3976,19 @@ begin
           inc(NumberTwoXmtrQSOs);
         end;
 
-        P1 := BandStringsArray[LastBand];
-        P2 := ModeStringArray[LastMode];
-        p3 := BandStringsArray[TempRXData.Band];
-        p4 := ModeStringArray[TempRXData.Mode];
-        asm
-        push sr
-        movzx eax, TempRXData.tSysTime.qtMinute
-        push eax
-        movzx eax, TempRXData.tSysTime.qtHour
-        push eax
-        push p4
-        push p3
-        push p2
-        push p1
-        push NumberBandChanges
-        end;
-        lpNumberOfBytesWritten := wsprintf(CABRILLO_BUFFER, '%4d.  Band change from %s%s to %s%s at %02d:%02d.%s'#13#10);
-        asm add esp,36
-        end;
-        sWriteFile(FileWrite, CABRILLO_BUFFER, lpNumberOfBytesWritten);
+        // Issue #998: asm-push wsprintf -> SysUtils.Format. cdecl arg order is
+        // NumberBandChanges, fromBand, fromMode, toBand, toMode, Hour, Minute, sr
+        // (%02d -> %.2d zero-pad).
+        sWriteFileFromString(FileWrite,
+          SysUtils.Format('%4d.  Band change from %s%s to %s%s at %.2d:%.2d.%s'#13#10,
+            [NumberBandChanges,
+             string(BandStringsArray[LastBand]),
+             string(ModeStringArray[LastMode]),
+             string(BandStringsArray[TempRXData.Band]),
+             string(ModeStringArray[TempRXData.Mode]),
+             TempRXData.tSysTime.qtHour,
+             TempRXData.tSysTime.qtMinute,
+             string(sr)]));
 
               //        WriteLn(FileWrite);
         LastBandChangeQSO := QSONumber;
@@ -4009,13 +4001,8 @@ begin
   if NumberTwoXmtrQSOs > 0 then
   begin
 
-    asm
-    push NumberTwoXmtrQSOs
-    end;
-    lpNumberOfBytesWritten := wsprintf(CABRILLO_BUFFER, #13#10'There were %d second radio QSOs made.');
-    asm add esp,12
-    end;
-    sWriteFile(FileWrite, CABRILLO_BUFFER, lpNumberOfBytesWritten);
+    sWriteFileFromString(FileWrite,
+      SysUtils.Format(#13#10'There were %d second radio QSOs made.', [NumberTwoXmtrQSOs]));
   end;
 
   CloseLogFile;


### PR DESCRIPTION
Part of #998 (inline-asm removal for the Delphi 12 / 64-bit migration). Batch 3 — three export/report routines converted from the manual cdecl `wsprintf` push idiom to standard `SysUtils.Format`, dropping the PChar buffers and the `asm add esp,N` cleanups.

### Routines (one commit each)
| Routine | Output | Notes |
|---|---|---|
| `BandChangeReport` | `BandChange.txt` | per-change line + second-radio footer |
| `ExportToEDIByBand` | `<call>_<band>.EDI` | header + per-QSO block |
| `ExportToCSV` | `<log>.CSV` | per-QSO line |

### Two issues found and fixed along the way
1. **`%03d` of negative values (EDI QSO numbers).** C `%03d` zero-pads to *width* 3 with the sign counted in the width (`-1` → `"-01"`); Delphi `%.3d` pads *digits* (`-1` → `"-001"`). They match for non-negatives but diverge for the `-1` "no serial received" sentinel. Reproduced C semantics with `SysUtils.Format`'s `*`-precision feature: `'%.*d'` with precision `3 - Ord(v < 0)`. No custom function.
2. **`ExportToCSV` wrote outside its `GoodLookingQSO` guard.** The `end` closed the guard one line before the write, so a CSV line was emitted for *every* record read — re-using the stale buffer for skipped/deleted/non-QSO records. Moved the write inside the guard so only good QSOs are written.

### Also
- `ExportToEDIByBand` per-QSO block had a benign 8-byte stack over-pop (`add esp,72` for 16 args); removed with the asm.
- nil flag-arrays (new/dupe) → `string(nil)` = `''` (EDI blank field).
- `%02d`→`%.2d` for date/time fields (always non-negative — verified equivalent).

### Validation
- FullBuild: 817 unit tests pass; tr4w.exe + server build clean.
- **Output-diff validated against a release build:** `BandChange.txt`, `.EDI` (20m + 40m), and `.CSV` all confirmed byte-equivalent to the asm version (CSV on a clean-QSO log; the out-of-guard fix only drops duplicate lines for logs containing filtered records).

Follows the same template as batches 1 (#1013) and 2 (#1014).