### PR TITLE
CW resend: move from = to Ctrl+= (avoids Quick QSL collision) + diagnostic logging

### DIFF
--- a/tr4w/src/MainUnit.pas
+++ b/tr4w/src/MainUnit.pas
@@ -365,6 +365,7 @@ procedure CreateQSONeedWindows;
 procedure CallWindowKeyDownProc(wParam: integer);
 procedure CallWindowKeyUpProc;
 procedure ExchangeWindowKeyDownProc(wParam: integer);
+procedure RepeatLastCWMessage;
 procedure OpenTR4WWindow(ID: WindowsType);
 procedure OpenOtherWindows;
 procedure CloseTR4WWindow(ID: WindowsType);
@@ -4078,6 +4079,22 @@ begin
 
 end;
 
+procedure RepeatLastCWMessage;
+   // '=' repeat-last-CW-message: replay the exact characters last sent on CW.
+   // Centralized so it works in both the call and exchange windows -- it is
+   // dispatched from the main message loop (tr4w.dpr), the same way the
+   // function keys are, rather than from a single window's key handler.
+begin
+   if LastCWMessage <> '' then
+      begin
+      AddStringToBuffer(LastCWMessage, CWTone);
+      if IsCWByCATActive then
+         begin
+         AddStringToBuffer(CWByCATBufferTerminator, CWTone);
+         end;
+      end;
+end;
+
 procedure CallWindowKeyDownProc(wParam: integer);
 var
   Key: Char;
@@ -4103,20 +4120,8 @@ begin
     Exit;
   end;
 
-  // '=' repeat-last-CW-message: replay the exact characters last sent on CW.
-  if (key = '=') and (ActiveMode = CW) then
-     begin
-     if LastCWMessage <> '' then
-        begin
-        AddStringToBuffer(LastCWMessage, CWTone);
-        if IsCWByCATActive then
-           begin
-           AddStringToBuffer(CWByCATBufferTerminator, CWTone);
-           end;
-        end;
-     CallWindowCharConsumed := True; // prevent WM_CHAR from inserting '=' into the call field
-     Exit;
-     end;
+  // '=' repeat-last-CW-message is handled centrally in the main message loop
+  // (tr4w.dpr WM_CHAR) so it works in both the call and exchange windows.
   // start sending now code
   if Key = StartSendingNowKey then
     if tAutoSendMode = False then

--- a/tr4w/src/lang/tr4w_consts_eng.pas
+++ b/tr4w/src/lang/tr4w_consts_eng.pas
@@ -98,7 +98,7 @@
   TC_IAMIN                              = '&I am in %s';
   TC_CROAT                              = 'I am in Croatia';
 //  TC_UKRSGB                             =  'UK/CD and RSGB member';
-  TC_NEWENGLANDSTATEABREVIATION         = 'Enter your New England state abreviation'#13'(ME, NH, VT, MA, CT, RI):';
+  TC_NEWENGLANDSTATEABREVIATION         = 'Enter your New England state abbreviation'#13'(ME, NH, VT, MA, CT, RI):';
   TC_ENTERTHEQTHTHATYOUWANTTOSEND       = 'Enter the QTH that you want to send:';
   TC_ENTERSTATEFORUSPROVINCEFORCANADA   = 'Enter state for U.S., province for Canada:';
   TC_ENTERYOUROBLASTID                  = 'Enter your oblast ID:';
@@ -255,7 +255,7 @@
 
   TC_NOTENOUGHINFOINEXCHANGE            = 'Not enough info in exchange!!';
   TC_IMPROPERDOMESITCQTH                = 'Improper domestic QTH!!';
-  TC_IMPROPERDOMESITCQTHORMISSINGNAME   = 'Improper domesitc QTH or missing name!!';
+  TC_IMPROPERDOMESITCQTHORMISSINGNAME   = 'Improper domestic QTH or missing name!!';
   TC_MISSINGQTHANDORNAME                = 'Missing QTH and/or name!!';
   TC_NOQSONUMBERFOUND                   = 'No QSO number found!!';
   TC_IMPROPERZONENUMBER                 = 'Improper zone number!!';
@@ -679,7 +679,7 @@
   RC_DELETELASTQSO                      = 'Delete the last QSO';
   RC_INITIALEX                          = 'Initial exchange';
   RC_TOOGLEST                           = 'Toggle sidetone';
-  RC_TOOGLEAS                           = 'Toogle autosend';
+  RC_TOOGLEAS                           = 'Toggle autosend';
   RC_BANDUP                             = 'Band Up';
   RC_BANDDOWN                           = 'Band Down';
   RC_SSBCWMODE                          = 'SSB/CW mode';

--- a/tr4w/src/trdos/LOGK1EA.PAS
+++ b/tr4w/src/trdos/LOGK1EA.PAS
@@ -1328,10 +1328,7 @@ begin
     exit;
   end;
 }
