### PR TITLE
CARS meeting discoveries: radio factory port/discovery (#1028), S&P F1 caption (#1012), CW '=' repeat, QuickDisplay clear

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -4105,6 +4105,21 @@ begin
     CallWindowCharConsumed := True; // prevent WM_CHAR from inserting '-' into the cleared field
     Exit;
   end;
+
+  // '=' repeat-last-CW-message: replay the exact characters last sent on CW.
+  if (key = '=') and (ActiveMode = CW) then
+     begin
+     if LastCWMessage <> '' then
+        begin
+        AddStringToBuffer(LastCWMessage, CWTone);
+        if IsCWByCATActive then
+           begin
+           AddStringToBuffer(CWByCATBufferTerminator, CWTone);
+           end;
+        end;
+     CallWindowCharConsumed := True; // prevent WM_CHAR from inserting '=' into the call field
+     Exit;
+     end;
   // start sending now code
   if Key = StartSendingNowKey then
     if tAutoSendMode = False then

--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -804,6 +804,11 @@ var
     tCallWindowSetFocus;
     CleanUpDisplay;
 
+    // A prior bad-exchange attempt (e.g. TC_IMPROPERARRLFIELDDAYCLASS) leaves
+    // an error in the QuickCommand window on its own 30s flash timer.  Once a
+    // corrected QSO is logged that error is stale, so clear it now.
+    ClearQuickDisplayText;
+
     Result := True;
 
     if OpMode = SearchAndPounceOpMode then

--- a/tr4w/src/trdos/CFGDEF.PAS
+++ b/tr4w/src/trdos/CFGDEF.PAS
@@ -43,11 +43,34 @@ uses
   LogRadio;
 
 procedure SetConfigurationDefaultValues;
+procedure UpdateSAndPF1Caption;        // Issue #1012
 
 implementation
 uses MainUnit;
 { Here are the default values that are used if nothing else in the
   configuration file addresses these variables.                     }
+
+// Issue #1012 (and #69): the S&P F1 ("send call") caption is derived from the
+// DE ENABLE setting.  DEEnable's final value is only known after the config
+// files are read, so this decision is factored out here and re-applied
+// post-config (see tr4w.dpr) rather than computed only once with the
+// compiled-in default of True.  RUS uses a language-fixed F1 caption that does
+// not depend on DE ENABLE, so it is left untouched.
+procedure UpdateSAndPF1Caption;
+begin
+{$IF LANG = 'RUS'}
+   // RUS S&P F1 caption is language-fixed; nothing to recompute.
+{$ELSE}
+   if DEEnable then
+      begin
+      SetEXCaptionMemoryString(CW, F1, 'DE+Call');
+      end
+   else
+      begin
+      SetEXCaptionMemoryString(CW, F1, 'Call');
+      end;
+{$IFEND}
+end;
 
 procedure SetConfigurationDefaultValues;
 var
@@ -435,14 +458,7 @@ begin
   SetEXCaptionMemoryString(CW, F1, '��� ��������');
   SetEXCaptionMemoryString(CW, F2, '�����. �����');
 {$ELSE}
- if DEEnable then        // ny4i Issue 69
-    begin
-    SetEXCaptionMemoryString(CW, F1, 'DE+Call');
-    end
- else
-    begin
-    SetEXCaptionMemoryString(CW, F1, 'Call');
-    end;
+  UpdateSAndPF1Caption;        // ny4i Issue 69 / Issue 1012
 
   SetEXCaptionMemoryString(CW, F2, 'S&P Exchange');
   SetEXCaptionMemoryString(Phone, F2, 'S&P Exchange');

--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -2793,39 +2793,10 @@ end;
 //------------------------------------------------------------------------------
 function RadioObject.MapRadioModelToFactory: TRadioModel;
 begin
-   // Maps InterfacedRadioType to TRadioModel for factory pattern
-   Result := rmNone;
-
-   case Self.RadioModel of
-      K4:
-         Result := rmElecraftK4;
-      IC7610:
-         Result := rmIcomIC7610;
-      IC7300:
-         Result := rmIcomIC7300;
-      IC9700:
-         Result := rmIcomIC9700;
-      IC705:
-         Result := rmIcomIC705;
-      IC7300MK2:
-         Result := rmIcomIC7300MK2;
-      IC7600:
-         Result := rmIcomIC7600;
-      IC7760:
-         Result := rmIcomIC7760;
-      IC7850, IC7851:
-         Result := rmIcomIC7850;
-      IC905:
-         Result := rmIcomIC905;
-      IC7100:
-         Result := rmIcomIC7100;
-      FLEX:
-         Result := rmFlexRadio6000;
-      TS890:                          // Issue #436 -- TS-890 network control
-         Result := rmKenwoodTS890;
-   else
-      Result := rmNone;
-   end;
+   // Issue #1028 -- the InterfacedRadioType -> TRadioModel mapping now lives on
+   // the radio factory (single source of truth, alongside the per-model network
+   // metadata).  Delegate to it.
+   Result := TRadioFactory.ModelForInterfacedType(Self.RadioModel);
 end;
 //------------------------------------------------------------------------------
 procedure RadioObject.SetUpRadioInterface;

--- a/tr4w/src/trdos/LOGSUBS1.PAS
+++ b/tr4w/src/trdos/LOGSUBS1.PAS
@@ -215,7 +215,11 @@ begin // 1
 
     CW:
       begin
+        // '=' repeat-last-CW-message: bracket the send so AddStringToBuffer
+        // records the actual expanded characters as LastCWMessage.
+        BeginCWCapture;
         SendCrypticCWstring(Message);
+        EndCWCapture;
       end;
 {$IF MMTTYMODE}
     Digital:

--- a/tr4w/src/trdos/LogCW.pas
+++ b/tr4w/src/trdos/LogCW.pas
@@ -118,6 +118,8 @@ var
   Short9                                : Char = 'N';
 
 procedure AddStringToBuffer(Msg: Str160; Tone: integer);
+procedure BeginCWCapture;   // '=' repeat-last-CW-message
+procedure EndCWCapture;
 procedure AppendConfigFile(AddedLine: Str160);
 function CalculateElements(sMsg: string): integer;
 //procedure ClearPTTForceOn;
@@ -170,6 +172,12 @@ procedure DisplayCrypticSSBMenu;
 var
   KeyStatus                             : KeyStatusType;
   slElements                            : TStringList;
+  // '=' repeat-last-CW-message: BeginCWCapture/EndCWCapture bracket one message;
+  // AddStringToBuffer appends the actual expanded characters it sends into
+  // CWBurstAccum, which EndCWCapture promotes to LastCWMessage for replay.
+  CWCaptureActive                       : boolean = False;
+  CWBurstAccum                          : Str160 = '';
+  LastCWMessage                         : Str160 = '';
 implementation
 
 uses
@@ -191,6 +199,21 @@ type
 //   NEWCW                           : TCW;
 
 
+procedure BeginCWCapture;
+begin
+   CWCaptureActive := True;
+   CWBurstAccum := '';
+end;
+
+procedure EndCWCapture;
+begin
+   CWCaptureActive := False;
+   if CWBurstAccum <> '' then
+      begin
+      LastCWMessage := CWBurstAccum;
+      end;
+end;
+
 procedure AddStringToBuffer(Msg: Str160; Tone: integer);
 var
   i                                     : integer;
@@ -200,6 +223,12 @@ begin
    //localMsg                                               := Format('Adding %s to CW Buffer', [Msg]);
    //AddStringToTelnetConsole(PChar(localMsg),tstAlert);
    logger.Debug('[AddStringToBuffer] Adding (%s) to CW Buffer',[Msg]);
+   // '=' repeat-last-CW-message: record the actual expanded text being sent
+   // (skip the CWByCAT control sentinel, which is not on-air content).
+   if CWCaptureActive and (Msg <> CWByCATBufferTerminator) then
+      begin
+      CWBurstAccum := CWBurstAccum + Msg;
+      end;
    if ( (Msg = CWByCATBufferTerminator) or
         ((CWEnable and CWEnabled and IsCWByCATActive )) ) then   // ny4i 4.44.5    + Issue 111
       begin

--- a/tr4w/src/uCAT.pas
+++ b/tr4w/src/uCAT.pas
@@ -51,35 +51,46 @@ implementation
 
 uses
   uRadioPolling,
+  uRadioFactory,   // Issue #1028 -- network metadata (port / is-network / discoverable)
   MainUnit;
 
-// Issue #968 -- the default network TCP port is per radio MODEL, not per CAT
-// family: the K4, Flex and the Kenwoods all carry rt = rtKenwood (they share a
-// Kenwood-style CAT dialect) yet use four different network ports, so we cannot
-// key off RadioParametersArray[].rt for them.  Icom is the one clean family case.
-// Returns 0 for a radio that has no network port (serial-only) -> no default.
+// Issue #968 / #1028 -- the default network port is a property of the radio
+// MODEL, now owned by the radio factory (single source of truth, keyed by
+// TRadioModel).  Returns 0 for a radio that has no network port (serial-only).
 function DefaultNetworkPortForRadio(rt: InterfacedRadioType): Integer;
 begin
-   case rt of
-      K4:     Result := 9200;
-      FLEX:   Result := 4992;
-      TS890:  Result := 60000;
-      TS990:  Result := 50000;    // NOT the same as the TS-890
-   else
-      if RadioParametersArray[rt].rt = rtICOM then
-         begin
-         Result := 50001;         // any Icom network model
-         end
-      else
-         begin
-         Result := 0;             // not a network radio -> no default
-         end;
-   end;
+   Result := TRadioFactory.DefaultNetworkPort(TRadioFactory.ModelForInterfacedType(rt));
 end;
 
-// Issue #968 -- when the dialog is showing a network radio (control-port combo
-// 122 = index 21) and the TCP-port edit (131) is empty/0, pre-fill it with the
-// selected model's default port.  Never overwrites a port the operator typed.
+// Issue #1028 -- True if `port` is the default network port of SOME network
+// radio model.  Lets us tell a stale leftover default (e.g. 50001 from a
+// previously-selected Icom) apart from a custom port the operator deliberately
+// typed.
+function IsSomeModelDefaultPort(port: Integer): Boolean;
+var
+   rt: InterfacedRadioType;
+begin
+   Result := False;
+   if port = 0 then
+      begin
+      Exit;
+      end;
+   for rt := Low(InterfacedRadioType) to High(InterfacedRadioType) do
+      begin
+      if DefaultNetworkPortForRadio(rt) = port then
+         begin
+         Result := True;
+         Exit;
+         end;
+      end;
+end;
+
+// Issue #968 / #1028 -- when the dialog is showing a network radio (control-port
+// combo 122 = index 21), set the TCP-port edit (131) to the selected model's
+// default port when the field is EMPTY or still holds a DIFFERENT model's
+// default (a stale leftover from the previous radio type -- e.g. 50001 from an
+// Icom when switching to a K4, which should become 9200).  Never clobbers a
+// genuinely custom (non-default) port the operator typed.
 procedure ApplyDefaultNetworkPort(hwnddlg: HWND);
 var
    typeIdx : Integer;
@@ -98,14 +109,16 @@ begin
       Exit;
       end;
 
-   port := Windows.GetDlgItemInt(hwnddlg, 131, ok, False);
-   if port <> 0 then                            // operator already set a port
+   def := DefaultNetworkPortForRadio(InterfacedRadioType(typeIdx));
+   if def = 0 then                              // not a network radio -> no default
       begin
       Exit;
       end;
 
-   def := DefaultNetworkPortForRadio(InterfacedRadioType(typeIdx));
-   if def <> 0 then
+   port := Windows.GetDlgItemInt(hwnddlg, 131, ok, False);
+   // Empty, or a stale default from a different model -> apply this model's
+   // default.  A non-default custom port (not any model's default) is kept.
+   if (port = 0) or (IsSomeModelDefaultPort(port) and (Integer(port) <> def)) then
       begin
       Windows.SetDlgItemInt(hwnddlg, 131, def, False);
       end;
@@ -169,8 +182,9 @@ begin
   rt := InterfacedRadioType(tCB_GETCURSEL(hwnddlg, 121));
   radioName := InterfacedRadioTypeSA[rt];
 
-  // Discoverable types: the K4, and any Icom network model (rtICOM).
-  if (rt <> K4) and (RadioParametersArray[rt].rt <> rtICOM) then
+  // Issue #1028 -- discoverability is now a radio-factory property (network
+  // radios with LAN auto-discovery: K4, the network Icoms, FLEX).
+  if not TRadioFactory.IsDiscoverable(TRadioFactory.ModelForInterfacedType(rt)) then
      begin
      Format(wsprintfBuffer, TC_DISCOVER_NOT_AVAILABLE, PChar(radioName));
      showwarning(wsprintfBuffer);

--- a/tr4w/src/uRadioFactory.pas
+++ b/tr4w/src/uRadioFactory.pas
@@ -35,6 +35,7 @@ type
       rmIcomIC7100,
       rmFlexRadio6000,
       rmKenwoodTS890,   // Issue #436 -- TS-890 network (Kenwood CAT over TCP + ##CN/##ID auth)
+      rmKenwoodTS990,   // TS-990 network (reuses the TS-890 CAT/auth path)
       rmHamLibDirect
    );
 
