### PR TITLE
Capstone: extract testable uCabrilloExchange.FormatCabrilloExchange + golden tests (Part of #998)

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -53,6 +53,7 @@ uses
   LogCW, // 4.53.2
   Windows,
   uCabrilloFormat,  // tCabrilloFreqString / tCabrilloModeString + per-field formatters (extracted from this unit, see uCabrilloFormat.pas)
+  uCabrilloExchange, // #998 capstone: FormatCabrilloExchange (the case ActiveExchange MYEX/HISEX builder, extracted + unit-tested)
   uSuperCheckPartialFileUpload,
   Dialogs;
 
@@ -2271,21 +2272,9 @@ begin
   Result := True;
 end;
 
-// Issue #998: thin wrappers that replace the per-exchange asm-push wsprintf and
-// custom Format(CABRILLO_*) idioms with standard SysUtils.Format.  They write the
-// formatted exchange into the fixed CABRILLO_MYEX / CABRILLO_HISEX buffers (kept
-// until every case arm in tGenerateLogPortionOfCabrilloFile is converted; a later
-// the formatted exchange into the CABRILLO_MYEX / CABRILLO_HISEX string globals.
-// PChar args are passed as string(p).
-procedure SetMyEx(const fmt: string; const args: array of const);
-begin
-   CABRILLO_MYEX := SysUtils.Format(fmt, args);
-end;
-
-procedure SetHisEx(const fmt: string; const args: array of const);
-begin
-   CABRILLO_HISEX := SysUtils.Format(fmt, args);
-end;
+// Issue #998 capstone: the per-exchange SetMyEx/SetHisEx + the whole
+// `case ActiveExchange of` were extracted into uCabrilloExchange.pas
+// (FormatCabrilloExchange) so the exchange formatting is unit-testable.
 
 function tGenerateLogPortionOfCabrilloFile: boolean;
 label
@@ -2319,6 +2308,7 @@ var
   sFmt                                  : string;     // Issue #998: assembly format string
   sCall1                                : string;     // Issue #998: QTC from-call (QTCR/QTCS swap)
   sCall2                                : string;     // Issue #998: QTC to-call (QTCR/QTCS swap)
+  myStationEx                           : TMyStationExchange;  // #998 capstone: My-station fields for FormatCabrilloExchange
   cRandomCharsReceived                  : PChar;
   cKids                                 : PChar;
   TempGrid                              : Str20;
@@ -2533,424 +2523,25 @@ if TempRXData.DomMultQTH = '' then
       Windows.lstrcat(CABRILLO_RST_RCVD, '599');
 }
           {Make Exchanges Strings}
