### PR TITLE
Serial-radio liveness indicator: freq display goes red when CAT goes silent

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -173,6 +173,7 @@ type
       FreqWindowHandle:    HWND;
       RadioNameWndHandle:  HWND;
       RadioDisconnected:   Boolean;
+      tLastValidResponse:  Cardinal;   // GetTickCount of last good serial read; drives the serial liveness indicator
       RadioName:        Str20;
       StartupCommand  : Str50;
       StartupCommandSent: Boolean;  // One-shot guard: set True after pNetworkRadio sends StartupCommand on first connect (Issue #436)

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -56,6 +56,9 @@ type
 
 function ReadFromSerialPort(BytesToRead: Cardinal; rig: RadioPtr): boolean;
 function ReadFromCOMPort(b: Cardinal; rig: RadioPtr): boolean;
+function ReadFromCOMPortRaw(b: Cardinal; rig: RadioPtr): boolean;
+procedure SetSerialRadioAlertState(rig: RadioPtr; alertOn: boolean);
+procedure MarkSerialRead(rig: RadioPtr; success: boolean);
 procedure pNetworkRadio(rig: RadioPtr);
 procedure pKenwood2(rig: RadioPtr);
 procedure pKenwoodNew(rig: RadioPtr);
@@ -218,6 +221,10 @@ begin
                 logger.warn('Radio Timeout 1000ms');
                 logger.warn('Buffer Bytes -' + inttostr(BytesInBuffer));
               end;
+
+            // Serial liveness indicator: bytes received => the radio answered;
+            // none within the timeout => after the grace period, mark it lost.
+            MarkSerialRead(rig, BytesInBuffer > 0);
 
             if BytesInBuffer > 0 then
                begin
@@ -3432,7 +3439,53 @@ begin
 
 end;
 
-function ReadFromCOMPort(b: Cardinal; rig: RadioPtr): boolean;
+// Serial liveness indicator: set/clear RadioDisconnected for a serial radio and
+// repaint the freq/name windows, only on a state transition.  Deliberately
+// mirrors the network-side SetRadioAlertState nested in pNetworkRadio -- kept
+// separate so this change does not touch the (battle-tested) network polling
+// path; unifying the two is a post-Field-Day cleanup.
+procedure SetSerialRadioAlertState(rig: RadioPtr; alertOn: boolean);
+begin
+   if alertOn = rig^.RadioDisconnected then Exit;   // no change -> do not repaint unnecessarily
+   rig^.RadioDisconnected := alertOn;
+   if alertOn then
+      begin
+      logger.Info('[SerialLiveness] %s -> alert color ON', [rig^.RadioName]);
+      end
+   else
+      begin
+      logger.Info('[SerialLiveness] %s -> alert color OFF', [rig^.RadioName]);
+      end;
+   if rig^.FreqWindowHandle <> 0 then
+      begin
+      Windows.InvalidateRect(rig^.FreqWindowHandle, nil, False);
+      end;
+   if rig^.RadioNameWndHandle <> 0 then
+      begin
+      Windows.InvalidateRect(rig^.RadioNameWndHandle, nil, False);
+      end;
+end;
+
+// Update the serial liveness indicator from one read attempt.  Shared by the
+// ReadFromCOMPort wrapper and pKenwood2's inline read loop so the logic lives
+// in one place.  A good read re-stamps the last-good time and clears the alert;
+// a sustained silence (no good read within the timeout) raises it.
+procedure MarkSerialRead(rig: RadioPtr; success: boolean);
+const
+   SERIAL_LIVENESS_TIMEOUT_MS = 3000;   // declare the serial radio "lost" after this much silence
+begin
+   if success then
+      begin
+      rig^.tLastValidResponse := GetTickCount;
+      SetSerialRadioAlertState(rig, False);
+      end
+   else if (GetTickCount - rig^.tLastValidResponse) > SERIAL_LIVENESS_TIMEOUT_MS then
+      begin
+      SetSerialRadioAlertState(rig, True);
+      end;
+end;
+
+function ReadFromCOMPortRaw(b: Cardinal; rig: RadioPtr): boolean;
 label
    1;
 var
@@ -3532,10 +3585,20 @@ begin
 
 end;
 
+function ReadFromCOMPort(b: Cardinal; rig: RadioPtr): boolean;
+begin
+   Result := ReadFromCOMPortRaw(b, rig);
+   // Serial liveness decorator (shared with pKenwood2's inline loop via
+   // MarkSerialRead): a good read keeps the indicator green; sustained silence
+   // turns it red.  Decorator only -- reconnect is handled elsewhere.
+   MarkSerialRead(rig, Result);
+end;
+
 procedure BeginPolling(rig: RadioPtr); stdcall;
 begin
    logger.debug('Entered BeginPolling');
    ClearRadioStatus(rig);
+   rig^.tLastValidResponse := GetTickCount;   // baseline so the liveness timer can't fire before the first poll
    Sleep(100);  // The polling thread did not start after reset?
 
    { If the radio is a network interface, we do not care what type of radio as


### PR DESCRIPTION
## Summary

The frequency display now turns the alert color (red) when a **serial** radio stops responding — matching what network radios already did. Previously the legacy serial polling never maintained `RadioDisconnected`, so a serial rig (e.g. a K3) stayed "connected"-colored even with the radio powered off; the indicator was meaningless for serial.

This is a **decorator only** — reconnect-on-return was already handled elsewhere; this just reflects the connection state in the UI.

## How it works

- A valid serial read is the heartbeat (there is no explicit heartbeat command). Each good read stamps `RadioObject.tLastValidResponse`; sustained silence (no good read for **3 s**) raises the alert; the next good read clears it.
- Hooked at **both** serial read mechanisms so it covers the whole legacy serial fleet:
  - the shared `ReadFromCOMPort` (used by the Yaesu `pFT*` family, legacy Icom, etc.) — the existing body was renamed `ReadFromCOMPortRaw` and a thin wrapper applies the liveness check to its result;
  - `pKenwood2`'s **inline** read loop (TS-xxx / K2 / K3 / KX3 / K4 / FLEX), which does not go through `ReadFromCOMPort`.
- Both paths call one shared `MarkSerialRead` helper, which drives `SetSerialRadioAlertState` (set/clear `RadioDisconnected` + repaint the freq/name windows, only on a state transition).
- `BeginPolling` baselines `tLastValidResponse` so the timer can't fire before the first poll.
- Transitions log at INFO: `[SerialLiveness] <radio> -> alert color ON/OFF`.

## Notes

- The network path's `SetRadioAlertState` (nested in `pNetworkRadio`) is intentionally left untouched; the serial helper mirrors it. Unifying the two is a small post-Field-Day cleanup (noted in a code comment).
- Observed time-to-red ≈ the 3 s window + one poll-cycle of detection granularity (`pKenwood2` polls ~1.6 s apart) + async repaint.

## Testing

Verified on hardware (NY4I) with a serial K3: powering the radio off turns the freq display red within a few seconds and logs `[SerialLiveness] K3-15 -> alert color ON`; powering back on clears it. Build green (unit tests + main app + server).