@@ -60,6 +61,15 @@ type
                                         dtr: Boolean = False): TNetRadioBase;
       class function GetSupportedModels: string;
       class function IsModelSupported(model: TRadioModel): boolean;
+
+      // Network metadata (Issue #1028) -- single source of truth for "is this a
+      // network radio", its default TCP/UDP port, and whether TR4W can auto-
+      // discover it on the LAN.  Keyed by TRadioModel; legacy InterfacedRadioType
+      // callers bridge via ModelForInterfacedType.
+      class function ModelForInterfacedType(rt: InterfacedRadioType): TRadioModel;
+      class function DefaultNetworkPort(model: TRadioModel): integer;
+      class function IsNetworkModel(model: TRadioModel): boolean;
+      class function IsDiscoverable(model: TRadioModel): boolean;
    end;
 
    ERadioFactoryException = class(Exception);
@@ -201,6 +211,17 @@ begin
          Result.radioPort := port;
          Result.radioModel := 'Kenwood TS-890S';
          logger.Info('[RadioFactory] Created Kenwood TS-890 instance (Issue #436)');
+         logger.Info('[RadioFactory] Remember to set NetworkUsername/NetworkPassword before Connect');
+         end;
+
+      rmKenwoodTS990:
+         begin
+         // Reuses the TS-890 network class (shared Kenwood CAT-over-TCP + ##CN/##ID auth).
+         Result := TKenwoodTS890Radio.Create;
+         Result.radioAddress := address;
+         Result.radioPort := port;
+         Result.radioModel := 'Kenwood TS-990S';
+         logger.Info('[RadioFactory] Created Kenwood TS-990 instance (via TS-890 class)');
          logger.Info('[RadioFactory] Remember to set NetworkUsername/NetworkPassword before Connect');
          end;
 
