### PR TITLE
Editable-log bottom border + #1040 (no CW in digital) + #1041 (connect-retry log spam)

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -7115,18 +7115,39 @@ begin
 end;
 
 procedure CheckEditableWindowHeight;
-label
-  1;
 var
-  h: integer;
+  h, guard: integer;
 begin
+  // Size the editable-log list so ALL LinesInEditableLog loaded rows are fully
+  // visible.  The old loop shrank to the largest height where only
+  // LinesInEditableLog-1 rows fit, which always left the next (loaded) row
+  // clipped at the bottom with no border.  Instead: shrink if too many rows
+  // fit, then grow to the SMALLEST height where every LinesInEditableLog row
+  // shows whole -- the list's static edge then forms a clean bottom border
+  // matching the top.  (Reported: editable-log bottom row cut off.)
   h := 30 + LinesInEditableLog * (ws + 2) {EditableLogWindowHeight};
-  1:
-  h := h - 1;
   Windows.SetWindowPos(wh[mweEditableLog], HWND_TOP, 0, ws * 7,
     MainWindowChildsWidth, h, SWP_SHOWWINDOW);
-  if ListView_GetCountPerPage(wh[mweEditableLog]) > LinesInEditableLog - 1 then
-    goto 1;
+
+  guard := 0;
+  while (ListView_GetCountPerPage(wh[mweEditableLog]) > LinesInEditableLog)
+        and (guard < 200) do
+    begin
+    h := h - 1;
+    Inc(guard);
+    Windows.SetWindowPos(wh[mweEditableLog], HWND_TOP, 0, ws * 7,
+      MainWindowChildsWidth, h, SWP_SHOWWINDOW);
+    end;
+
+  guard := 0;
+  while (ListView_GetCountPerPage(wh[mweEditableLog]) < LinesInEditableLog)
+        and (guard < 200) do
+    begin
+    h := h + 1;
+    Inc(guard);
+    Windows.SetWindowPos(wh[mweEditableLog], HWND_TOP, 0, ws * 7,
+      MainWindowChildsWidth, h, SWP_SHOWWINDOW);
+    end;
 end;
 
 function CheckCommandInCallsignWindow: boolean;

--- a/tr4w/src/TF.pas
+++ b/tr4w/src/TF.pas
@@ -139,7 +139,7 @@ function IntegerBetween(v: integer; i: integer; k: integer): boolean;
 
 function ValExt(Source: PChar; var code: integer): extended;
 
-function tCreateThread(lpStartAddress: TFNThreadStartRoutine; var lpThreadId: DWORD): THandle;
+function tCreateThread(lpStartAddress: TFNThreadStartRoutine; var lpThreadId: DWORD; Quiet: boolean = False): THandle;
 
 //function tgethostbyname(h_Name: PChar): PChar;
 function tDialogBox(WindowID: Byte; WinProcAdr: Pointer): integer;
@@ -1022,10 +1022,14 @@ begin
 
 end;
 
-function tCreateThread(lpStartAddress: TFNThreadStartRoutine; var lpThreadId: DWORD): THandle;
+function tCreateThread(lpStartAddress: TFNThreadStartRoutine; var lpThreadId: DWORD; Quiet: boolean): THandle;
 begin
   Result := CreateThread(nil, 0, lpStartAddress, nil, 0, lpThreadId);
-  logger.Debug('[tCreateThread] Created thread %d',[lpThreadId]);
+  // Issue #1041: Quiet suppresses this per-create debug line so the network
+  // connect-retry loop (one thread every 5s while the server is unreachable)
+  // does not spam the log -- loud on a genuine attempt, silent on retries.
+  if not Quiet then
+    logger.Debug('[tCreateThread] Created thread %d',[lpThreadId]);
 end;
 
 //function _Pow10(val: Extended; Power: Integer): Extended;

--- a/tr4w/src/trdos/LogSend.pas
+++ b/tr4w/src/trdos/LogSend.pas
@@ -130,12 +130,26 @@ begin
 // So, it's more efficient to use \ than NY4I
 // I wonder if this could be improved to buffer the characters? // 4.44.5
 
-  if CWEnabled = False then
+  // Issue #1040: key CW only when this is genuinely a CW send (CW mode with CW
+  // enabled) OR an MMTTY/RTTY send (DigitalModeEnable=True -> we want to drive
+  // MMTTY).  Any other state -- notably Digital mode with DigitalModeEnable=
+  // False (e.g. FT8 via WSJT-X, where the external app transmits) -- must NOT
+  // key CW when a call is typed / DE / exchange / a function key fires.
+  // DigitalModeEnable is what makes Digital a real (RTTY) mode here (see the
+  // mode-cycle in LOGSUBS2 and the DIG status text in JCtrl1).
+  if not (((ActiveMode = CW) and CWEnabled) or
+          DigitalModeEnable)                then
      begin
-     logger.warn('Attempting SendCrypticCWString with CWEnabled = false');
+     if (ActiveMode = CW) and (not CWEnabled) then
+        begin
+        logger.warn('Attempting SendCrypticCWString with CWEnabled = false');
+        end;
      Exit;
      end;
