### PR TITLE
Remove inline asm from 6 small units (wsprintf-push -> Format) (Part of #997)

### DIFF
--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -1922,12 +1922,12 @@ var
 begin
 
   Score := TotalScore;
-  asm
-  push eax
-  end;
-  wsprintf(wsprintfBuffer, TC_PTS);
-  asm add esp,12
-  end;
+  // Issue #997: asm-push wsprintf -> Format (the TF.Format idiom already used
+  // ~18x in this unit; LOGWIND deliberately avoids SysUtils -- see the BoolToStr
+  // note below).  The old code relied on `Score := TotalScore` leaving the value
+  // in EAX for the `push eax` -- a fragile Delphi-7 codegen assumption that 64-bit
+  // would break.  TC_PTS = '%d Pts'.
+  Format(wsprintfBuffer, TC_PTS, Score);
   SetMainWindowText(mweTotalScore, wsprintfBuffer);
 
   //  tSetWindowText(TotalScoreWindowHandle, IntToStr(Score) + ' Pts');

--- a/tr4w/src/uDistance.pas
+++ b/tr4w/src/uDistance.pas
@@ -67,12 +67,8 @@ begin
           if Grid2 = '' then Exit;
 
           I := GetDistanceBetweenGrids(Grid1, Grid2);
-          asm
-          push i
-          end;
-          wsprintf(wsprintfBuffer, '%u km');
-          asm add esp,12    end;
-          Windows.SetDlgItemText(hwnddlg, 108, wsprintfBuffer);
+          // Issue #997: asm-push wsprintf -> SysUtils.Format (single %u arg = I).
+          Windows.SetDlgItemText(hwnddlg, 108, PChar(SysUtils.Format('%u km', [I])));
 
           TR4W_WM_SetTest(hwnddlg, 108, IntToStr(GetDistanceBetweenGrids(Grid1, Grid2)) + ' km');
           TR4W_WM_SetTest(hwnddlg, 109, IntToStr(GetEuropeanDistanceBetweenGrids(Grid1, Grid2)) + ' km');

--- a/tr4w/src/uEditQSO.pas
+++ b/tr4w/src/uEditQSO.pas
@@ -834,15 +834,8 @@ begin
     if FType = ctInteger then
       w := PDWORD(ValueAdr)^;
 
-    asm
-      xor eax,eax
-      mov eax,dword ptr W
-      push eax
-    end;
-
-    wsprintf(IntToPCharBuffer, '%d');
-    asm add esp,12
-    end;
+    // Issue #997: asm-push wsprintf -> Format (single %d arg = W).
+    Format(IntToPCharBuffer, '%d', W);
     Value := IntToPCharBuffer;
   end;
   tCreateStaticWindow(Caption, LeftStyle, 10, CurrentEditRow * 20 + 400, 70, ws,

--- a/tr4w/src/uLogSearch.pas
+++ b/tr4w/src/uLogSearch.pas
@@ -41,7 +41,7 @@ function LogSearchDlgProc(hwnddlg: HWND; Msg: UINT; wParam: wParam; lParam: lPar
 procedure EditLogInSearch;
 
 implementation
-uses MainUnit;
+uses MainUnit, SysUtils;   // Issue #997: SysUtils for Format/StrPCopy
 const
   MAXSEARCHINDEX                        = 255;
 var
@@ -146,14 +146,10 @@ begin
                 end;
               end;
               CloseLogFile;
-              asm
-              call GetTickCount
-              sub eax, StartCPU
-              push eax
-              push LogSearchListViewIndex
-              end;
-              wsprintf(wsprintfBuffer, TC_ENTRIESPERMS);
-              asm add esp,16 end;
+              // Issue #997: asm-push wsprintf -> SysUtils.Format.
+              // TC_ENTRIESPERMS = '%u entries per %u ms'; args = index, elapsed ms.
+              StrPCopy(wsprintfBuffer, SysUtils.Format(TC_ENTRIESPERMS,
+                [LogSearchListViewIndex, Windows.GetTickCount - StartCPU]));
               Windows.SetDlgItemText(hwnddlg, 104, wsprintfBuffer);
               if LogSearchListViewIndex > 0 then EnsureListViewColumnVisible(LogSearchListView);
             end;

--- a/tr4w/src/uNewContest.pas
+++ b/tr4w/src/uNewContest.pas
@@ -681,12 +681,8 @@ end;
 
 procedure DisplayCheckBox(Text: PChar);
 begin
-  asm
-  push Text
-  end;
-  wsprintf(wsprintfBuffer, TC_IAMIN);
-  asm add esp,12
-  end;
+  // Issue #997: asm-push wsprintf -> Format (TC_IAMIN = '&I am in %s').
+  Format(wsprintfBuffer, TC_IAMIN, Text);
   Windows.SetWindowText(NewContestCheckBox, wsprintfBuffer);
   Windows.ShowWindow(NewContestCheckBox, SW_SHOW);
 end;
@@ -701,13 +697,9 @@ end;
 procedure EnterCountyOrState(State: PChar);
 begin
   DisplayInitialCommand(icmyState);
-  asm
-  push State
-  push State
-  end;
-  wsprintf(wsprintfBuffer, TC_ENTERYOURCOUNTYORSTATEPOROVINCEDX);
-  asm add esp,16
-  end;
+  // Issue #997: asm-push wsprintf -> Format. TC_ENTERYOURCOUNTYORSTATEPOROVINCEDX
+  // has two %s, both = State.
+  Format(wsprintfBuffer, TC_ENTERYOURCOUNTYORSTATEPOROVINCEDX, State, State);
   Windows.SetWindowText(NewContestCommentWndHandle, wsprintfBuffer);
 end;
 

--- a/tr4w/src/uSpots.pas
+++ b/tr4w/src/uSpots.pas
@@ -102,6 +102,7 @@ var
 
 implementation
 uses
+  SysUtils,   // Issue #997: Format/StrPCopy
   LOGSUBS2,
   MainUnit,
   uNet,
@@ -385,11 +386,8 @@ begin
   // immediately without erasing — owner-draw items fill their own background.
   ValidateRect(BandMapListBox, nil);
   RedrawWindow(BandMapListBox, nil, 0, RDW_INVALIDATE or RDW_NOERASE or RDW_UPDATENOW);
-  asm push NumberEntriesDisplayed
-  end;
-  wsprintf(wsprintfBuffer, TC_SPOTS);
-  asm add esp,12
-  end;
+  // Issue #997: asm-push wsprintf -> SysUtils.Format (TC_SPOTS = '%d spots').
+  StrPCopy(wsprintfBuffer, SysUtils.Format(TC_SPOTS, [NumberEntriesDisplayed]));
   SetTextInBMSB(5, wsprintfBuffer);
   if NumberEntriesDisplayed = 0 then
     ClearSpotInfo;


### PR DESCRIPTION
Part of TR4W/TR4W-D12#24 (remove inline x86 asm for 64-bit Delphi). First batch of the **small units** (<10 asm blocks) — the clean `wsprintf`-push idiom converted to `Format`. Six units whose *entire* real asm was this pattern, so each is now fully asm-free.

### Units (one commit each)
| Unit | Conversion |
|---|---|
| `uDistance` | `'%u km'` distance label → `SysUtils.Format` |
| `uSpots` | `TC_SPOTS` ('%d spots') → `SysUtils.Format` (added SysUtils to uses) |
| `uLogSearch` | `TC_ENTRIESPERMS` ('%u entries per %u ms'), incl. `GetTickCount-StartCPU` → `SysUtils.Format` (added SysUtils to uses) |
| `LOGWIND` (`DisplayTotalScore`) | fragile `push eax` (relied on `Score:=TotalScore` leaving the value in EAX) → `Format(buf, TC_PTS, Score)` |
| `uNewContest` | 2 sites: `TC_IAMIN`, `TC_ENTER…` (two %s) → `Format` |
| `uEditQSO` | `'%d'` of W → `Format` |

### Notes
- **`Format` source per unit:** used `SysUtils.Format` where the unit had/could take SysUtils; used the unit's existing **`TF.Format`** (external `wsprintfA`) for legacy units that deliberately avoid SysUtils (LOGWIND has an explicit "avoid pulling SysUtils" comment and 18 existing `TF.Format` calls — adding SysUtils would ambiguate them). Per NY4I, `TF.Format` is acceptable for TR4W/TR4W-D12#24; the `TF.Format`→`SysUtils` modernization is a separate task.
- **`LOGWIND.DisplayTotalScore`** was the only *live* asm in that unit — its other 3 `asm` matches are inside `{ }` comments (dead).
- i18n preserved (kept the `TC_*` format constants).
- The benign `add esp,N` over-pops that accompanied these pushes are gone with them.

### Validation
- FullBuild after each unit: **817 unit tests pass; tr4w.exe + server build clean.**
- These are UI-label / export strings; build-verified (a visual check of the spots count, log-search timing, distance dialog, and total-score display is a nice-to-have but low-stakes).

The remaining small units are mixed (the `tWM_SETFONT` register-convention font idiom, function-call asm, `%#x`/`%C` formats, asm loops) and need a dedicated pass — classified in the issue/notes for follow-up.