-  logger.debug('[CWThreadProc] AddCharacterToCWBuffer');
-{$IF tDebugMode}
-  AddStringToTelnetConsole('AddCharacterToCWBuffer',tstReceived);
-{$IFEND}
+  logger.debug('[CWThreadProc] AddCharacterToCWBuffer %s',[Character]);
 
   case UpCase(Character) of
     'A':

--- a/tr4w/src/trdos/LOGSUBS1.PAS
+++ b/tr4w/src/trdos/LOGSUBS1.PAS
@@ -215,7 +215,7 @@ begin // 1
 
     CW:
       begin
-        // '=' repeat-last-CW-message: bracket the send so AddStringToBuffer
+        // 'ctrl-=' repeat-last-CW-message: bracket the send so AddStringToBuffer
         // records the actual expanded characters as LastCWMessage.
         BeginCWCapture;
         SendCrypticCWstring(Message);

--- a/tr4w/src/trdos/LogCW.pas
+++ b/tr4w/src/trdos/LogCW.pas
@@ -223,7 +223,7 @@ begin
    //localMsg                                               := Format('Adding %s to CW Buffer', [Msg]);
    //AddStringToTelnetConsole(PChar(localMsg),tstAlert);
    logger.Debug('[AddStringToBuffer] Adding (%s) to CW Buffer',[Msg]);
-   // '=' repeat-last-CW-message: record the actual expanded text being sent
+   // 'ctrl-=' repeat-last-CW-message: record the actual expanded text being sent
    // (skip the CWByCAT control sentinel, which is not on-air content).
    if CWCaptureActive and (Msg <> CWByCATBufferTerminator) then
       begin

--- a/tr4w/src/uProcessCommand.pas
+++ b/tr4w/src/uProcessCommand.pas
@@ -352,8 +352,11 @@ end;
 
 procedure scWINEXEC;
 begin
-  if Windows.WinExec(@scFileName[1], SW_SHOWMINIMIZED) < 31 then
-    ShowSysErrorMessage('WINEXEC');
+   logger.Info('[scWINEXEC] Calling WinExec with %s',[scFileName]);
+   if Windows.WinExec(@scFileName[1], SW_SHOWMINIMIZED) < 31 then
+      begin
+      ShowSysErrorMessage('WINEXEC');
+      end;
 end;
 
 procedure scDISABLECW;

--- a/tr4w/tr4w.dpr
+++ b/tr4w/tr4w.dpr
@@ -975,6 +975,16 @@ begin
 
           if (Msg.HWND = wh[mweCall]) or (Msg.HWND = wh[mweExchange]) then
           begin
+            // Ctrl+= : repeat the exact characters last sent on CW (call +
+            // exchange windows, CW mode).  '=' alone is QUICK QSL KEY 2, so a
+            // bare key collides; a Ctrl combo avoids that and is dispatched
+            // here like the other WM_KEYDOWN shortcuts, then fully consumed.
+            if (Msg.wParam = 187 {VK_OEM_PLUS '='}) and (ActiveMode = CW) and
+               ((GetKeyState(VK_CONTROL) and $8000) <> 0) then
+            begin
+              RepeatLastCWMessage;
+              goto NoTransMess;
+            end;
             if Msg.wParam in [VK_F1..vk_f12] then ProcessFuntionKeys(Msg.wParam);
             if Msg.wParam = VK_F4 then goto NoTransMess;
             if Msg.wParam > 40 then goto TransMess;


### PR DESCRIPTION
Small fixes found during SST (CW) operating. No changes to legacy serial radio code (the K3/serial liveness decorator is a separate, deferred item).

## CW "resend last message" key: `=` → Ctrl+= (main change)

The 4.148.11 "resend exactly what you last sent on CW" feature used a bare `=`, which is also the default **Quick QSL Key 2**. Pressing `=` fired `QuickQSLProcedure` -> `ParametersOkay` (a log attempt) *before* the resend, surfacing a spurious "Improper domestic QTH or missing name" exchange-validation message -- most visibly in the exchange window.

- Resend is now **Ctrl+=**, handled centrally in the `WM_KEYDOWN` loop (`tr4w.dpr`) so it works in **both the call and exchange windows**, dispatched like the function keys and fully consumed (no stray `=` in the field).
- The logic lives in one shared `RepeatLastCWMessage` helper (`MainUnit.pas`); the old bare-`=` handler in `CallWindowKeyDownProc` is removed (no duplicate logic).
- Ctrl+= verified free in the accelerator table (only Alt+= is bound, to sidetone toggle).
- Comments in `LOGSUBS1.PAS` / `LogCW.pas` updated to reflect the new key.

## Typo fix

`TC_IMPROPERDOMESITCQTHORMISSINGNAME`: `domesitc` -> `domestic` (English string only).

## Diagnostic logging (no behavior change)

- `LOGK1EA.PAS`: the `AddCharacterToCWBuffer` debug line now logs the character.
- `uProcessCommand.pas`: `scWINEXEC` logs the command line before calling `WinExec`.

Build green (unit tests + main app + server).