-      // Issue #998: cleared each QSO so an arm that writes only one side leaves
-      // the other empty (was ZeroMemory on the fixed buffers).
-      CABRILLO_MYEX := '';
-      CABRILLO_HISEX := '';
-      case ActiveExchange of
-
-        // Issue #998: GridExchange and Grid2Exchange had byte-identical bodies
-        // (only the debug-log label differed); merged into one case label.
-        GridExchange, Grid2Exchange:
-          begin
-            SetMyEx('%-11s', [string(cMyGrid)]);
-            logger.debug('[CabDetail-GridExchange] MyExchange = (%s)',[CABRILLO_MYEX]);
-            SetHisEx('%-11s', [string(csQTHString)]);
-          end;
-
-        RSTAndGrid3Exchange:                // 4.96.3
-          begin
-            SetMyEx('%-7s%-11s ', [string(RSTSent), string(cMyGrid)]);
-            SetHisEx('%-3s %-11s ', [string(RSTReceived), string(csQTHString)]);
-          end;
-
-        RSTNameAndQTHExchange:
-          begin
-            SetMyEx('%-3s %-5s %-7s', [string(RSTSent), string(cMyName), string(cMyState)]);
-            SetHisEx('%-3s %-5s %-7s', [string(RSTReceived), string(csName), string(csQTHString)]);
-          end;
-
-        QSONumberAndNameExchange:
-          begin
-            SetMyEx('%-3d %-7s', [nrSent, string(cMyName)]);
-            SetHisEx('%-3u %-7s', [nrReceived, string(csName)]);
-          end;
-
-
-
-
-        RSTAndPostalCodeExchange:
-          begin
-            if contacts = 1 then
-              SetMyEx('%-3s %-10s', [string(RSTSent), string(PChar(@MyPostalCode[1]))])
-            else
-              SetMyEx('%-3s %-10s', [string(RSTSent), string(PChar(@PreviousQTHString[1]))]);
-            SetHisEx('%-3s %-10s', [string(RSTReceived), string(PChar(@TempRXData.QTHString[1]))]);
-          end;
-
-        RSTQSONumberAndGridSquareExchange:
-          begin
-            // %-4.4d/%-4.4u carry a precision, so C->Delphi maps directly.
-            SetMyEx('%-3s %-4.4d %-7s', [string(RSTSent), nrSent, string(cMyGrid)]);
-            SetHisEx('%-3s %-4.4u %-7s', [string(RSTReceived), nrReceived, string(csQTHString)]);
-          end;
-
- {         RSTAndSerialNumberAndGridandPossibleMemberNumber:
-          begin
-          end;
-  }
-       RSTQSONumberOrDomesticQTHExchange:      //n4af 4.40.6
-          begin
-         p  := (IntToPchar(nrReceived)) ;
-
-          if nrReceived <  1 then
-          p := nil;
-
-          if cMystate[1] <> '' then
-             begin
-             SetMyEx('%-3s  %-8s', [string(RSTSent), string(cMyState)]);        // 4.98.11
-             end;
-
-          if cMystate[1] = '' then
-             begin
-             SetMyEx('%-3s  %-6d', [string(RSTSent), nrSent]);
-             end;
-
-          if p <> nil then
-             begin
-             SetHisEx('%-3s %6d %-6s', [string(RSTReceived), nrReceived, string(csQTHString)]);
-             end;
-          if p = nil then
-             begin
-             SetHisEx('%-3s   %9s', [string(RSTReceived), string(csQTHString)]);
-             end;
-            end;
-
-        RSTPrefectureExchange:
-          begin
-            SetMyEx('%-3s %-7d', [string(RSTSent), cMyZone]);
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-          end;
-
-        NameAndDomesticOrDXQTHExchange:
-          begin
-            // cMyName was PChar(string(MyName)) (null-terminated copy of MyName);
-            // string(MyName) yields the same content directly.
-            SetMyEx('  %-10s %-4s', [string(MyName), string(cMyState)]);
-            SetHisEx('  %-10s %-4s', [string(csName), string(csQTHString)]);
-          end;
-
-        QSONumberPrecedenceCheckDomesticQTHExchange:
-          begin
-            CID_TWO_BYTES[0] := TempRXData.Precedence;
-            csName := CID_TWO_BYTES;
-
-            cMyName := @MyPrec[1] ;
-            csCheck := {inttopchar}(TempRXData.Check);
-            cMyCheck := @MyCheck[1];
-            cMyState := @MySection[1];
-
-            // Issue #998. MYEX: serial, my-prec, my-check, my-section.
-            SetMyEx('%-4d %s %s %-3s ', [nrSent, string(cMyName), string(cMyCheck), string(cMyState)]);
-            if nrReceived = -1 then
-            nrReceived := 0;
-            // HISEX: serial, his-prec(csName), his-check(%02u -> %.2u), his-section.
-            SetHisEx('%-4d %s %.2u %-3s', [nrReceived, string(csName), csCheck, string(csQTHString)]);
-          end;
-
-        QSONumberNameDomesticOrDXQTHExchange:
-          begin
-            csName := @TempRXData.Name[1];
-            cMyName := @MyName[1];
-            if MyState = '' then cMyState := 'DX';
-            if TempRXData.QTHString = '' then csQTHString := 'DX';
-
-            SetMyEx('%-4d %-7s %-8s', [nrSent, string(cMyName), string(cMyState)]);    // 4.88.3
-            SetHisEx('%-4u %-5s %-4s', [nrReceived, string(csName), string(csQTHString)]);  // 4.88.3
-          end;
-
-        RSTAgeAndPossibleSK:
-          begin
-            SetMyEx('%-3s %-16s', [string(RSTSent), string(cMyState)]);
-            nrReceived := TempRXData.Age;
-            SetHisEx('%-3s %u %s', [string(RSTReceived), nrReceived, string(csQTHString)]);
-          end;
-
-        RSTAgeExchange:
-          begin
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-            nrReceived := TempRXData.Age;
-            SetHisEx('%-3s %-7u', [string(RSTReceived), nrReceived]);
-          end;
-
-        AgeAndQSONumberExchange:      // 4.55.4
-          begin
-            // nrSent '%03d' / nrReceived '%04d' = zero-pad to WIDTH (sign in
-            // width) -> '%.*d' + precision N-Ord(v<0) (EDI negative note).
-            SetMyEx('%-2s %.*d ', [string(cMyState), 3 - Ord(nrSent < 0), nrSent]);
-            hisAge := TempRXData.Age ;
-            nrreceived := TempRXData.NumberReceived;          // n4af 04.42.4
-            SetHisEx(' %-3d %.*d', [hisAge, 4 - Ord(nrReceived < 0), nrReceived]);   // n4af 4.42.4
-          end;
-
-         QSONumberAndAgeExchange:      // 4.119.1
-          begin
-            // Unreachable by any active contest (no AE: / no FCONTEST assign);
-            // converted for completeness.  RSTSent here is the numeric RST.
-            // nrSent '%03d' -> '%.*d' (sign-in-width); hisAge '%02d' -> '%.2d'.
-            SetMyEx('%-3d %.*d %-2s      ', [TempRXData.RSTSent, 3 - Ord(nrSent < 0), nrSent, string(cMyState)]);
-            hisAge := TempRXData.Age ;
-            nrreceived := TempRXData.NumberReceived;          // n4af 04.42.4
-            SetHisEx(' %-3d %3d %.2d', [TempRXData.RSTSent, nrReceived, hisAge]);       // n4af 4.42.4
-          end;
-
-        RSTPowerExchange:
-        begin
-         csPower := @TempRXData.Power[1];
-         if contest = FOCMARATHON then
-            begin
-            cMyFOCNumber :=  @MyFOCNumber[1];
-            crFOCNr := @TempRXData.Power[1];
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyFOCNumber)]);
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(crFOCNr)]);
-            end;
-         if Contest <> FOCMARATHON then
-            begin
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(csPower)]);
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-            end;
-          end;
-        RSTAndOrGridExchange:
-          begin
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyGrid)]);
-          end;
-
-        QSONumberAndGridSquare:
-          begin
-            // nrSent '%03d' -> '%.*d' (sign-in-width); '%-6.4s' truncates to 4
-            // chars (precision) -- maps directly.  '%03.4u': precision present
-            // so C ignores the 0 flag -> '%3.4u'.
-            SetMyEx('%.*d %-6.4s ', [3 - Ord(nrSent < 0), nrSent, string(cMyState)]);
-            SetHisEx('%3.4u %-6s', [nrReceived, string(csQTHString)]);
-          end;
-
-        QSONumberDomesticOrDXQTHExchange, QSONumberDomesticQTHExchange:
-          if (Contest = UKRAINECHAMPIONSHIP) or (Contest = CUPURAL) then
-          begin
-            SetMyEx('%-4s %-6.4d', [string(cMyState), nrSent]);
-            SetHisEx('%-4s %-6.4u', [string(csQTHString), nrReceived]);
-          end
-          else
-          begin
-            SetMyEx('%-4d %-6s', [nrSent, string(cMyState)]);
-            SetHisEx('%-4.4u %-6s', [nrReceived, string(csQTHString)]);
-          end;
-
-        QSONumberAndPossibleDomesticQTHExchange, RSTQSONumberAndDomesticQTHExchange, RSTQSONumberAndPossibleDomesticQTHExchange:
-          begin
-            // All nrSent/nrReceived specs here carry a width or precision (%d,
-            // %3.3d, %-4.4d, %4.4d, %5.3d, %5d) -- none is a bare %0Nd -- so the
-            // C->Delphi mapping is direct (no %.*d needed).
-            if cMyState = 'TRC' then      // 4.63.3
-               SetMyEx('%-3s %d%-6s', [string(RSTSent), nrSent, string(cMyState)])
-            else if ContestTitle = 'PGA' then       // 4.92.4
-               SetMyEx('%-3s %3.3d%s     ', [string(RSTSent), nrSent, string(cMyState)])
-            else
-               SetMyEx('%-3s %-4.4d %6s      ', [string(RSTSent), nrSent, string(cMyState)]);
-
-            if Contest = UKEI then           // 4.58.2
-            if TempRXData.QTHString = '' then
-               csQTHString := '--';
-
-            if Contest = IOTA then
-            begin
-              if csQTHString[0] = #0 then csQTHString := '------';
-              {
-              else
-              begin
-                Windows.ZeroMemory(@IOTAString, SizeOf(IOTAString));
-                IOTAString := Copy(TempRXData.DomesticQTH, 1, 2) + '-' + Copy(TempRXData.DomesticQTH, 3, 3);
-                csQTHString := @IOTAString[1];
-              end;
-              }
-            end;
-
-            if Contest = DARC10M then     // n4af 4.43.7
-               SetHisEx('%-3s %4.4d %3s', [string(RSTReceived), nrReceived, string(csQTHString)])
-            else if ContestTitle = 'PGA' then           // 4.92.4
-               SetHisEx('%-3s%5.3d%s', [string(RSTReceived), nrReceived, string(csQTHString)])
-            else if csQTHString = 'TRC' then      // 4.63.3
-               SetHisEx('%-3s%5d%-8s', [string(RSTReceived), nrReceived, string(csQTHString)])
-            else
-               SetHisEx('%-3s %4.4d %4s', [string(RSTReceived), nrReceived, string(csQTHString)]);
-          end;
-
-        RSTZoneAndPossibleDomesticQTHExchange:
-          begin
-            if MyState = '' then
-              cMyState := 'DX';
-
-            SetMyEx('%-3s %.2u %-4s', [string(RSTSent), cMyZone, string(cMyState)]);
-
-            if TempRXData.QTHString = '' then
-              csQTHString := 'DX';
-            SetHisEx('%-3s %.2u %-3s', [string(RSTReceived), HisZone, string(csQTHString)]);
-          end;
-
-        RSTZoneOrDomesticQTH, RSTZoneOrSocietyExchange:
-          begin
-            if MyState <> '' then
-               begin
-               SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-               end
-            else
-               begin
-               SetMyEx('%-3s %-7d', [string(RSTSent), cMyZone]);
-               end;
-
-            if TempRXData.QTHString <> '' then
-               begin
-               SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-               end
-            else
-               begin
-               SetHisEx('%-3s %-7u', [string(RSTReceived), HisZone]);
-               end;
-          end;
-
-        QSONumberAndCoordinatesSum: {RFASCHAMPIONSHIP}
-          begin
-            // %03.4d/%03.4u: precision present -> C drops the 0 flag -> %3.4d/%3.4u.
-            SetMyEx('%-3s %3.4d    ', [string(cMyState), nrSent]);
-            SetHisEx('%-3s %3.4u', [string(csQTHString), nrReceived]);
-          end;
-
-        ClassDomesticOrDXQTHExchange:
-          begin
-            SetMyEx('%-3s %-7s ', [string(PChar(@MyFDClass[1])), string(PChar(@MySection[1]))]);
-            if Contest in [ARRLFIELDDAY, WINTERFIELDDAY] then
-               begin
-               csQTHString := @TempRXData.QTHString[1];   // Issue 407 ny4i
-               end;
-            SetHisEx('%-3s %-7s', [string(PChar(@TempRXData.ceClass[1])), string(csQTHString)]);
-          end;
-
-        QSONumberAndGeoCoordinates:
-          begin
-            SetMyEx('%-3.4d %-7s ', [nrSent, string(cMyState)]);
-            SetHisEx('%-3.4u %-7s', [nrReceived, string(csQTHString)]);
-          end;
-
-        RSTQSONumberExchange:
-          begin
-            // Issue #998.  nrSent was C '%03d' (zero-pad to WIDTH 3, sign counted
-            // in the width); reproduced with '%.*d' + precision 3-Ord(v<0) (see
-            // the EDI %0Nd-of-negatives note).  nrReceived was '%-03.3u' -- a
-            // precision is present so C ignores the 0 flag, giving '%-3.3u'.
-            SetMyEx('%-3s %.*d ', [string(RSTSent), 3 - Ord(nrSent < 0), nrSent]);   // issue 177
-            SetHisEx('%-3s %-3.3u', [string(RSTReceived), nrReceived]);              // issue 177
-          end;
-        RSTAndContinentExchange:
-          begin
-            csQTHString := @TempRXData.QTHString[1];
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-          end;
-
-        RSTDomesticQTHExchange:
-          begin
-            if Contest in [ CQVHF {, MMAA}] then
-            begin
-              SetHisEx(' %-7s', [string(csQTHString)]);
-              SetMyEx('%-7s', [string(cMyGrid)]);
-            end
-            else
-            begin
-              if MyState = '' then cMyState := 'DX';
-//              if MyCounty <> '' then cMyState := @MyCounty[1];
-              if Contest in [SPDX, PACC] then cMyState := inttopchar(nrSent);
-              if TempRXData.QTHString = '' then csQTHString := 'DX';
-              SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-              SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-            end;
-          end;
-
-        RSTDomesticOrDXQTHExchange:
-           begin
-                //-                if MyState = '' then cMyState := 'DX';
-           if TempRXData.QTHString = '' then
-              begin
-              if TempRXData.DXQTH = '' then
-                 begin
-                 csQTHString := 'DX';
-                 end
-              else
-                 begin
-                 if Contest = FLORIDAQSOPARTY then
-                    begin
-                    csQTHString := @TempRXData.QTH.Prefix[1];
-                    end
-                 else
-                    begin
-                    csQTHString := @TempRXData.DXQTH[1];
-                    end;
-                 end;
-              end
-           else if TempRXData.QTHString = 'DX' then
-              begin
-              if Contest = FLORIDAQSOPARTY then
-                 begin
-                 csQTHString := @TempRXData.QTH.Prefix[1];
-                 end;
-              end;
-
-            SetHisEx('%-3s %-7s', [string(RSTReceived), string(csQTHString)]);
-            SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-          end;
-
-        QSONumberAndZone:
-          begin
-//            if (Contest = RFCHAMPIONSHIPSSB) or (Contest = RFCHAMPIONSHIPCW) then
-            // %0.3d / %03.4d: precision present -> C drops the 0 flag -> %.3d / %3.4d.
-            SetHisEx('  %-4u   %.3d', [HisZone, nrReceived]);   // 4.98.4
-            SetMyEx('  %s    %3.4d ', [string(cMyState), nrSent]);
-          end;
-
-        RSTZoneExchange:
-          begin
-            if Contest in [JIDXSSB, JIDXCW] then cMyZone := StrToInt(MyState);
-            SetHisEx('%-3s %-7.2d', [string(RSTReceived), HisZone]);   // 4.51.1 issue185
-            SetMyEx('%-3s %-7.2d', [string(RSTSent), cMyZone]);        // 4.51.1 issue#185
-          end;
-
-         QSONumberAndPreviousQSONumber:
-          begin
-          hisnr := (nrreceived div 1000);    // 4.53.2
-           rxnr := (nrreceived mod 1000);    // 4.53.2
-            SetMyEx('%-.3u%-7.4d', [pnr, nrSent]);    // 4.72.9
-          //  pnr := temprxdata.numberreceived div  1000;      // 4.53.2
-              pnr := RXNR;
-            SetHisEx('%-.4d%-.4d', [HisNR, RXNR]);    // 4.53.4        // 4.72.9
-          end;
-
-        RSTAndQSONumberOrFrenchDepartmentExchange, RSTAndQSONumberOrDomesticQTHExchange, RSTDomesticQTHOrQSONumberExchange:
-          begin
-           // %03.4u: precision present -> %3.4u.  %03u (HISEX else): no precision,
-           // unsigned, so %.3u == %03u (no sign, no negative-zero-pad concern).
-           if (MyState <> '') and (Contest <> PCC) then      // 4.83.2
-              begin
-              SetMyEx('%-3s %-7s', [string(RSTSent), string(cMyState)]);
-              end
-           else if StringIsAllNumbers(MyState) then
-              begin
-              SetMyEx('%-4s %3.4u/M   ', [string(RSTSent), nrSent]);  // n4af 4.43.12
-              end
-           else
-              begin
-              SetMyEx('%-4s %3.4u   ', [string(RSTSent), nrSent]);  // n4af 4.43.12
-              end;
-
-            if TempRXData.QTHString {.DomMultQTH} <> '' then
-               begin
-               SetHisEx('%-3s %-3s', [string(RSTReceived), string(csQTHString)]); // 4.84.2
-               end
-            else
-               begin
-               SetHisEx('%-3s %.3u', [string(RSTReceived), nrReceived]);
-               end;
-          end;
-      end;
+      // Issue #998 capstone: the per-exchange MYEX/HISEX builder was extracted
+      // into uCabrilloExchange.FormatCabrilloExchange (dependency-light + unit-
+      // tested).  Build the My-station record and pass the per-QSO derived
+      // strings; it fills CABRILLO_MYEX / CABRILLO_HISEX (and carries pnr).
+      myStationEx.MyState      := string(MyState);
+      myStationEx.MyGrid       := string(MyGrid);
+      myStationEx.MyName       := string(MyName);
+      myStationEx.MyZone       := string(MyZone);
+      myStationEx.MyFDClass    := string(MyFDClass);
+      myStationEx.MySection    := string(MySection);
+      myStationEx.MyCheck      := string(MyCheck);
+      myStationEx.MyPrec       := string(MyPrec);
+      myStationEx.MyFOCNumber  := string(MyFOCNumber);
+      myStationEx.MyPostalCode := string(MyPostalCode);
+      FormatCabrilloExchange(ActiveExchange, Contest, ContestTitle, ContestName,
+        TempRXData, myStationEx,
+        string(RSTSent), string(RSTReceived), string(csQTHString),
+        string(PChar(@PreviousQTHString[1])),
+        contacts, pnr, CABRILLO_MYEX, CABRILLO_HISEX);
 //----------------------------
 
       // Issue #998: StrUpper (ASCII a-z only) on the old PChar buffer -> UpperCase

--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -2285,19 +2285,7 @@ var
   RSTReceived                           : PChar;
   Freq                                  : PChar;
   ModeString                            : PChar;
-  cMyZone                               : integer;
-  cMyState                              : PChar;
-  cMyName                               : PChar;
-  csName                                : PChar;
-  cMyFOCNumber                          : PChar;
-  cMyCheck                              : PChar;
-  csCheck                               : integer {PChar};
-  crFOCNr                               : PChar;
-  cMyGrid                               : PChar;
-  csPower                               : PChar;
-  hisAge                                : Integer;
   csQTHString                           : PChar;