@@ -443,6 +464,7 @@ begin
       rmIcomIC7100:     Result := 'Icom IC-7100';
       rmFlexRadio6000:  Result := 'FlexRadio 6000';
       rmKenwoodTS890:   Result := 'Kenwood TS-890S';
+      rmKenwoodTS990:   Result := 'Kenwood TS-990S';
       rmHamLibDirect:   Result := 'HamLib Direct (DLL)';
    else
       Result := 'Unknown';
@@ -463,6 +485,7 @@ begin
              '  - Icom IC-7850 (implemented)'#13#10 +
              '  - Icom IC-905 (implemented)'#13#10 +
              '  - Kenwood TS-890S (implemented, Issue #436)'#13#10 +
+             '  - Kenwood TS-990S (implemented, via TS-890 class)'#13#10 +
              '  - HamLib Direct via DLL (implemented)'#13#10 +
              '  - Elecraft K3 (planned)'#13#10 +
              '  - Yaesu FTdx101 (planned)'#13#10 +
@@ -485,7 +508,64 @@ begin
              (model = rmIcomIC7100) or
              (model = rmFlexRadio6000) or
              (model = rmKenwoodTS890) or
+             (model = rmKenwoodTS990) or
              (model = rmHamLibDirect);
+end;
+
+// Maps the legacy InterfacedRadioType (LOGRADIO RadioParametersArray order) to
+// the factory's TRadioModel.  Single source of truth -- RadioObject.MapRadio
+// ModelToFactory delegates here.  Radios with no factory model -> rmNone.
+class function TRadioFactory.ModelForInterfacedType(rt: InterfacedRadioType): TRadioModel;
+begin
+   case rt of
+      K4:             Result := rmElecraftK4;
+      IC7610:         Result := rmIcomIC7610;
+      IC7300:         Result := rmIcomIC7300;
+      IC9700:         Result := rmIcomIC9700;
+      IC705:          Result := rmIcomIC705;
+      IC7300MK2:      Result := rmIcomIC7300MK2;
+      IC7600:         Result := rmIcomIC7600;
+      IC7760:         Result := rmIcomIC7760;
+      IC7850, IC7851: Result := rmIcomIC7850;
+      IC905:          Result := rmIcomIC905;
+      IC7100:         Result := rmIcomIC7100;
+      FLEX:           Result := rmFlexRadio6000;
+      TS890:          Result := rmKenwoodTS890;
+      TS990:          Result := rmKenwoodTS990;
+   else
+      Result := rmNone;
+   end;
+end;
+
+// The default network port per model.  0 means "not a network radio".
+class function TRadioFactory.DefaultNetworkPort(model: TRadioModel): integer;
+begin
+   case model of
+      rmElecraftK4:     Result := 9200;
+      rmFlexRadio6000:  Result := 4992;
+      rmKenwoodTS890:   Result := 60000;
+      rmKenwoodTS990:   Result := 50000;
+      rmIcomIC7610, rmIcomIC9700, rmIcomIC705, rmIcomIC7300MK2,
+      rmIcomIC7600, rmIcomIC7760, rmIcomIC7850, rmIcomIC905:
+                        Result := 50001;   // Icom network models (CI-V over UDP)
+   else
+      Result := 0;                          // serial-only / not a network radio
+   end;
+end;
+
+// A model is a network radio iff it carries a default network port.
+class function TRadioFactory.IsNetworkModel(model: TRadioModel): boolean;
+begin
+   Result := DefaultNetworkPort(model) > 0;
+end;
+
+// Discoverable = a network radio with LAN auto-discovery.  Every network radio
+// qualifies EXCEPT the Kenwoods (network, but no discovery protocol wired yet).
+class function TRadioFactory.IsDiscoverable(model: TRadioModel): boolean;
+begin
+   Result := IsNetworkModel(model)
+             and (model <> rmKenwoodTS890)
+             and (model <> rmKenwoodTS990);
 end;
 
 initialization

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -678,6 +678,11 @@ begin
   ReadInConfigFile(cfgCFG);          //n4af 4.31.5
   ReadInConfigFile(cfgCommMes);      //common messages gets precedence - n4af
 
