### PR TITLE
Fix CW ENABLE state desync (CWEnable vs CWEnabled)

### DIFF
--- a/tr4w/src/trdos/LOGWIND.PAS
+++ b/tr4w/src/trdos/LOGWIND.PAS
@@ -1562,7 +1562,13 @@ begin
   DisplayedCodeSpeed := CodeSpeed;
   if ActiveMode = CW then
   begin
-    if CWEnable or CWEnabled {CWEnabled} then
+    // CW-state desync fix: show the ACTUAL transmit gate (CWEnabled), not
+    // CWEnable OR CWEnabled.  The OR let a stale CWEnable mask a disabled gate,
+    // so the display read "WPM" while Enter sent nothing.  CWEnable and
+    // CWEnabled are now kept in step at config load (see ReadInConfigFile), so
+    // this matches CWEnable too -- but keying off the gate the sender checks
+    // means the UI can never claim CW is on when it will not transmit.
+    if CWEnabled then
        begin
        tPChar := '%u WPM';
        end

--- a/tr4w/src/trdos/LogCfg.pas
+++ b/tr4w/src/trdos/LogCfg.pas
@@ -536,6 +536,16 @@ begin
   if ConfigFileName = cfgINI then
      EnumerateLinesInFile(TR4W_INI_FILENAME, RestoreCFGPasswordCase, False);
 
+  // CW-state desync fix: the 'CW ENABLE' config command writes only CWEnable,
+  // but the actual transmit gate (SendCrypticCWString) and the Alt-K toggle
+  // (SetCWState) key off CWEnabled, while the speed display ORs the two.  With
+  // nothing syncing them, "CW ENABLE = FALSE" left CWEnabled at its True
+  // default -- so the display showed "WPM" yet no CW was sent until two Alt-K
+  // toggles reconciled both.  Mirror the configured value into the runtime gate
+  // after every config read so the two can never start out of step.  (CWEnable
+  // and CWEnabled represent the same thing and SetCWState always sets both.)
+  CWEnabled := CWEnable;
+
   if ConfigFileName = cfgCFG then if not ConfigurationOkay then halt;
 end;
 


### PR DESCRIPTION
## Summary
Fixes a CW on/off state desync: with `CW ENABLE = FALSE` in the config, the speed display showed "WPM" yet pressing Enter/F1 sent no CW until two Alt-K toggles reconciled it. Root cause is two flags written by different layers and combined inconsistently.

## Root cause
CW state lives in **two** flags:
- `CW ENABLE` config command writes only **`CWEnable`** (default True).
- The transmit gate (`SendCrypticCWString`) and the keying start in `AddStringToBuffer` use **`CWEnabled`** (default True).
- The speed display ORs the two (`CWEnable OR CWEnabled`).
- Alt-K (`SetCWState`) writes **both** together.

Nothing synced them at load, so `CW ENABLE = FALSE` set `CWEnable=False` but left `CWEnabled=True` (or vice-versa) — the display read "WPM" while the keyer thread never started (confirmed in the log: chars buffered but no `PTTOn`/`tCreateThread` until two toggles set both flags).

## Changes
- **`b9ea0d8`** Mirror the configured value into the runtime gate (`CWEnabled := CWEnable`) at the end of `ReadInConfigFile`, after each config file, so the two can never start out of step.
- **`30c8a54`** `DisplayCodeSpeed` keys the "WPM"/"NO CW" indicator off the actual transmit gate (`CWEnabled`) instead of `CWEnable OR CWEnabled`, so the UI can't claim CW is on when it won't transmit.

## Testing
Verified: with `CW ENABLE` absent/True, CW keys from startup with no Alt-K dance; with `CW ENABLE = FALSE`, display reads "NO CW" and stays off. Confirmed in a combined build with the VHF fixes (#1046).