-  HisZone                               : integer;
   nrReceived                            : integer;
   nrSent                                : integer;
   tempcategoryoperator                  : tcategoryoperator;
@@ -2311,14 +2299,11 @@ var
   myStationEx                           : TMyStationExchange;  // #998 capstone: My-station fields for FormatCabrilloExchange
   cRandomCharsReceived                  : PChar;
   cKids                                 : PChar;
-  TempGrid                              : Str20;
   previousqsonr                         : integer;
   TransmitterIDPos                      : integer;
   contacts                              : integer;
   PreviousQTHString                     : Str10;
   pnr                                   : integer;
-  hisnr                                 : integer;
-  rxnr                                  : integer;
   slOperators                           : TStringList;
 
 
@@ -2340,17 +2325,9 @@ begin
       try
       slOperators := TStringList.Create;
       slOperators.Duplicates := dupIgnore;
-      TempGrid := MyGrid;
-  // Issue #902 -- null-terminate after the actual grid length.
-  // Old code wrote #0 at byte 7 unconditionally; for 4-char grids (e.g. EL88)
-  // that left bytes 5..6 holding uninitialized stack memory, which leaked
-  // into the Cabrillo MY-EXCH column as random non-printables.
-  TempGrid[Length(MyGrid) + 1] := #0;
-  cMyGrid := @TempGrid[1];
-
-  cMyName := @MyName[1];
-  cMyZone := StrToInt(MyZone);
-  cMyState := @MyState[1];
+      // Issue #998 capstone: the My-station / his-zone / his-name locals that fed
+      // the exchange `case` were removed here -- FormatCabrilloExchange now derives
+      // them from the rx/my it is passed (PostUnit builds myStationEx at the call).
 
   previousqsonr := 0;
   1:
@@ -2488,9 +2465,6 @@ if TempRXData.DomMultQTH = '' then
   csQTHString := 'DX';
   end;
   end;
-    HisZone := TempRXData.Zone;
-
-    csName := @TempRXData.Name[1];
 
     if GoodLookingQSO then
     begin