+  // Issue #1012: the S&P F1 caption is derived from DE ENABLE, whose value is
+  // only known after the config files above are read.  Recompute it now so
+  // DE ENABLE = FALSE shows "Call" instead of the default "DE+Call".
+  UpdateSAndPF1Caption;
+
   if WSJTXEnabled then
      begin
      wsjtx := TWSJTXServer.Create;


### PR DESCRIPTION
Four independent fixes/features from the CARS meeting discoveries. Each is a self-contained commit and could be split into separate PRs if preferred.

## Commits

### `#1028` — radio factory owns network-port + discoverability metadata
Makes `uRadioFactory` the single source of truth for three radio traits: is-network-radio, default network port, and discoverability.
- `uRadioFactory`: `ModelForInterfacedType`, `DefaultNetworkPort`, `IsNetworkModel`, `IsDiscoverable`; adds `rmKenwoodTS990` (reuses `TKenwoodTS890Radio`).
- `uCAT`: `DefaultNetworkPortForRadio` and the discovery-eligibility gate delegate to the factory. `ApplyDefaultNetworkPort` now applies the default when the port is empty **or** holds a stale different-model default — fixing the IC-7760 (50001) → K4 (9200) switch.
- `LOGRADIO`: `MapRadioModelToFactory` delegates to the factory.
- **Tested on hardware** (port now updates correctly on radio switch + discovery rerun).

