### PR TITLE
Fix AUTO S&P clearing the call window on a commanded (bandmap) QSY (latent, #795 interaction)

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -165,6 +165,7 @@ type
       tTwoRadioMode:     TRMode;
       RadioOnTheMove:    boolean;
       LastDisplayedFreq: integer;
+      tCommandedQSYFreq: integer;  // Issue #795 vs bandmap: last app-commanded VFO-A freq; auto-S&P treats a QSY landing here as commanded (don't clear the entry), not a manual dial tune
       SpeedMemory:       integer;
       BandMemory:        BandType;
       ModeMemory:        ModeType;
@@ -3271,6 +3272,13 @@ begin
       logger.debug('[SetRadioFreq] freq <= 0 (no band memory or default for this band/mode) -- skipping tune');
       Exit;
       end;
+
+   // Issue #795 vs bandmap double-click: record the app-commanded VFO-A
+   // frequency so the auto-S&P "QSY clears the entry" logic (uRadioPolling) can
+   // tell a COMMANDED QSY (bandmap/spot/typed freq -- a call may have been
+   // placed deliberately) from a MANUAL dial QSY (which #795 wants to clear).
+   if VFO = 'A' then
+      Self.tCommandedQSYFreq := Freq;
 
    if Self.tNetObject <> nil then
       begin

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -3139,7 +3139,15 @@ begin
          if rig.LastDisplayedFreq <> 0 then
             if dif > AutoSAPEnableRate then
                if dif <= 10000 then
-                  if AutoSAPEnable {and (Not Switch) } then // n4af 4.44.10
+                  if AutoSAPEnable and
+                     // Issue #795 vs bandmap: #795 made a MANUAL dial QSY clear
+                     // the call/exchange in S&P.  But a COMMANDED QSY (bandmap
+                     // double-click, spot click, typed freq) also moves the VFO
+                     // and may have just placed a call -- don't clobber it.
+                     // SetRadioFreq records the commanded VFO-A freq; treat this
+                     // as a manual tune (and clear) only if we landed FAR from
+                     // the last commanded freq.
+                     (Abs(rig.FilteredStatus.Freq - rig.tCommandedQSYFreq) > AutoSAPEnableRate) then // n4af 4.44.10
                     // if OpMode = CQOpMode then    // 4.139.3
                         begin
                            SetOpMode(SearchAndPounceOpMode);


### PR DESCRIPTION
## Summary
Fixes a **latent** bug: with `AUTO S&P ENABLE = TRUE`, double-clicking a band-map spot intermittently wiped the call that was just placed in the call window. Present since the #795 "S&P QSY clears the call/exchange" feature; only bites when AUTO S&P is on and on a real radio that reports the QSY back (so it's been hiding for a while).

## Root cause
The auto-S&P handler in `uRadioPolling` (runs on the radio **poll thread**) treats any active-radio frequency change `> AutoSAPEnableRate` as a manual dial QSY and resets the entry (the #795 behavior). A band-map double-click (or spot click / typed freq) **also** moves the VFO — and having just placed a call via `PutCallToCallWindow` on the main thread, the poll thread then cleared it. Confirmed in the log: call placed on thread A, `Clearing main call window` ~40 ms later on the K4 poll thread. Race → intermittent.

## Fix
Distinguish a **commanded** QSY from a **manual** tune:
- `RadioObject.SetRadioFreq` records the app-commanded VFO-A frequency in a new `tCommandedQSYFreq` field (band-map, spot click, and typed-freq all route through `SetRadioFreq`).
- The auto-S&P clear now fires only when the radio lands **far** (`> AutoSAPEnableRate`) from that commanded freq — i.e. a genuine manual dial turn. A commanded QSY lands *at* the commanded freq, so it no longer trips the clear.

Preserves #795 for manual tuning; stops the band-map call-window wipe.

## Testing
Hardware-verified (Elecraft K4): band-map double-click keeps the call across repeated clicks; manual dial QSY still clears the entry in S&P (#795 intact); same-band, cross-band, and SO2R inactive-radio paths all good.