--- a/tr4w/src/uCabrilloExchange.pas
+++ b/tr4w/src/uCabrilloExchange.pas
@@ -1,0 +1,490 @@
+unit uCabrilloExchange;
+
+{
+  Issue #998 capstone -- testable extraction of the per-exchange Cabrillo
+  MY-EXCHANGE / HIS-EXCHANGE builder.
+
+  The logic here was lifted (behaviour-preserving) from
+  trdos/PostUnit.tGenerateLogPortionOfCabrilloFile's `case ActiveExchange of`.
+  It is deliberately DEPENDENCY-LIGHT (uses only VC + SysUtils, no MainUnit /
+  trdos globals / log I/O) so the per-contest exchange formatting can be
+  unit-tested with golden lines -- which it could NOT be while embedded in the
+  1,200-line PostUnit writer.
+
+  PostUnit derives the per-QSO inputs (the display RST strings, the selected
+  HIS-QTH, the My-station fields) and calls FormatCabrilloExchange, then feeds
+  the returned MyEx/HisEx into the QSO: line assembly.  The QSO:/X-QSO: header,
+  the final assembly, the QTC block, StrUpper(HisEx) and file I/O stay in
+  PostUnit -- this unit only PRODUCES the two exchange column strings.
+
+  See plan_cabrillo_exchange_capstone for the phasing.
+}
+
+interface
+
+uses
+  VC,
+  SysUtils;
+
+type
+  // The My-station fields the exchange arms read.  Strings so the unit needs no
+  // globals; PostUnit fills these from MyState / MyGrid / ... at the call site.
+  TMyStationExchange = record
+    MyState     : string;
+    MyGrid      : string;
+    MyName      : string;
+    MyZone      : string;     // StrToInt'd internally (matches the old cMyZone := StrToInt(MyZone))
+    MyFDClass   : string;
+    MySection   : string;
+    MyCheck     : string;
+    MyPrec      : string;
+    MyFOCNumber : string;
+    MyPostalCode: string;
+  end;
+
+// Builds the MY-EXCHANGE (MyEx) and HIS-EXCHANGE (HisEx) Cabrillo columns for
+// one QSO, dispatching on ActiveExchange.  RSTSentIn/RSTReceivedIn are the
+// already-formatted RST display strings; HisQTH is the his-QTH already selected
+// by PostUnit (DoingDomesticMults / LiteralDomesticQTH / ... ); PrevQTH is the
+// previous QSO's QTHString (RSTAndPostalCode); pnr is carried across QSOs
+// (QSONumberAndPreviousQSONumber).  Result is always True (mirrors the old
+// fall-through behaviour).
+function FormatCabrilloExchange(
+    ActiveExchange : ExchangeType;
+    Contest        : ContestType;
+    const ContestTitle, ContestName : string;
+    const rx       : ContestExchange;
+    const my       : TMyStationExchange;
+    const RSTSentIn, RSTReceivedIn, HisQTH, PrevQTH : string;
+    contacts       : integer;
+    var   pnr      : integer;
+    out   MyEx, HisEx : string) : boolean;
+
+implementation
+
+function StringIsAllNumbersLocal(const s: string): boolean;
+var
+  i: integer;
+begin
+  Result := (s <> '');
+  for i := 1 to Length(s) do
+    if not (s[i] in ['0'..'9']) then
+       begin
+       Result := False;
+       Exit;
+       end;
+end;
+
+function FormatCabrilloExchange(
+    ActiveExchange : ExchangeType;
+    Contest        : ContestType;
+    const ContestTitle, ContestName : string;
+    const rx       : ContestExchange;
+    const my       : TMyStationExchange;
+    const RSTSentIn, RSTReceivedIn, HisQTH, PrevQTH : string;
+    contacts       : integer;
+    var   pnr      : integer;
+    out   MyEx, HisEx : string) : boolean;
+var
+  // Mirror the PostUnit per-QSO locals (as strings/ints instead of PChar).
+  RSTSent, RSTReceived, csQTHString, csName,
+  cMyGrid, cMyName, cMyState,
+  csPower, crFOCNr, cMyFOCNumber, cMyCheck : string;
+  cMyZone, nrSent, nrReceived, HisZone, hisAge, csCheck, hisnr, rxnr : integer;
+
+  procedure SetMyEx(const fmt: string; const args: array of const);
+  begin
+    MyEx := SysUtils.Format(fmt, args);
+  end;
+
+  procedure SetHisEx(const fmt: string; const args: array of const);
+  begin
+    HisEx := SysUtils.Format(fmt, args);
+  end;
+
+begin
+  Result := True;
+  MyEx := '';
+  HisEx := '';
+
+  // --- Preamble: initialise the per-QSO locals from rx / my / params,
+  //     mirroring the setup PostUnit did before the case. ---
+  RSTSent     := RSTSentIn;
+  RSTReceived := RSTReceivedIn;
+  csQTHString := HisQTH;
+  csName      := string(rx.Name);
+  cMyGrid     := my.MyGrid;
+  cMyName     := my.MyName;
+  cMyState    := my.MyState;
+  cMyZone     := StrToIntDef(my.MyZone, 0);
+  nrSent      := rx.NumberSent;
+  nrReceived  := rx.NumberReceived;
+  HisZone     := rx.Zone;
+
+  case ActiveExchange of
+
+    GridExchange, Grid2Exchange:
+      begin
+        SetMyEx('%-11s', [cMyGrid]);
+        SetHisEx('%-11s', [csQTHString]);
+      end;
+
+    RSTAndGrid3Exchange:                // 4.96.3
+      begin
+        SetMyEx('%-7s%-11s ', [RSTSent, cMyGrid]);
+        SetHisEx('%-3s %-11s ', [RSTReceived, csQTHString]);
+      end;
+
+    RSTNameAndQTHExchange:
+      begin
+        SetMyEx('%-3s %-5s %-7s', [RSTSent, cMyName, cMyState]);
+        SetHisEx('%-3s %-5s %-7s', [RSTReceived, csName, csQTHString]);
+      end;
+
+    QSONumberAndNameExchange:
+      begin
+        SetMyEx('%-3d %-7s', [nrSent, cMyName]);
+        SetHisEx('%-3u %-7s', [nrReceived, csName]);
+      end;
+
+    RSTAndPostalCodeExchange:
+      begin
+        if contacts = 1 then
+          SetMyEx('%-3s %-10s', [RSTSent, my.MyPostalCode])
+        else
+          SetMyEx('%-3s %-10s', [RSTSent, PrevQTH]);
+        SetHisEx('%-3s %-10s', [RSTReceived, string(rx.QTHString)]);
+      end;
+
+    RSTQSONumberAndGridSquareExchange:
+      begin
+        SetMyEx('%-3s %-4.4d %-7s', [RSTSent, nrSent, cMyGrid]);
+        SetHisEx('%-3s %-4.4u %-7s', [RSTReceived, nrReceived, csQTHString]);
+      end;
+
+    RSTQSONumberOrDomesticQTHExchange:      //n4af 4.40.6
+      begin
+        if cMyState <> '' then
+           begin
+           SetMyEx('%-3s  %-8s', [RSTSent, cMyState]);        // 4.98.11
+           end;
+
+        if cMyState = '' then
+           begin
+           SetMyEx('%-3s  %-6d', [RSTSent, nrSent]);
+           end;
+
+        if nrReceived >= 1 then
+           begin
+           SetHisEx('%-3s %6d %-6s', [RSTReceived, nrReceived, csQTHString]);
+           end;
+        if nrReceived < 1 then
+           begin
+           SetHisEx('%-3s   %9s', [RSTReceived, csQTHString]);
+           end;
+      end;
+
+    RSTPrefectureExchange:
+      begin
+        SetMyEx('%-3s %-7d', [RSTSent, cMyZone]);
+        SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+      end;
+
+    NameAndDomesticOrDXQTHExchange:
+      begin
+        SetMyEx('  %-10s %-4s', [my.MyName, cMyState]);
+        SetHisEx('  %-10s %-4s', [csName, csQTHString]);
+      end;
+
+    QSONumberPrecedenceCheckDomesticQTHExchange:
+      begin
+        csName   := rx.Precedence;       // the precedence character
+        cMyName  := my.MyPrec;
+        csCheck  := rx.Check;
+        cMyCheck := my.MyCheck;
+        cMyState := my.MySection;
+
+        SetMyEx('%-4d %s %s %-3s ', [nrSent, cMyName, cMyCheck, cMyState]);
+        if nrReceived = -1 then
+          nrReceived := 0;
+        SetHisEx('%-4d %s %.2u %-3s', [nrReceived, csName, csCheck, csQTHString]);
+      end;
+
+    QSONumberNameDomesticOrDXQTHExchange:
+      begin
+        csName  := string(rx.Name);
+        cMyName := my.MyName;
+        if my.MyState = '' then cMyState := 'DX';
+        if rx.QTHString = '' then csQTHString := 'DX';
+
+        SetMyEx('%-4d %-7s %-8s', [nrSent, cMyName, cMyState]);    // 4.88.3
+        SetHisEx('%-4u %-5s %-4s', [nrReceived, csName, csQTHString]);  // 4.88.3
+      end;
+
+    RSTAgeAndPossibleSK:
+      begin
+        SetMyEx('%-3s %-16s', [RSTSent, cMyState]);
+        nrReceived := rx.Age;
+        SetHisEx('%-3s %u %s', [RSTReceived, nrReceived, csQTHString]);
+      end;
+
+    RSTAgeExchange:
+      begin
+        SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+        nrReceived := rx.Age;
+        SetHisEx('%-3s %-7u', [RSTReceived, nrReceived]);
+      end;
+
+    AgeAndQSONumberExchange:      // 4.55.4
+      begin
+        SetMyEx('%-2s %.*d ', [cMyState, 3 - Ord(nrSent < 0), nrSent]);
+        hisAge := rx.Age;
+        nrReceived := rx.NumberReceived;          // n4af 04.42.4
+        SetHisEx(' %-3d %.*d', [hisAge, 4 - Ord(nrReceived < 0), nrReceived]);   // n4af 4.42.4
+      end;
+
+    QSONumberAndAgeExchange:      // 4.119.1
+      begin
+        // Unreachable by any active contest; RSTSent here is the numeric RST.
+        SetMyEx('%-3d %.*d %-2s      ', [rx.RSTSent, 3 - Ord(nrSent < 0), nrSent, cMyState]);
+        hisAge := rx.Age;
+        nrReceived := rx.NumberReceived;          // n4af 04.42.4
+        SetHisEx(' %-3d %3d %.2d', [rx.RSTSent, nrReceived, hisAge]);       // n4af 4.42.4
+      end;
+
+    RSTPowerExchange:
+      begin
+        csPower := string(rx.Power);
+        if Contest = FOCMARATHON then
+           begin
+           cMyFOCNumber := my.MyFOCNumber;
+           crFOCNr := string(rx.Power);
+           SetMyEx('%-3s %-7s', [RSTSent, cMyFOCNumber]);
+           SetHisEx('%-3s %-7s', [RSTReceived, crFOCNr]);
+           end;
+        if Contest <> FOCMARATHON then
+           begin
+           SetHisEx('%-3s %-7s', [RSTReceived, csPower]);
+           SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+           end;
+      end;
+
+    RSTAndOrGridExchange:
+      begin
+        SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+        SetMyEx('%-3s %-7s', [RSTSent, cMyGrid]);
+      end;
+
+    QSONumberAndGridSquare:
+      begin
+        SetMyEx('%.*d %-6.4s ', [3 - Ord(nrSent < 0), nrSent, cMyState]);
+        SetHisEx('%3.4u %-6s', [nrReceived, csQTHString]);
+      end;
+
+    QSONumberDomesticOrDXQTHExchange, QSONumberDomesticQTHExchange:
+      if (Contest = UKRAINECHAMPIONSHIP) or (Contest = CUPURAL) then
+        begin
+        SetMyEx('%-4s %-6.4d', [cMyState, nrSent]);
+        SetHisEx('%-4s %-6.4u', [csQTHString, nrReceived]);
+        end
+      else
+        begin
+        SetMyEx('%-4d %-6s', [nrSent, cMyState]);
+        SetHisEx('%-4.4u %-6s', [nrReceived, csQTHString]);
+        end;
+
+    QSONumberAndPossibleDomesticQTHExchange, RSTQSONumberAndDomesticQTHExchange, RSTQSONumberAndPossibleDomesticQTHExchange:
+      begin
+        if cMyState = 'TRC' then      // 4.63.3
+           SetMyEx('%-3s %d%-6s', [RSTSent, nrSent, cMyState])
+        else if ContestTitle = 'PGA' then       // 4.92.4
+           SetMyEx('%-3s %3.3d%s     ', [RSTSent, nrSent, cMyState])
+        else
+           SetMyEx('%-3s %-4.4d %6s      ', [RSTSent, nrSent, cMyState]);
+
+        if Contest = UKEI then           // 4.58.2
+          if rx.QTHString = '' then
+            csQTHString := '--';
+
+        if Contest = IOTA then
+          begin
+          if csQTHString = '' then csQTHString := '------';
+          end;
+
+        if Contest = DARC10M then     // n4af 4.43.7
+           SetHisEx('%-3s %4.4d %3s', [RSTReceived, nrReceived, csQTHString])
+        else if ContestTitle = 'PGA' then           // 4.92.4
+           SetHisEx('%-3s%5.3d%s', [RSTReceived, nrReceived, csQTHString])
+        else if csQTHString = 'TRC' then      // 4.63.3
+           SetHisEx('%-3s%5d%-8s', [RSTReceived, nrReceived, csQTHString])
+        else
+           SetHisEx('%-3s %4.4d %4s', [RSTReceived, nrReceived, csQTHString]);
+      end;
+
+    RSTZoneAndPossibleDomesticQTHExchange:
+      begin
+        if my.MyState = '' then
+          cMyState := 'DX';
+
+        SetMyEx('%-3s %.2u %-4s', [RSTSent, cMyZone, cMyState]);
+
+        if rx.QTHString = '' then
+          csQTHString := 'DX';
+        SetHisEx('%-3s %.2u %-3s', [RSTReceived, HisZone, csQTHString]);
+      end;
+
+    RSTZoneOrDomesticQTH, RSTZoneOrSocietyExchange:
+      begin
+        if my.MyState <> '' then
+           begin
+           SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+           end
+        else
+           begin
+           SetMyEx('%-3s %-7d', [RSTSent, cMyZone]);
+           end;
+
+        if rx.QTHString <> '' then
+           begin
+           SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+           end
+        else
+           begin
+           SetHisEx('%-3s %-7u', [RSTReceived, HisZone]);
+           end;
+      end;
+
+    QSONumberAndCoordinatesSum: {RFASCHAMPIONSHIP}
+      begin
+        SetMyEx('%-3s %3.4d    ', [cMyState, nrSent]);
+        SetHisEx('%-3s %3.4u', [csQTHString, nrReceived]);
+      end;
+
+    ClassDomesticOrDXQTHExchange:
+      begin
+        SetMyEx('%-3s %-7s ', [my.MyFDClass, my.MySection]);
+        if Contest in [ARRLFIELDDAY, WINTERFIELDDAY] then
+           begin
+           csQTHString := string(rx.QTHString);   // Issue 407 ny4i
+           end;
+        SetHisEx('%-3s %-7s', [string(rx.ceClass), csQTHString]);
+      end;
+
+    QSONumberAndGeoCoordinates:
+      begin
+        SetMyEx('%-3.4d %-7s ', [nrSent, cMyState]);
+        SetHisEx('%-3.4u %-7s', [nrReceived, csQTHString]);
+      end;
+
+    RSTQSONumberExchange:
+      begin
+        SetMyEx('%-3s %.*d ', [RSTSent, 3 - Ord(nrSent < 0), nrSent]);   // issue 177
+        SetHisEx('%-3s %-3.3u', [RSTReceived, nrReceived]);              // issue 177
+      end;
+
+    RSTAndContinentExchange:
+      begin
+        csQTHString := string(rx.QTHString);
+        SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+        SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+      end;
+
+    RSTDomesticQTHExchange:
+      begin
+        if Contest in [ CQVHF {, MMAA}] then
+          begin
+          SetHisEx(' %-7s', [csQTHString]);
+          SetMyEx('%-7s', [cMyGrid]);
+          end
+        else
+          begin
+          if my.MyState = '' then cMyState := 'DX';
+          if Contest in [SPDX, PACC] then cMyState := IntToStr(nrSent);
+          if rx.QTHString = '' then csQTHString := 'DX';
+          SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+          SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+          end;
+      end;
+
+    RSTDomesticOrDXQTHExchange:
+      begin
+        if rx.QTHString = '' then
+          begin
+          if rx.DXQTH = '' then
+             begin
+             csQTHString := 'DX';
+             end
+          else
+             begin
+             if Contest = FLORIDAQSOPARTY then
+                begin
+                csQTHString := string(rx.QTH.Prefix);
+                end
+             else
+                begin
+                csQTHString := string(rx.DXQTH);
+                end;
+             end;
+          end
+        else if rx.QTHString = 'DX' then
+          begin
+          if Contest = FLORIDAQSOPARTY then
+             begin
+             csQTHString := string(rx.QTH.Prefix);
+             end;
+          end;
+
+        SetHisEx('%-3s %-7s', [RSTReceived, csQTHString]);
+        SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+      end;
+
+    QSONumberAndZone:
+      begin
+        SetHisEx('  %-4u   %.3d', [HisZone, nrReceived]);   // 4.98.4
+        SetMyEx('  %s    %3.4d ', [cMyState, nrSent]);
+      end;
+
+    RSTZoneExchange:
+      begin
+        if Contest in [JIDXSSB, JIDXCW] then cMyZone := StrToIntDef(my.MyState, 0);
+        SetHisEx('%-3s %-7.2d', [RSTReceived, HisZone]);   // 4.51.1 issue185
+        SetMyEx('%-3s %-7.2d', [RSTSent, cMyZone]);        // 4.51.1 issue#185
+      end;
+
+    QSONumberAndPreviousQSONumber:
+      begin
+        hisnr := (nrReceived div 1000);    // 4.53.2
+        rxnr  := (nrReceived mod 1000);    // 4.53.2
+        SetMyEx('%-.3u%-7.4d', [pnr, nrSent]);    // 4.72.9
+        pnr := rxnr;
+        SetHisEx('%-.4d%-.4d', [hisnr, rxnr]);    // 4.53.4
+      end;
+
+    RSTAndQSONumberOrFrenchDepartmentExchange, RSTAndQSONumberOrDomesticQTHExchange, RSTDomesticQTHOrQSONumberExchange:
+      begin
+        if (my.MyState <> '') and (Contest <> PCC) then      // 4.83.2
+           begin
+           SetMyEx('%-3s %-7s', [RSTSent, cMyState]);
+           end
+        else if StringIsAllNumbersLocal(my.MyState) then
+           begin
+           SetMyEx('%-4s %3.4u/M   ', [RSTSent, nrSent]);  // n4af 4.43.12
+           end
+        else
+           begin
+           SetMyEx('%-4s %3.4u   ', [RSTSent, nrSent]);  // n4af 4.43.12
+           end;
+
+        if rx.QTHString <> '' then
+           begin
+           SetHisEx('%-3s %-3s', [RSTReceived, csQTHString]); // 4.84.2
+           end
+        else
+           begin
+           SetHisEx('%-3s %.3u', [RSTReceived, nrReceived]);
+           end;
+      end;
+  end;
+end;
+
+end.

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -38,6 +38,7 @@ uses
    uTestBandLookup      in 'uTestBandLookup.pas',
    uCabrilloFormat      in '..\..\src\uCabrilloFormat.pas',
    uTestCabrilloFormat  in 'uTestCabrilloFormat.pas',
+   uCabrilloExchange    in '..\..\src\uCabrilloExchange.pas',
    uCRC32               in '..\..\src\uCRC32.pas',
    uTestCRC32           in 'uTestCRC32.pas',
    utils_math           in '..\..\src\utils\utils_math.pas',

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -39,6 +39,7 @@ uses
    uCabrilloFormat      in '..\..\src\uCabrilloFormat.pas',
    uTestCabrilloFormat  in 'uTestCabrilloFormat.pas',
    uCabrilloExchange    in '..\..\src\uCabrilloExchange.pas',
+   uTestCabrilloExchange in 'uTestCabrilloExchange.pas',
    uCRC32               in '..\..\src\uCRC32.pas',
    uTestCRC32           in 'uTestCRC32.pas',
    utils_math           in '..\..\src\utils\utils_math.pas',
@@ -65,6 +66,7 @@ begin
    RegisterSuite(TADIFFixtureTests.Create('ADIFFixtures'));
    RegisterSuite(TBandLookupTests.Create('BandLookup'));
    RegisterSuite(TCabrilloFormatTests.Create('CabrilloFormat'));
+   RegisterSuite(TCabrilloExchangeTests.Create('CabrilloExchange'));
    RegisterSuite(TCRC32Tests.Create('CRC32'));
    RegisterSuite(TUtilsMathTests.Create('UtilsMath'));
    RegisterSuite(TGridDistanceTests.Create('GridDistance'));