### QuickCommand window — clear stale exchange error after a QSO is logged
A failed exchange validation (e.g. `TC_IMPROPERARRLFIELDDAYCLASS`) shows via `QuickDisplayError` on a 30s flash timer. Its lifetime was tied only to the timer, so the stale error kept flashing after the corrected QSO was logged. `TryLogContact` now clears it on a successful log (the definitive signal the failure is resolved).

### `#1012` — hide "DE+Call" from S&P F1 caption when DE ENABLE = FALSE
The S&P F1 caption is derived from `DEEnable`, but was computed once in `SetConfigurationDefaultValues` **before** the config files are read — so it always showed `DE+Call` (the default). Factored the decision into `UpdateSAndPF1Caption` and re-apply it after the config files are read, so `DE ENABLE = FALSE` correctly shows `Call`.

### `=` replays the exact characters last sent on CW
Pressing `=` in the call window (CW mode) re-keys the most recent CW message verbatim. The text is captured as the **actual expanded characters** sent (at the `AddStringToBuffer` keyer funnel) — not the pre-send cryptic command — so a replay after the QSO is logged still sends the original serial and call, even though the call window has cleared and the serial advanced. Works across all keyers (radio CWByCAT / WinKeyer / YCCC / serial-LPT), CQ and S&P. RTTY can reuse the same funnel later; voice (DVK) out of scope.

## Testing
- All four build clean via `FullBuild.ps1` (894 unit tests pass).
- `#1028` and `#1012` verified by the reporter on the running app; the CW `=` replay and the QuickDisplay clear were tested live.