-  if length(SendString) = 0 then Exit;
+  if length(SendString) = 0 then
+     begin
+     Exit;
+     end;
   //SetSpeed(DisplayedCodeSpeed); //ny4i This seems superflous. The speed should be set already
 
 

--- a/tr4w/src/uNet.pas
+++ b/tr4w/src/uNet.pas
@@ -617,15 +617,36 @@ var
   // else.  We log only on transitions: first attempt, recover, fail.
   FConnectLogState : TNetConnectLogState = nclsInitial;
 
+  // Issue #1041: was THIS connect attempt an announced one (first / after a
+  // recovery) rather than a silent retry?  ConnectThread reads it at exit to
+  // log its destruction at the same volume as its creation.  No lock needed:
+  // NetThreadID gates a single connect thread at a time, so the value set when
+  // the thread is created stays put for that thread's whole life.
+  FConnectThreadAnnounced : boolean = False;
+
 procedure TryConnectToNetwork;
+var
+  announce: boolean;
 begin
-  // Only log on state transitions.
-  if FConnectLogState <> nclsTrying then
+  // Issue #1041: log the "trying" line only on a GENUINE new attempt -- the
+  // first one (nclsInitial) or after we'd been connected and dropped
+  // (nclsConnected).  The old condition (<> nclsTrying) re-fired here every
+  // retry because after a failure the state is nclsFailed; that, paired with
+  // the fail handler flipping it back to nclsFailed, made the "trying" debug
+  // and the "failed" warn ping-pong every 5s instead of going silent.  While
+  // we are in the silent retry phase (nclsFailed) we must NOT relabel the
+  // state, so neither line repeats until something actually changes.
+  announce := FConnectLogState in [nclsInitial, nclsConnected];
+  if announce then
      begin
      logger.Debug('TryConnectToNetwork -> %s:%d  (will retry every 5s while server is unreachable; further attempts logged only on state change)', [ServerAddress, ServerPort]);
      FConnectLogState := nclsTrying;
      end;
-  if NetThreadID = 0 then tCreateThread(@ConnectThread, NetThreadID);
+  if NetThreadID = 0 then
+     begin
+     FConnectThreadAnnounced := announce;
+     tCreateThread(@ConnectThread, NetThreadID, not announce {Quiet on silent retries});
+     end;
 end;
 
 procedure ConnectThread;
@@ -693,10 +714,13 @@ begin
        end;
   end;
   2:
-  // Demoted from debug to trace: this fires every ~5s during a retry loop
-  // and was drowning the log.  Still available for thread-lifecycle
-  // debugging at trace level.
-  logger.Trace('[ConnectThread] Thread %d exiting, NetThreadID cleared', [GetCurrentThreadId]);
+  // Issue #1041: log destruction at the same volume as creation -- debug on a
+  // genuine (announced) attempt so create/destroy pair up in the log, trace
+  // during the silent retry loop so it stays quiet.
+  if FConnectThreadAnnounced then
+     logger.Debug('[ConnectThread] Thread %d destroyed, NetThreadID cleared', [GetCurrentThreadId])
+  else
+     logger.Trace('[ConnectThread] Thread %d exiting, NetThreadID cleared', [GetCurrentThreadId]);
   NetThreadID := 0;
 end;
 


### PR DESCRIPTION
## Summary
Three independent fixes found during ARRL VHF (FT8) operating. All verified in a combined build alongside the CW-state desync fix (#fix-cw-enable-state-desync).

## Changes
- **`557e34a` Editable-log window clips the last QSO row.** `CheckEditableWindowHeight` shrank to the largest height where only `LinesInEditableLog-1` rows fit, always leaving the next loaded row clipped with no bottom border. Replaced the shrink-only loop with shrink-then-grow to the smallest height where *all* `LinesInEditableLog` rows show whole, so the list's static edge forms a clean bottom border matching the top. Guarded both loops against runaway. *Verified rows 5–15.*
- **`3b3228d` #1040: no CW in a non-MMTTY digital mode.** In digital mode (e.g. FT8 via WSJT-X) with `DIGITAL MODE ENABLE = False`, typing a call still ran the cryptic-CW path and keyed CW even though the external app owns transmit. Gated `SendCrypticCWString` at its chokepoint: run only for a genuine CW send (`ActiveMode=CW and CWEnabled`) **or** an MMTTY/RTTY send (`DigitalModeEnable=True`). CW mode and RTTY/MMTTY unaffected.
- **`15cf91c` #1041: connect-retry log spam.** The retry state machine ping-ponged `nclsTrying`/`nclsFailed`, re-firing both the "trying" debug and "failed" warn every 5 s. Now logs the try/fail pair once then goes silent until the state actually changes; the per-retry `tCreateThread` line is suppressed during the silent loop (new optional `Quiet` flag on `tCreateThread`, default off), and thread create/destroy log symmetrically. *Verified: noise gone.*

## Testing
All four behaviors verified in a combined build: log-window border (5–15), FT8 → type call → no CW, server-down retry log quiet.