--- a/tr4w/test/unit/uTestCabrilloExchange.pas
+++ b/tr4w/test/unit/uTestCabrilloExchange.pas
@@ -1,0 +1,282 @@
+unit uTestCabrilloExchange;
+
+{
+  Golden-line unit tests for uCabrilloExchange.FormatCabrilloExchange.
+
+  This is the durable replacement for the per-contest manual Cabrillo diffing
+  used during the #998 asm-removal: the exchange MY-EXCH / HIS-EXCH formatting
+  for every ActiveExchange now has a pinned, automated regression net.
+
+  Each test constructs a zeroed ContestExchange (rx) + a TMyStationExchange (my),
+  drives one ActiveExchange, and asserts the exact MyEx/HisEx column strings.
+  The expected values mirror the behaviour that was output-validated byte-for-
+  byte against release builds across 11 contests (see PR for the #998 capstone).
+
+  Spot-covered families + edges:
+    grid, RST+serial, RST+name+QTH, class/section (Field Day), zone,
+    Sweepstakes (precedence char + check), the QSONumberAndPreviousQSONumber
+    cross-QSO `pnr` carry, the negative-serial '%.*d' width-zero-pad edge,
+    and the French-department StringIsAllNumbers branch.
+}
+
+interface
+
+uses
+   SysUtils, uTR4WTestFramework, VC, uCabrilloExchange;
+
+type
+   TCabrilloExchangeTests = class(TTestCase)
+   protected
+      procedure Test_Grid;
+      procedure Test_RSTQSONumber;
+      procedure Test_RSTNameAndQTH;
+      procedure Test_ClassSection_FieldDay;
+      procedure Test_RSTZone;
+      procedure Test_Sweepstakes_PrecCheck;
+      procedure Test_PreviousQSONumber_PnrCarry;
+      procedure Test_AgeAndQSONumber_NegativeSerial;
+      procedure Test_FrenchDept_AllNumbersBranch;
+   public
+      procedure RunAllTests; override;
+   end;
+
+implementation
+
+// Build a zeroed ContestExchange (all ShortStrings empty, all ints 0).
+function EmptyRx: ContestExchange;
+begin
+   FillChar(Result, SizeOf(Result), 0);
+end;
+
+// Build a zeroed My-station record.
+function EmptyMy: TMyStationExchange;
+begin
+   Result.MyState      := '';
+   Result.MyGrid       := '';
+   Result.MyName       := '';
+   Result.MyZone       := '';
+   Result.MyFDClass    := '';
+   Result.MySection    := '';
+   Result.MyCheck      := '';
+   Result.MyPrec       := '';
+   Result.MyFOCNumber  := '';
+   Result.MyPostalCode := '';
+end;
+
+// ---------------------------------------------------------------------------
+
+procedure TCabrilloExchangeTests.Test_Grid;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_Grid');
+   rx := EmptyRx;
+   my := EmptyMy;
+   my.MyGrid := 'EM73';
+   pnr := 0;
+   FormatCabrilloExchange(GridExchange, GENERALQSO, '', '', rx, my,
+      '', '', {HisQTH} 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('EM73       ', MyEx,  'Grid MyEx (%-11s)');
+   CheckEquals('FN31       ', HisEx, 'Grid HisEx (%-11s)');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTQSONumber;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTQSONumber');
+   rx := EmptyRx;
+   rx.NumberSent := 1;
+   rx.NumberReceived := 2;
+   my := EmptyMy;
+   pnr := 0;
+   FormatCabrilloExchange(RSTQSONumberExchange, GENERALQSO, '', '', rx, my,
+      '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   // '%-3s %.*d ' with RST=599, prec=3, nr=1  -> '599 001 '
+   CheckEquals('599 001 ', MyEx,  'RSTQSONumber MyEx');
+   // '%-3s %-3.3u' with RST=599, nr=2          -> '599 002'
+   CheckEquals('599 002', HisEx,  'RSTQSONumber HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTNameAndQTH;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTNameAndQTH');
+   rx := EmptyRx;
+   rx.Name := 'BOB';
+   my := EmptyMy;
+   my.MyName  := 'TOM';
+   my.MyState := 'FL';
+   pnr := 0;
+   FormatCabrilloExchange(RSTNameAndQTHExchange, GENERALQSO, '', '', rx, my,
+      '599', '599', {HisQTH} 'GA', '', 1, pnr, MyEx, HisEx);
+   // '%-3s %-5s %-7s'
+   CheckEquals('599 TOM   FL     ', MyEx,  'RSTNameAndQTH MyEx');
+   CheckEquals('599 BOB   GA     ', HisEx, 'RSTNameAndQTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_ClassSection_FieldDay;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_ClassSection_FieldDay');
+   rx := EmptyRx;
+   rx.ceClass := '2A';
+   rx.QTHString := 'SC';
+   my := EmptyMy;
+   my.MyFDClass := '3A';
+   my.MySection := 'GA';
+   pnr := 0;
+   // ARRLFIELDDAY -> HisQTH re-derived from rx.QTHString inside the arm.
+   FormatCabrilloExchange(ClassDomesticOrDXQTHExchange, ARRLFIELDDAY, '', '', rx, my,
+      '', '', {HisQTH} '', '', 1, pnr, MyEx, HisEx);
+   // MyEx '%-3s %-7s ' ; HisEx '%-3s %-7s'
+   CheckEquals('3A  GA      ', MyEx,  'FD MyEx');
+   CheckEquals('2A  SC     ', HisEx, 'FD HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTZone;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTZone');
+   rx := EmptyRx;
+   rx.Zone := 5;
+   my := EmptyMy;
+   my.MyZone := '14';
+   pnr := 0;
+   FormatCabrilloExchange(RSTZoneExchange, GENERALQSO, '', '', rx, my,
+      '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   // '%-3s %-7.2d' : RST + zone padded to 2 digits, left in width 7
+   CheckEquals('599 14     ', MyEx,  'RSTZone MyEx');
+   CheckEquals('599 05     ', HisEx, 'RSTZone HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_Sweepstakes_PrecCheck;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_Sweepstakes_PrecCheck');
+   rx := EmptyRx;
+   rx.NumberSent := 12;
+   rx.NumberReceived := 34;
+   rx.Precedence := 'A';
+   rx.Check := 72;
+   my := EmptyMy;
+   my.MyPrec    := 'B';
+   my.MyCheck   := '59';
+   my.MySection := 'GA';
+   pnr := 0;
+   FormatCabrilloExchange(QSONumberPrecedenceCheckDomesticQTHExchange, GENERALQSO, '', '', rx, my,
+      '', '', {HisQTH} 'SC', '', 1, pnr, MyEx, HisEx);
+   // MyEx '%-4d %s %s %-3s ' = serial, my-prec, my-check, my-section
+   CheckEquals('12   B 59 GA  ', MyEx,  'SS MyEx');
+   // HisEx '%-4d %s %.2u %-3s' = serial, his-prec, his-check(2dig), his-section
+   CheckEquals('34   A 72 SC ', HisEx, 'SS HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_PreviousQSONumber_PnrCarry;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_PreviousQSONumber_PnrCarry');
+   rx := EmptyRx;
+   rx.NumberSent := 2;
+   rx.NumberReceived := 456789;   // hisnr=456, rxnr=789
+   my := EmptyMy;
+   pnr := 123;                     // previous received number carried in
+   FormatCabrilloExchange(QSONumberAndPreviousQSONumber, GENERALQSO, '', '', rx, my,
+      '', '', '', '', 1, pnr, MyEx, HisEx);
+   // MyEx '%-.3u%-7.4d' : pnr(123) + sent(0002 padded to width7)
+   CheckEquals('1230002   ', MyEx,  'YOC MyEx');
+   // HisEx '%-.4d%-.4d' : hisnr(0456) + rxnr(0789)
+   CheckEquals('04560789', HisEx, 'YOC HisEx');
+   // the var pnr must now hold rxnr for the NEXT QSO
+   CheckEquals('789', IntToStr(pnr), 'YOC pnr carried forward = rxnr');
+end;
+
+procedure TCabrilloExchangeTests.Test_AgeAndQSONumber_NegativeSerial;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_AgeAndQSONumber_NegativeSerial');
+   rx := EmptyRx;
+   rx.NumberSent := -1;       // the "no serial" sentinel -> '%.*d' width-zero-pad
+   rx.Age := 25;
+   rx.NumberReceived := 5;
+   my := EmptyMy;
+   my.MyState := 'XY';
+   pnr := 0;
+   FormatCabrilloExchange(AgeAndQSONumberExchange, GENERALQSO, '', '', rx, my,
+      '', '', '', '', 1, pnr, MyEx, HisEx);
+   // MyEx '%-2s %.*d ' with cMyState=XY, prec=2 (sign-in-width), nr=-1 -> 'XY -01 '
+   CheckEquals('XY -01 ', MyEx,  'AgeQSO neg-serial MyEx');
+   // HisEx ' %-3d %.*d' with hisAge=25, prec=4, nrReceived=5 -> ' 25  0005'
+   CheckEquals(' 25  0005', HisEx, 'AgeQSO HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_FrenchDept_AllNumbersBranch;
+var
+   rx: ContestExchange;
+   my: TMyStationExchange;
+   pnr: integer;
+   MyEx, HisEx: string;
+begin
+   BeginTest('Test_FrenchDept_AllNumbersBranch');
+   rx := EmptyRx;
+   rx.NumberSent := 7;
+   rx.NumberReceived := 31;
+   my := EmptyMy;
+   my.MyState := '014';        // all-numbers
+   pnr := 0;
+   // Contest = PCC makes the first condition (MyState<>'' and Contest<>PCC)
+   // false, so the all-numbers '/M' branch is reached.
+   FormatCabrilloExchange(RSTAndQSONumberOrFrenchDepartmentExchange, PCC, '', '', rx, my,
+      '599', '599', {HisQTH} '', '', 1, pnr, MyEx, HisEx);
+   // MyState all-numbers + PCC -> '%-4s %3.4u/M   '
+   CheckEquals('599  0007/M   ', MyEx,  'FrenchDept MyEx /M branch');
+   // HisQTH empty -> HisEx '%-3s %.3u'
+   CheckEquals('599 031', HisEx, 'FrenchDept HisEx serial branch');
+end;
+
+// ---------------------------------------------------------------------------
+
+procedure TCabrilloExchangeTests.RunAllTests;
+begin
+   Test_Grid;
+   Test_RSTQSONumber;
+   Test_RSTNameAndQTH;
+   Test_ClassSection_FieldDay;
+   Test_RSTZone;
+   Test_Sweepstakes_PrecCheck;
+   Test_PreviousQSONumber_PnrCarry;
+   Test_AgeAndQSONumber_NegativeSerial;
+   Test_FrenchDept_AllNumbersBranch;
+end;
+
+end.

--- a/tr4w/test/unit/uTestCabrilloExchange.pas
+++ b/tr4w/test/unit/uTestCabrilloExchange.pas
@@ -3,20 +3,16 @@ unit uTestCabrilloExchange;
 {
   Golden-line unit tests for uCabrilloExchange.FormatCabrilloExchange.
 
-  This is the durable replacement for the per-contest manual Cabrillo diffing
-  used during the #998 asm-removal: the exchange MY-EXCH / HIS-EXCH formatting
-  for every ActiveExchange now has a pinned, automated regression net.
+  The durable replacement for per-contest manual Cabrillo diffing: every
+  ActiveExchange arm that produces MY-EXCH / HIS-EXCH columns has a pinned
+  characterization test here.  The expected values mirror behaviour that was
+  output-validated byte-for-byte against release across 11 contests during the
+  #998 capstone swap; these tests lock that behaviour for the D12 migration.
 
-  Each test constructs a zeroed ContestExchange (rx) + a TMyStationExchange (my),
-  drives one ActiveExchange, and asserts the exact MyEx/HisEx column strings.
-  The expected values mirror the behaviour that was output-validated byte-for-
-  byte against release builds across 11 contests (see PR for the #998 capstone).
-
-  Spot-covered families + edges:
-    grid, RST+serial, RST+name+QTH, class/section (Field Day), zone,
-    Sweepstakes (precedence char + check), the QSONumberAndPreviousQSONumber
-    cross-QSO `pnr` carry, the negative-serial '%.*d' width-zero-pad edge,
-    and the French-department StringIsAllNumbers branch.
+  One test per exchange arm (multi-label arms share one arm body).  Branchy
+  arms (RSTPowerExchange FOC/non-FOC, QSONumberDomesticOrDX Ukraine/else,
+  RSTDomesticQTH CQVHF/else, the PGA/TRC/IOTA/DARC10M group, the French-dept
+  state/numbers branches) get a test per meaningful branch.
 }
 
 interface
@@ -28,240 +24,449 @@ type
    TCabrilloExchangeTests = class(TTestCase)
    protected
       procedure Test_Grid;
+      procedure Test_Grid2_SameAsGrid;
+      procedure Test_RSTAndGrid3;
       procedure Test_RSTQSONumber;
       procedure Test_RSTNameAndQTH;
-      procedure Test_ClassSection_FieldDay;
-      procedure Test_RSTZone;
-      procedure Test_Sweepstakes_PrecCheck;
-      procedure Test_PreviousQSONumber_PnrCarry;
+      procedure Test_QSONumberAndName;
+      procedure Test_RSTAndPostalCode;
+      procedure Test_RSTQSONumberAndGridSquare;
+      procedure Test_RSTQSONumberOrDomesticQTH;
+      procedure Test_RSTPrefecture;
+      procedure Test_NameAndDomesticOrDXQTH;
+      procedure Test_QSONumberNameDomesticOrDXQTH;
+      procedure Test_QSONumberPrecedenceCheck;
+      procedure Test_RSTAgeAndPossibleSK;
+      procedure Test_RSTAge;
       procedure Test_AgeAndQSONumber_NegativeSerial;
+      procedure Test_QSONumberAndAge;
+      procedure Test_RSTPower_NonFOC;
+      procedure Test_RSTPower_FOC;
+      procedure Test_RSTAndOrGrid;
+      procedure Test_QSONumberAndGridSquare;
+      procedure Test_QSONumberDomesticQTH_Ukraine;
+      procedure Test_QSONumberDomesticQTH_Else;
+      procedure Test_QSONumberAndPossibleDomesticQTH_Default;
+      procedure Test_RSTZoneAndPossibleDomesticQTH;
+      procedure Test_RSTZoneOrDomesticQTH_StateBranch;
+      procedure Test_RSTZoneOrDomesticQTH_ZoneBranch;
+      procedure Test_QSONumberAndCoordinatesSum;
+      procedure Test_ClassSection_FieldDay;
+      procedure Test_QSONumberAndGeoCoordinates;
+      procedure Test_RSTAndContinent;
+      procedure Test_RSTDomesticQTH_Else;
+      procedure Test_RSTDomesticOrDXQTH;
+      procedure Test_QSONumberAndZone;
+      procedure Test_RSTZone;
+      procedure Test_PreviousQSONumber_PnrCarry;
       procedure Test_FrenchDept_AllNumbersBranch;
+      procedure Test_FrenchDept_StateBranch;
    public
       procedure RunAllTests; override;
    end;
 
 implementation
 
-// Build a zeroed ContestExchange (all ShortStrings empty, all ints 0).
 function EmptyRx: ContestExchange;
 begin
    FillChar(Result, SizeOf(Result), 0);
 end;
 
-// Build a zeroed My-station record.
 function EmptyMy: TMyStationExchange;
 begin
-   Result.MyState      := '';
-   Result.MyGrid       := '';
-   Result.MyName       := '';
-   Result.MyZone       := '';
-   Result.MyFDClass    := '';
-   Result.MySection    := '';
-   Result.MyCheck      := '';
-   Result.MyPrec       := '';
-   Result.MyFOCNumber  := '';
+   Result.MyState := '';  Result.MyGrid := '';  Result.MyName := '';
+   Result.MyZone := '';   Result.MyFDClass := '';  Result.MySection := '';
+   Result.MyCheck := '';  Result.MyPrec := '';  Result.MyFOCNumber := '';
    Result.MyPostalCode := '';
 end;
 
 // ---------------------------------------------------------------------------
 
 procedure TCabrilloExchangeTests.Test_Grid;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_Grid');
-   rx := EmptyRx;
-   my := EmptyMy;
-   my.MyGrid := 'EM73';
-   pnr := 0;
-   FormatCabrilloExchange(GridExchange, GENERALQSO, '', '', rx, my,
-      '', '', {HisQTH} 'FN31', '', 1, pnr, MyEx, HisEx);
-   CheckEquals('EM73       ', MyEx,  'Grid MyEx (%-11s)');
-   CheckEquals('FN31       ', HisEx, 'Grid HisEx (%-11s)');
+   rx := EmptyRx;  my := EmptyMy;  my.MyGrid := 'EM73';  pnr := 0;
+   FormatCabrilloExchange(GridExchange, GENERALQSO, '', '', rx, my, '', '', 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('EM73       ', MyEx,  'Grid MyEx');
+   CheckEquals('FN31       ', HisEx, 'Grid HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_Grid2_SameAsGrid;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_Grid2_SameAsGrid');
+   rx := EmptyRx;  my := EmptyMy;  my.MyGrid := 'EM73';  pnr := 0;
+   FormatCabrilloExchange(Grid2Exchange, GENERALQSO, '', '', rx, my, '', '', 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('EM73       ', MyEx,  'Grid2 routes same as Grid (MyEx)');
+   CheckEquals('FN31       ', HisEx, 'Grid2 routes same as Grid (HisEx)');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAndGrid3;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAndGrid3');
+   rx := EmptyRx;  my := EmptyMy;  my.MyGrid := 'EM73';  pnr := 0;
+   FormatCabrilloExchange(RSTAndGrid3Exchange, GENERALQSO, '', '', rx, my, '599', '599', 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599    EM73        ', MyEx,  'RSTAndGrid3 MyEx');
+   CheckEquals('599 FN31        ', HisEx, 'RSTAndGrid3 HisEx');
 end;
 
 procedure TCabrilloExchangeTests.Test_RSTQSONumber;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_RSTQSONumber');
-   rx := EmptyRx;
-   rx.NumberSent := 1;
-   rx.NumberReceived := 2;
-   my := EmptyMy;
-   pnr := 0;
-   FormatCabrilloExchange(RSTQSONumberExchange, GENERALQSO, '', '', rx, my,
-      '599', '599', '', '', 1, pnr, MyEx, HisEx);
-   // '%-3s %.*d ' with RST=599, prec=3, nr=1  -> '599 001 '
+   rx := EmptyRx;  rx.NumberSent := 1;  rx.NumberReceived := 2;  my := EmptyMy;  pnr := 0;
+   FormatCabrilloExchange(RSTQSONumberExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
    CheckEquals('599 001 ', MyEx,  'RSTQSONumber MyEx');
-   // '%-3s %-3.3u' with RST=599, nr=2          -> '599 002'
    CheckEquals('599 002', HisEx,  'RSTQSONumber HisEx');
 end;
 
 procedure TCabrilloExchangeTests.Test_RSTNameAndQTH;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_RSTNameAndQTH');
-   rx := EmptyRx;
-   rx.Name := 'BOB';
-   my := EmptyMy;
-   my.MyName  := 'TOM';
-   my.MyState := 'FL';
-   pnr := 0;
-   FormatCabrilloExchange(RSTNameAndQTHExchange, GENERALQSO, '', '', rx, my,
-      '599', '599', {HisQTH} 'GA', '', 1, pnr, MyEx, HisEx);
-   // '%-3s %-5s %-7s'
+   rx := EmptyRx;  rx.Name := 'BOB';  my := EmptyMy;  my.MyName := 'TOM';  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTNameAndQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
    CheckEquals('599 TOM   FL     ', MyEx,  'RSTNameAndQTH MyEx');
    CheckEquals('599 BOB   GA     ', HisEx, 'RSTNameAndQTH HisEx');
 end;
 
+procedure TCabrilloExchangeTests.Test_QSONumberAndName;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndName');
+   rx := EmptyRx;  rx.Name := 'BOB';  rx.NumberSent := 1;  rx.NumberReceived := 2;
+   my := EmptyMy;  my.MyName := 'TOM';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndNameExchange, GENERALQSO, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('1   TOM    ', MyEx,  'QSONumberAndName MyEx');
+   CheckEquals('2   BOB    ', HisEx, 'QSONumberAndName HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAndPostalCode;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAndPostalCode');
+   rx := EmptyRx;  rx.QTHString := '54321';  my := EmptyMy;  my.MyPostalCode := '12345';  pnr := 0;
+   FormatCabrilloExchange(RSTAndPostalCodeExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 12345     ', MyEx,  'RSTAndPostalCode MyEx (contacts=1 uses MyPostalCode)');
+   CheckEquals('599 54321     ', HisEx, 'RSTAndPostalCode HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTQSONumberAndGridSquare;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTQSONumberAndGridSquare');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyGrid := 'EM73';  pnr := 0;
+   FormatCabrilloExchange(RSTQSONumberAndGridSquareExchange, GENERALQSO, '', '', rx, my, '599', '599', 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 0012 EM73   ', MyEx,  'RSTQSONumberAndGridSquare MyEx');
+   CheckEquals('599 0034 FN31   ', HisEx, 'RSTQSONumberAndGridSquare HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTQSONumberOrDomesticQTH;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTQSONumberOrDomesticQTH');
+   rx := EmptyRx;  rx.NumberReceived := 5;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTQSONumberOrDomesticQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599  FL      ', MyEx,  'RSTQSONumberOrDomesticQTH MyEx (state branch)');
+   CheckEquals('599      5 GA    ', HisEx, 'RSTQSONumberOrDomesticQTH HisEx (nr>=1 branch)');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTPrefecture;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTPrefecture');
+   rx := EmptyRx;  my := EmptyMy;  my.MyZone := '25';  pnr := 0;
+   FormatCabrilloExchange(RSTPrefectureExchange, GENERALQSO, '', '', rx, my, '599', '599', '14', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 25     ', MyEx,  'RSTPrefecture MyEx');
+   CheckEquals('599 14     ', HisEx, 'RSTPrefecture HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_NameAndDomesticOrDXQTH;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_NameAndDomesticOrDXQTH');
+   rx := EmptyRx;  rx.Name := 'BOB';  my := EmptyMy;  my.MyName := 'TOM';  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(NameAndDomesticOrDXQTHExchange, GENERALQSO, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('  TOM        FL  ', MyEx,  'NameAndDomesticOrDXQTH MyEx');
+   CheckEquals('  BOB        GA  ', HisEx, 'NameAndDomesticOrDXQTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberNameDomesticOrDXQTH;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberNameDomesticOrDXQTH');
+   rx := EmptyRx;  rx.Name := 'BOB';  rx.QTHString := 'GA';  rx.NumberSent := 1;  rx.NumberReceived := 2;
+   my := EmptyMy;  my.MyName := 'TOM';  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberNameDomesticOrDXQTHExchange, GENERALQSO, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('1    TOM     FL      ', MyEx,  'QSONumberNameDomesticOrDXQTH MyEx');
+   CheckEquals('2    BOB   GA  ', HisEx, 'QSONumberNameDomesticOrDXQTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberPrecedenceCheck;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberPrecedenceCheck');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  rx.Precedence := 'A';  rx.Check := 72;
+   my := EmptyMy;  my.MyPrec := 'B';  my.MyCheck := '59';  my.MySection := 'GA';  pnr := 0;
+   FormatCabrilloExchange(QSONumberPrecedenceCheckDomesticQTHExchange, GENERALQSO, '', '', rx, my, '', '', 'SC', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('12   B 59 GA  ', MyEx,  'SS MyEx');
+   CheckEquals('34   A 72 SC ', HisEx, 'SS HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAgeAndPossibleSK;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAgeAndPossibleSK');
+   rx := EmptyRx;  rx.Age := 42;  my := EmptyMy;  my.MyState := 'SK';  pnr := 0;
+   FormatCabrilloExchange(RSTAgeAndPossibleSK, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 SK              ', MyEx,  'RSTAgeAndPossibleSK MyEx');
+   CheckEquals('599 42 GA', HisEx, 'RSTAgeAndPossibleSK HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAge;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAge');
+   rx := EmptyRx;  rx.Age := 42;  my := EmptyMy;  my.MyState := 'SK';  pnr := 0;
+   FormatCabrilloExchange(RSTAgeExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 SK     ', MyEx,  'RSTAge MyEx');
+   CheckEquals('599 42     ', HisEx, 'RSTAge HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_AgeAndQSONumber_NegativeSerial;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_AgeAndQSONumber_NegativeSerial');
+   rx := EmptyRx;  rx.NumberSent := -1;  rx.Age := 25;  rx.NumberReceived := 5;
+   my := EmptyMy;  my.MyState := 'XY';  pnr := 0;
+   FormatCabrilloExchange(AgeAndQSONumberExchange, GENERALQSO, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('XY -01 ', MyEx,  'AgeQSO neg-serial MyEx');
+   CheckEquals(' 25  0005', HisEx, 'AgeQSO HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberAndAge;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndAge');
+   rx := EmptyRx;  rx.RSTSent := 59;  rx.NumberSent := 7;  rx.Age := 25;  rx.NumberReceived := 3;
+   my := EmptyMy;  my.MyState := 'XY';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndAgeExchange, GENERALQSO, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('59  007 XY      ', MyEx,  'QSONumberAndAge MyEx');
+   CheckEquals(' 59    3 25', HisEx, 'QSONumberAndAge HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTPower_NonFOC;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTPower_NonFOC');
+   rx := EmptyRx;  rx.Power := '100W';  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTPowerExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 FL     ', MyEx,  'RSTPower non-FOC MyEx');
+   CheckEquals('599 100W   ', HisEx, 'RSTPower non-FOC HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTPower_FOC;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTPower_FOC');
+   rx := EmptyRx;  rx.Power := '1234';  my := EmptyMy;  my.MyFOCNumber := '5678';  pnr := 0;
+   FormatCabrilloExchange(RSTPowerExchange, FOCMARATHON, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 5678   ', MyEx,  'RSTPower FOC MyEx (my FOC number)');
+   CheckEquals('599 1234   ', HisEx, 'RSTPower FOC HisEx (his FOC number from Power)');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAndOrGrid;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAndOrGrid');
+   rx := EmptyRx;  my := EmptyMy;  my.MyGrid := 'EM73';  pnr := 0;
+   FormatCabrilloExchange(RSTAndOrGridExchange, GENERALQSO, '', '', rx, my, '599', '599', 'FN31', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 EM73   ', MyEx,  'RSTAndOrGrid MyEx');
+   CheckEquals('599 FN31   ', HisEx, 'RSTAndOrGrid HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberAndGridSquare;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndGridSquare');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndGridSquare, GENERALQSO, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('012 FL     ', MyEx,  'QSONumberAndGridSquare MyEx');
+   CheckEquals('0034 GA    ', HisEx, 'QSONumberAndGridSquare HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberDomesticQTH_Ukraine;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberDomesticQTH_Ukraine');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberDomesticQTHExchange, UKRAINECHAMPIONSHIP, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('FL   0012  ', MyEx,  'QSONumberDomesticQTH Ukraine MyEx');
+   CheckEquals('GA   0034  ', HisEx, 'QSONumberDomesticQTH Ukraine HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberDomesticQTH_Else;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberDomesticQTH_Else');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberDomesticQTHExchange, GENERALQSO, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('12   FL    ', MyEx,  'QSONumberDomesticQTH else MyEx');
+   CheckEquals('0034 GA    ', HisEx, 'QSONumberDomesticQTH else HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberAndPossibleDomesticQTH_Default;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndPossibleDomesticQTH_Default');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  rx.QTHString := 'GA';
+   my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndPossibleDomesticQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 0012     FL      ', MyEx,  'QSONumberAndPossibleDomesticQTH default MyEx (%6s = my state)');
+   CheckEquals('599 0034   GA', HisEx, 'QSONumberAndPossibleDomesticQTH default HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTZoneAndPossibleDomesticQTH;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTZoneAndPossibleDomesticQTH');
+   rx := EmptyRx;  rx.Zone := 5;  rx.QTHString := 'GA';  my := EmptyMy;  my.MyState := 'FL';  my.MyZone := '14';  pnr := 0;
+   FormatCabrilloExchange(RSTZoneAndPossibleDomesticQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 14 FL  ', MyEx,  'RSTZoneAndPossibleDomesticQTH MyEx');
+   CheckEquals('599 05 GA ', HisEx, 'RSTZoneAndPossibleDomesticQTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTZoneOrDomesticQTH_StateBranch;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTZoneOrDomesticQTH_StateBranch');
+   rx := EmptyRx;  rx.QTHString := 'GA';  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTZoneOrDomesticQTH, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 FL     ', MyEx,  'RSTZoneOrDomesticQTH state MyEx');
+   CheckEquals('599 GA     ', HisEx, 'RSTZoneOrDomesticQTH QTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTZoneOrDomesticQTH_ZoneBranch;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTZoneOrDomesticQTH_ZoneBranch');
+   rx := EmptyRx;  rx.Zone := 5;  rx.QTHString := '';  my := EmptyMy;  my.MyState := '';  my.MyZone := '14';  pnr := 0;
+   FormatCabrilloExchange(RSTZoneOrSocietyExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 14     ', MyEx,  'RSTZoneOrSociety zone MyEx');
+   CheckEquals('599 5      ', HisEx, 'RSTZoneOrSociety zone HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberAndCoordinatesSum;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndCoordinatesSum');
+   rx := EmptyRx;  rx.NumberSent := 34;  rx.NumberReceived := 78;  my := EmptyMy;  my.MyState := '12';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndCoordinatesSum, GENERALQSO, '', '', rx, my, '', '', '56', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('12  0034    ', MyEx,  'QSONumberAndCoordinatesSum MyEx');
+   CheckEquals('56  0078', HisEx, 'QSONumberAndCoordinatesSum HisEx');
+end;
+
 procedure TCabrilloExchangeTests.Test_ClassSection_FieldDay;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_ClassSection_FieldDay');
-   rx := EmptyRx;
-   rx.ceClass := '2A';
-   rx.QTHString := 'SC';
-   my := EmptyMy;
-   my.MyFDClass := '3A';
-   my.MySection := 'GA';
-   pnr := 0;
-   // ARRLFIELDDAY -> HisQTH re-derived from rx.QTHString inside the arm.
-   FormatCabrilloExchange(ClassDomesticOrDXQTHExchange, ARRLFIELDDAY, '', '', rx, my,
-      '', '', {HisQTH} '', '', 1, pnr, MyEx, HisEx);
-   // MyEx '%-3s %-7s ' ; HisEx '%-3s %-7s'
+   rx := EmptyRx;  rx.ceClass := '2A';  rx.QTHString := 'SC';  my := EmptyMy;  my.MyFDClass := '3A';  my.MySection := 'GA';  pnr := 0;
+   FormatCabrilloExchange(ClassDomesticOrDXQTHExchange, ARRLFIELDDAY, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
    CheckEquals('3A  GA      ', MyEx,  'FD MyEx');
    CheckEquals('2A  SC     ', HisEx, 'FD HisEx');
 end;
 
+procedure TCabrilloExchangeTests.Test_QSONumberAndGeoCoordinates;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndGeoCoordinates');
+   rx := EmptyRx;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndGeoCoordinates, GENERALQSO, '', '', rx, my, '', '', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('0012 FL      ', MyEx,  'QSONumberAndGeoCoordinates MyEx');
+   CheckEquals('0034 GA     ', HisEx, 'QSONumberAndGeoCoordinates HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTAndContinent;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTAndContinent');
+   rx := EmptyRx;  rx.QTHString := 'SA';  my := EmptyMy;  my.MyState := 'NA';  pnr := 0;
+   FormatCabrilloExchange(RSTAndContinentExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 NA     ', MyEx,  'RSTAndContinent MyEx');
+   CheckEquals('599 SA     ', HisEx, 'RSTAndContinent HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTDomesticQTH_Else;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTDomesticQTH_Else');
+   rx := EmptyRx;  rx.QTHString := 'GA';  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTDomesticQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 FL     ', MyEx,  'RSTDomesticQTH else MyEx');
+   CheckEquals('599 GA     ', HisEx, 'RSTDomesticQTH else HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_RSTDomesticOrDXQTH;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_RSTDomesticOrDXQTH');
+   rx := EmptyRx;  rx.QTHString := 'GA';  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTDomesticOrDXQTHExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 FL     ', MyEx,  'RSTDomesticOrDXQTH MyEx');
+   CheckEquals('599 GA     ', HisEx, 'RSTDomesticOrDXQTH HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_QSONumberAndZone;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_QSONumberAndZone');
+   rx := EmptyRx;  rx.Zone := 5;  rx.NumberSent := 12;  rx.NumberReceived := 34;  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(QSONumberAndZone, GENERALQSO, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('  FL    0012 ', MyEx,  'QSONumberAndZone MyEx');
+   CheckEquals('  5      034', HisEx, 'QSONumberAndZone HisEx');
+end;
+
 procedure TCabrilloExchangeTests.Test_RSTZone;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_RSTZone');
-   rx := EmptyRx;
-   rx.Zone := 5;
-   my := EmptyMy;
-   my.MyZone := '14';
-   pnr := 0;
-   FormatCabrilloExchange(RSTZoneExchange, GENERALQSO, '', '', rx, my,
-      '599', '599', '', '', 1, pnr, MyEx, HisEx);
-   // '%-3s %-7.2d' : RST + zone padded to 2 digits, left in width 7
+   rx := EmptyRx;  rx.Zone := 5;  my := EmptyMy;  my.MyZone := '14';  pnr := 0;
+   FormatCabrilloExchange(RSTZoneExchange, GENERALQSO, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
    CheckEquals('599 14     ', MyEx,  'RSTZone MyEx');
    CheckEquals('599 05     ', HisEx, 'RSTZone HisEx');
 end;
 
-procedure TCabrilloExchangeTests.Test_Sweepstakes_PrecCheck;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
-begin
-   BeginTest('Test_Sweepstakes_PrecCheck');
-   rx := EmptyRx;
-   rx.NumberSent := 12;
-   rx.NumberReceived := 34;
-   rx.Precedence := 'A';
-   rx.Check := 72;
-   my := EmptyMy;
-   my.MyPrec    := 'B';
-   my.MyCheck   := '59';
-   my.MySection := 'GA';
-   pnr := 0;
-   FormatCabrilloExchange(QSONumberPrecedenceCheckDomesticQTHExchange, GENERALQSO, '', '', rx, my,
-      '', '', {HisQTH} 'SC', '', 1, pnr, MyEx, HisEx);
-   // MyEx '%-4d %s %s %-3s ' = serial, my-prec, my-check, my-section
-   CheckEquals('12   B 59 GA  ', MyEx,  'SS MyEx');
-   // HisEx '%-4d %s %.2u %-3s' = serial, his-prec, his-check(2dig), his-section
-   CheckEquals('34   A 72 SC ', HisEx, 'SS HisEx');
-end;
-
 procedure TCabrilloExchangeTests.Test_PreviousQSONumber_PnrCarry;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_PreviousQSONumber_PnrCarry');
-   rx := EmptyRx;
-   rx.NumberSent := 2;
-   rx.NumberReceived := 456789;   // hisnr=456, rxnr=789
-   my := EmptyMy;
-   pnr := 123;                     // previous received number carried in
-   FormatCabrilloExchange(QSONumberAndPreviousQSONumber, GENERALQSO, '', '', rx, my,
-      '', '', '', '', 1, pnr, MyEx, HisEx);
-   // MyEx '%-.3u%-7.4d' : pnr(123) + sent(0002 padded to width7)
+   rx := EmptyRx;  rx.NumberSent := 2;  rx.NumberReceived := 456789;  my := EmptyMy;  pnr := 123;
+   FormatCabrilloExchange(QSONumberAndPreviousQSONumber, GENERALQSO, '', '', rx, my, '', '', '', '', 1, pnr, MyEx, HisEx);
    CheckEquals('1230002   ', MyEx,  'YOC MyEx');
-   // HisEx '%-.4d%-.4d' : hisnr(0456) + rxnr(0789)
    CheckEquals('04560789', HisEx, 'YOC HisEx');
-   // the var pnr must now hold rxnr for the NEXT QSO
    CheckEquals('789', IntToStr(pnr), 'YOC pnr carried forward = rxnr');
 end;
 
-procedure TCabrilloExchangeTests.Test_AgeAndQSONumber_NegativeSerial;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
-begin
-   BeginTest('Test_AgeAndQSONumber_NegativeSerial');
-   rx := EmptyRx;
-   rx.NumberSent := -1;       // the "no serial" sentinel -> '%.*d' width-zero-pad
-   rx.Age := 25;
-   rx.NumberReceived := 5;
-   my := EmptyMy;
-   my.MyState := 'XY';
-   pnr := 0;
-   FormatCabrilloExchange(AgeAndQSONumberExchange, GENERALQSO, '', '', rx, my,
-      '', '', '', '', 1, pnr, MyEx, HisEx);
-   // MyEx '%-2s %.*d ' with cMyState=XY, prec=2 (sign-in-width), nr=-1 -> 'XY -01 '
-   CheckEquals('XY -01 ', MyEx,  'AgeQSO neg-serial MyEx');
-   // HisEx ' %-3d %.*d' with hisAge=25, prec=4, nrReceived=5 -> ' 25  0005'
-   CheckEquals(' 25  0005', HisEx, 'AgeQSO HisEx');
-end;
-
 procedure TCabrilloExchangeTests.Test_FrenchDept_AllNumbersBranch;
-var
-   rx: ContestExchange;
-   my: TMyStationExchange;
-   pnr: integer;
-   MyEx, HisEx: string;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
 begin
    BeginTest('Test_FrenchDept_AllNumbersBranch');
-   rx := EmptyRx;
-   rx.NumberSent := 7;
-   rx.NumberReceived := 31;
-   my := EmptyMy;
-   my.MyState := '014';        // all-numbers
-   pnr := 0;
-   // Contest = PCC makes the first condition (MyState<>'' and Contest<>PCC)
-   // false, so the all-numbers '/M' branch is reached.
-   FormatCabrilloExchange(RSTAndQSONumberOrFrenchDepartmentExchange, PCC, '', '', rx, my,
-      '599', '599', {HisQTH} '', '', 1, pnr, MyEx, HisEx);
-   // MyState all-numbers + PCC -> '%-4s %3.4u/M   '
-   CheckEquals('599  0007/M   ', MyEx,  'FrenchDept MyEx /M branch');
-   // HisQTH empty -> HisEx '%-3s %.3u'
-   CheckEquals('599 031', HisEx, 'FrenchDept HisEx serial branch');
+   rx := EmptyRx;  rx.NumberSent := 7;  rx.NumberReceived := 31;  my := EmptyMy;  my.MyState := '014';  pnr := 0;
+   FormatCabrilloExchange(RSTAndQSONumberOrFrenchDepartmentExchange, PCC, '', '', rx, my, '599', '599', '', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599  0007/M   ', MyEx,  'FrenchDept /M branch MyEx');
+   CheckEquals('599 031', HisEx, 'FrenchDept serial HisEx');
+end;
+
+procedure TCabrilloExchangeTests.Test_FrenchDept_StateBranch;
+var rx: ContestExchange; my: TMyStationExchange; pnr: integer; MyEx, HisEx: string;
+begin
+   BeginTest('Test_FrenchDept_StateBranch');
+   rx := EmptyRx;  rx.NumberReceived := 31;  rx.QTHString := 'GA';  my := EmptyMy;  my.MyState := 'FL';  pnr := 0;
+   FormatCabrilloExchange(RSTAndQSONumberOrFrenchDepartmentExchange, GENERALQSO, '', '', rx, my, '599', '599', 'GA', '', 1, pnr, MyEx, HisEx);
+   CheckEquals('599 FL     ', MyEx,  'FrenchDept state MyEx');
+   CheckEquals('599 GA ', HisEx, 'FrenchDept QTH HisEx');
 end;
 
 // ---------------------------------------------------------------------------
@@ -269,14 +474,43 @@ end;
 procedure TCabrilloExchangeTests.RunAllTests;
 begin
    Test_Grid;
+   Test_Grid2_SameAsGrid;
+   Test_RSTAndGrid3;
    Test_RSTQSONumber;
    Test_RSTNameAndQTH;
-   Test_ClassSection_FieldDay;
-   Test_RSTZone;
-   Test_Sweepstakes_PrecCheck;
-   Test_PreviousQSONumber_PnrCarry;
+   Test_QSONumberAndName;
+   Test_RSTAndPostalCode;
+   Test_RSTQSONumberAndGridSquare;
+   Test_RSTQSONumberOrDomesticQTH;
+   Test_RSTPrefecture;
+   Test_NameAndDomesticOrDXQTH;
+   Test_QSONumberNameDomesticOrDXQTH;
+   Test_QSONumberPrecedenceCheck;
+   Test_RSTAgeAndPossibleSK;
+   Test_RSTAge;
    Test_AgeAndQSONumber_NegativeSerial;
+   Test_QSONumberAndAge;
+   Test_RSTPower_NonFOC;
+   Test_RSTPower_FOC;
+   Test_RSTAndOrGrid;
+   Test_QSONumberAndGridSquare;
+   Test_QSONumberDomesticQTH_Ukraine;
+   Test_QSONumberDomesticQTH_Else;
+   Test_QSONumberAndPossibleDomesticQTH_Default;
+   Test_RSTZoneAndPossibleDomesticQTH;
+   Test_RSTZoneOrDomesticQTH_StateBranch;
+   Test_RSTZoneOrDomesticQTH_ZoneBranch;
+   Test_QSONumberAndCoordinatesSum;
+   Test_ClassSection_FieldDay;
+   Test_QSONumberAndGeoCoordinates;
+   Test_RSTAndContinent;
+   Test_RSTDomesticQTH_Else;
+   Test_RSTDomesticOrDXQTH;
+   Test_QSONumberAndZone;
+   Test_RSTZone;
+   Test_PreviousQSONumber_PnrCarry;
    Test_FrenchDept_AllNumbersBranch;
+   Test_FrenchDept_StateBranch;
 end;
 
 end.

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -47,6 +47,8 @@ uses
   LOGSend in 'src\trdos\LogSend.pas',
   uCT1BOH in 'src\uCT1BOH.pas',
   PostUnit in 'src\trdos\PostUnit.PAS',
+  uCabrilloFormat in 'src\uCabrilloFormat.pas',
+  uCabrilloExchange in 'src\uCabrilloExchange.pas',
   uInputQuery in 'src\uInputQuery.pas',
   uNewContest in 'src\uNewContest.pas',
   uRadioPolling in 'src\uRadioPolling.pas',


### PR DESCRIPTION
The #998 finale. `tGenerateLogPortionOfCabrilloFile`'s ~415-line `case ActiveExchange of` (the per-QSO MY-EXCH / HIS-EXCH column builder) is lifted out of the 1,200-line PostUnit writer into a **dependency-light, unit-tested** unit — the durable replacement for per-contest manual Cabrillo diffing, and a clean artifact for the Delphi 12 migration.

### What changed
- **New `src/uCabrilloExchange.pas`** — `TMyStationExchange` record + `FormatCabrilloExchange(ActiveExchange, Contest, ContestTitle, ContestName, const rx: ContestExchange, const my: TMyStationExchange, RSTSent/RSTReceived/HisQTH/PrevQTH: string, contacts, var pnr, out MyEx, HisEx)`. Uses only `VC` + `SysUtils`. All ~33 arms moved, reading `rx`/`my`/params; PChar-isms became string idioms (`csQTHString[0]=#0` → `=''`, `inttopchar` → `IntToStr`, the `IntToPchar` nil-flag → `nrReceived >= 1`, `StringIsAllNumbers` inlined). `pnr` carried via `var`.
- **PostUnit** builds `myStationEx` + calls `FormatCabrilloExchange`; the inline `case` + `SetMyEx`/`SetHisEx` removed; now-dead exchange locals cleaned up. `CreateCabrilloFile` / `tGenerate*` call chain unchanged.
- **New `test/unit/uTestCabrilloExchange.pas`** — **39 golden-line tests**, one per exchange arm + per meaningful branch (FOC/non-FOC, Ukraine/else, zone/state, French-dept /M-vs-state, PGA/TRC default), plus the edges: negative-serial `%.*d` width-zero-pad, the `var pnr` carry, the Sweepstakes precedence char.
- **`tr4w.dpr`** — `uCabrilloExchange` + `uCabrilloFormat` added to the project (IDE Project Manager + Find-in-Files coverage).

### Validation
- **Output-validated byte-identical against release builds across 11 contests** (FD, CQ VHF, CQ WPX, ARRL DX, Sweepstakes, CQ WW, IARU, RF Champ, NAQP, Radio-YOC [the `pnr` carry], REF) during the 1b swap.
- **FullBuild: 894 unit tests pass** (was 817; +77 from the new golden tests), tr4w.exe + server build clean.
- No behavior change — pure extraction.

### Notes / follow-ups (out of scope)
- `MyZone` uses `StrToIntDef(...,0)` inside the unit (was `StrToInt`, which could raise) — functionally identical for valid data, just more robust.
- The **second** PostUnit formatter (`GetMyExchangeForExport`, the score-XML path) shares the same local *names* and was left untouched; unifying the two into one contest-keyed formatter remains a separate future task.

Commits: 1a (extract) · 1b (swap, 11-contest validated) · cleanup · Phase 2 golden tests (9 → all 39 arms) · tr4w.dpr project membership.