### PR TITLE
PostUnit asm removal 4g: CABRILLO_MYEX/HISEX PChar buffers -> strings (Part of #998)

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -175,8 +175,8 @@ var
 
   CABRILLO_RST_SEND                     : array[0..3] of Char;
   CABRILLO_RST_RCVD                     : array[0..3] of Char;
-  CABRILLO_MYEX                         : array[0..64 - 1] of Char;
-  CABRILLO_HISEX                        : array[0..64 - 1] of Char;
+  CABRILLO_MYEX                         : string;   // Issue #998: was array[0..63] of Char
+  CABRILLO_HISEX                        : string;   // Issue #998: was array[0..63] of Char
 
   ADIF_FREQ_STRING                      : array[0..15] of Char;
 
@@ -2275,16 +2275,16 @@ end;
 // custom Format(CABRILLO_*) idioms with standard SysUtils.Format.  They write the
 // formatted exchange into the fixed CABRILLO_MYEX / CABRILLO_HISEX buffers (kept
 // until every case arm in tGenerateLogPortionOfCabrilloFile is converted; a later
-// sub-batch turns those buffers into strings -- at which point only these two
-// bodies change, not the ~33 call sites).  PChar args are passed as string(p).
+// the formatted exchange into the CABRILLO_MYEX / CABRILLO_HISEX string globals.
+// PChar args are passed as string(p).
 procedure SetMyEx(const fmt: string; const args: array of const);
 begin
-   StrPCopy(CABRILLO_MYEX, SysUtils.Format(fmt, args));
+   CABRILLO_MYEX := SysUtils.Format(fmt, args);
 end;
 
 procedure SetHisEx(const fmt: string; const args: array of const);
 begin
-   StrPCopy(CABRILLO_HISEX, SysUtils.Format(fmt, args));
+   CABRILLO_HISEX := SysUtils.Format(fmt, args);
 end;
 
 function tGenerateLogPortionOfCabrilloFile: boolean;
@@ -2533,8 +2533,10 @@ if TempRXData.DomMultQTH = '' then
       Windows.lstrcat(CABRILLO_RST_RCVD, '599');
 }
           {Make Exchanges Strings}
-      Windows.ZeroMemory(@CABRILLO_MYEX,SizeOf(CABRILLO_MYEX));
-      Windows.ZeroMemory(@CABRILLO_HISEX,SizeOf(CABRILLO_HISEX));
+      // Issue #998: cleared each QSO so an arm that writes only one side leaves
+      // the other empty (was ZeroMemory on the fixed buffers).
+      CABRILLO_MYEX := '';
+      CABRILLO_HISEX := '';
       case ActiveExchange of
 
         // Issue #998: GridExchange and Grid2Exchange had byte-identical bodies
@@ -2951,7 +2953,9 @@ if TempRXData.DomMultQTH = '' then
       end;
 //----------------------------
 
-      StrUpper(CABRILLO_HISEX);
+      // Issue #998: StrUpper (ASCII a-z only) on the old PChar buffer -> UpperCase
+      // on the string (also ASCII a-z; Cabrillo exchanges are ASCII so identical).
+      CABRILLO_HISEX := UpperCase(CABRILLO_HISEX);
 
   if CategoryOperator = coMULTIOP then
       if temprxdata.cecomputerid = ComputerID then        // 4.73.6
@@ -2972,9 +2976,9 @@ if TempRXData.DomMultQTH = '' then
          sFmt := '%s%s%-15s%-10s %-5s'#13#10;        // 4.100.3
       sWriteFileFromString(tReportFileWrite, SysUtils.Format(sFmt,
         [sFirstPart,
-         string(PChar(@CABRILLO_MYEX[0])),
+         CABRILLO_MYEX,
          string(HisCallsign),
-         string(PChar(@CABRILLO_HISEX[0])),
+         CABRILLO_HISEX,
          string(T4)]));
 
       previousqsonr := nrReceived mod 1000;


### PR DESCRIPTION
Part of #998. Final cleanup of `tGenerateLogPortionOfCabrilloFile`: converts the last two exchange buffers, `CABRILLO_MYEX` / `CABRILLO_HISEX`, from `array[0..63] of Char` to Delphi `string`. This is the buffer→string step the `SetMyEx`/`SetHisEx` helper design (4b) was built to enable.

### Six touchpoints
- **`SetMyEx`/`SetHisEx`**: `StrPCopy(buf, SysUtils.Format(...))` → `BUF := SysUtils.Format(...)` (the single-place change the helpers were structured for).
- **Per-QSO clear**: `ZeroMemory(@buf, SizeOf(buf))` → `BUF := ''` (preserves the "an arm that writes only one side leaves the other empty" behavior).
- **`StrUpper(CABRILLO_HISEX)`** → `CABRILLO_HISEX := UpperCase(...)`. The unit's `StrUpper` (utils_text.pas) uppercases ASCII `a..z` only; Delphi `UpperCase` does the same — identical for ASCII Cabrillo exchanges.
- **Final-assembly read**: `string(PChar(@buf[0]))` → `BUF` directly.
- `logger.debug([CABRILLO_MYEX])` works unchanged with a string arg.

### Benefit
Removes the last two fixed PChar buffers in the routine (and the implicit 64-byte truncation cap they imposed). The exchange path is now pure string production — the prerequisite for the planned capstone (lifting it into a testable `FormatExchange` unit with golden-line tests).

### Validation
- FullBuild: 817 unit tests pass; both EXEs clean.
- **Output-neutral refactor, re-diffed against release** on 4 contests spanning the exchange shapes: Field Day (class/section), CQ WPX (RST+serial), CQ WW (RST+zone), CQ VHF (grid) — all byte-identical.

With this, `tGenerateLogPortionOfCabrilloFile` is fully off inline asm, custom `Format(CABRILLO_*)`, and PChar exchange buffers. (QTC block output still pending Howie's WAE check from #1024.)