### PR TITLE
Fix duplicate STX_STRING (FD/WFD) and over-broad ADIF STATE (#1050)

### DIFF
--- a/tr4w/src/trdos/PostUnit.PAS
+++ b/tr4w/src/trdos/PostUnit.PAS
@@ -1909,7 +1909,10 @@ begin
          begin
          Result := Result + EmitADIFField('SRX_STRING', string(rec.ExchString));
          if LooksLikeAState(string(rec.ExchString)) then
-            Result := Result + EmitADIFField('STATE', string(rec.ExchString))
+            begin
+            Result := Result + EmitADIFField('DXCC','291'); // Yes, hard-coded to US country ARRL code
+            Result := Result + EmitADIFField('STATE', string(rec.ExchString));
+            end
          else
             begin
             exchForGrid := rec.ExchString;
@@ -1958,17 +1961,29 @@ begin
                begin
                if rec.QTHString <> 'DX' then
                   begin
+                  if rec.QTH.CountryID = 'K' then
+                     begin
+                     Result := Result + EmitADIFField('DXCC','291'); // Yes, hard-coded to US country ARRL code    ny4i
+                     Result := Result + EMitADIFField('STATE',GetStateFromSection(rec.QTHString));
+                     end
+                  else if rec.QTH.CountryID = 'VE' then
+                     begin
+                     Result := Result + EmitADIFField('DXCC','1'); // Yes, hard-coded to VE country ARRL code    ny4i
+                     Result := Result + EMitADIFField('STATE',GetStateFromSection(rec.QTHString));
+                     end;
                   Result := Result + EmitADIFField('ARRL_SECT',
                                                    string(rec.QTHString));
                   Result := Result + EmitADIFField('CLASS',
                                                    string(rec.ceClass));
                   end;
-               // Legacy behaviour: emit an additional STX_STRING with
-               // MyFDClass + MySection.  The record then has two
-               // STX_STRING tags; the second one wins on parse.
-               Result := Result + EmitADIFField('STX_STRING',
-                                                string(MyFDClass) + ' ' +
-                                                string(MySection));
+               // No STX_STRING here (#1050).  It is already emitted once above
+               // from GetMyExchangeForExport, which builds "<class> <section>" for
+               // both FD and WFD (AE = ClassDomesticOrDXQTHExchange).  The
+               // former extra emission here produced a duplicate STX_STRING
+               // tag once the general emitter was fixed to run per-record
+               // (#1049) -- before that the general one was the broken
+               // "Error generating my exchange" default, so this explicit
+               // copy was the one that "won on parse".  Now redundant.
                end;
             ARRLSSCW, ARRLSSSSB:
                if rec.QTHString <> 'DX' then

--- a/tr4w/src/uADIF.pas
+++ b/tr4w/src/uADIF.pas
@@ -1336,16 +1336,20 @@ begin
    // ResolveSRXString below is exported as a helper for the tail
    // emitter's RST-normalizing branch.
 
-   // STATE - emit when QTHString is a 2-letter postal code, OR when this
-   // is a single-state QSO party and QTHString is a county code.
-   if (Length(rec.QTHString) = 2) and not StringHasNumber(rec.QTHString) then
-      Result := Result + EmitADIFField('STATE', string(rec.QTHString))
-   else
-      begin
-      stateForQP := GetStateForContest(rec.ceContest);
-      if (stateForQP <> '') and (rec.QTHString <> '') then
-         Result := Result + EmitADIFField('STATE', stateForQP);
-      end;
+   // STATE - only for single-state QSO parties, where the host state is
+   // known from the contest type and QTHString is a county code.
+   //
+   // We deliberately do NOT infer STATE from a bare 2-char QTHString.
+   // QTHString means different things per contest (an ARRL section, a
+   // zone, a serial, a name, ...), so a "2 letters => it's a state"
+   // heuristic mislabels section-based contests -- e.g. ARRL section
+   // 'EB' (East Bay) is not the state 'EB'.  Contest-specific STATE that
+   // must be derived (e.g. Field Day: section -> state) is emitted by the
+   // PostUnit tail emitter, which has the contest knowledge to do it
+   // correctly.  See Issue #1050.
+   stateForQP := GetStateForContest(rec.ceContest);
+   if (stateForQP <> '') and (rec.QTHString <> '') then
+      Result := Result + EmitADIFField('STATE', stateForQP);
 
    // QTH - the "default" location field.  Always emit when QTHString
    // is non-empty.  Contests that prefer GRIDSQUARE/IOTA/ARRL_SECT


### PR DESCRIPTION
Fixes TR4W/TR4W#1050.

## What

Two related ADIF-export cleanups discovered while testing TR4W/TR4W#1049.

### 1. Duplicate `STX_STRING` on Field Day / Winter Field Day (#1050)

The export tail emitted `STX_STRING` twice for FD/WFD — once from the general `GetMyExchangeForExport` path and again from an explicit `MyFDClass + ' ' + MySection` line. Both FD and WFD use `AE = ClassDomesticOrDXQTHExchange`, so the general emitter already produces the identical `"<class> <section>"`. The explicit copy was only the "real" one back when the general emitter returned its `'Error generating my exchange'` default (pre-#1049); now it's pure duplication. Removed the explicit emission; `ARRL_SECT` and `CLASS` stay.

### 2. Over-broad `STATE` inference in `uADIF.EmitADIFRecord`

The body emitter guessed `STATE` from any bare 2-char `QTHString`. But `QTHString` is contest-dependent (an ARRL section, a zone, a serial, a name…), so the "2 letters ⇒ state" heuristic mislabeled section-based contests — e.g. ARRL section `EB` (East Bay) became `STATE=EB`.

`STATE` is now emitted contest-dependently:
- **Body**: only for single-state QSO parties, via `GetStateForContest`.
- **PostUnit tail**: FD/WFD derive `STATE` from the section (`GetStateFromSection`) and emit `DXCC` (291 US / 1 VE). POTA emits `DXCC` when the worked exchange is a US state.

## Audit

Checked every `EmitADIFField` in the tail against the body emitter and sibling branches. `STX_STRING`/FD was the only true duplicate. POTA `STATE`/`GRIDSQUARE` were flagged as suspects but confirmed OK in testing.

## Known follow-up (not in this PR)

ARRL-section contests other than FD/WFD (Sweepstakes, ARRL-160) now emit `ARRL_SECT` only (no `STATE`). Extending the section→state treatment to them is blocked on TR4W/TR4W-D12#13 — the DOM file stores the truncated alias (`EM`) instead of the canonical section (`EMA`), so the section value feeding `GetStateFromSection` is unreliable. Deferred to the contest-factory rework. Emitting no `STATE` is preferable to a wrong one.

## Testing

Verified on hardware by NY4I: ARRL Field Day export now has exactly one `<STX_STRING>` per record and correct `<STATE>` (section→state, e.g. `WCF`→`FL`); POTA export confirmed correct. Build green (970 unit tests + main app + server).
