### PR TITLE
Add Pascal begin/end lint script (tooling)

### DIFF
--- a/tr4w/build/Lint-PascalBeginEnd.ps1
+++ b/tr4w/build/Lint-PascalBeginEnd.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+   Lints Object Pascal source for if/for/while/with bodies that are missing the
+   required begin/end block (per the project's coding standard).
+
+.DESCRIPTION
+   Flags the high-confidence, unambiguous case: a line that ends with the body
+   introducer `then` or `do`, whose next code line is a single statement NOT
+   wrapped in `begin`.
+
+   Deliberately conservative to avoid false positives:
+     * Only end-of-line `then`/`do` are checked -- single-line forms like
+       `if X then Exit;` and `else if Y then DoY` are not flagged (this also
+       sidesteps the `if X then Exit;` and dispatch-chain carve-outs).
+     * `else` bodies are not checked (can't distinguish if-else from case-else
+       line-by-line without a real parser).
+     * Bodies that are `begin`, `Exit`, `Continue`, or `Break` are allowed.
+
+   Trailing // and { } / (* *) comments are stripped before the check.
+
+.PARAMETER Path
+   One or more Pascal files to lint.
+
+.OUTPUTS
+   One line per violation:  <file>:<line>: <message>
+   Exit code 0 = clean, 1 = at least one violation (handy for CI).
+#>
+[CmdletBinding()]
+param(
+   [Parameter(ValueFromRemainingArguments = $true)]
+   [string[]] $Path
+)
+
+function Test-IsSkippableBody {
+   param([string] $Body)
+   # A body that legitimately needs no begin/end on its own line.
+   if ($Body -match '^begin\b')                  { return $true }
+   if ($Body -match '^(Exit|Continue|Break)\b')  { return $true }
+   return $false
+}
+
+$violations = 0
+
+foreach ($file in $Path) {
+   if (-not (Test-Path -LiteralPath $file -PathType Leaf)) { continue }
+
+   $lines = Get-Content -LiteralPath $file
+   for ($i = 0; $i -lt $lines.Count; $i++) {
+
+      # Strip trailing comments, then trim.
+      $code = $lines[$i]
+      $code = $code -replace '//.*$', ''
+      $code = $code -replace '\{[^}]*\}\s*$', ''
+      $code = $code -replace '\(\*.*?\*\)\s*$', ''
+      $code = $code.TrimEnd()
+
+      # Rule #2: `begin` inline after then/do -- it must be on its own line.
+      if ($code -match '\b(then|do)\s+begin\b') {
+         Write-Output ("{0}:{1}: 'begin' must be on its own line, not inline after then/do (line: {2})" -f $file, ($i + 1), $code.Trim())
+         $violations++
+      }
+
+      # Rule #1: body introducer at end of line?
+      if ($code -notmatch '(^|\s)(then|do)$') { continue }
+
+      # Find the next non-blank, non-comment line (the body).
+      $j = $i + 1
+      while ($j -lt $lines.Count) {
+         $t = $lines[$j].Trim()
+         if ($t -eq '' -or $t.StartsWith('//') -or $t.StartsWith('{') -or $t.StartsWith('(*')) {
+            $j++
+            continue
+         }
+         break
+      }
+      if ($j -ge $lines.Count) { continue }
+
+      $body = $lines[$j].Trim()
+      if (-not (Test-IsSkippableBody $body)) {
+         Write-Output ("{0}:{1}: if/for/while body not wrapped in begin/end (next line: '{2}')" -f $file, ($i + 1), $body)
+         $violations++
+      }
+   }
+}
+
+if ($violations -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## Summary

Adds `tr4w/build/Lint-PascalBeginEnd.ps1`, a small dependency-free PowerShell linter for the project's `begin`/`end` coding standard. Pure tooling — **no effect on the application**.

## What it checks

- **#1** — an `if`/`for`/`while` body that isn't wrapped in a `begin`/`end` block (body introducer `then`/`do` at end of line, next code line not `begin`).
- **#2** — `begin` placed inline after `then`/`do` instead of on its own line.

Conservative by design to avoid false positives:
- Single-line `if X then Exit;`, and the `Exit`/`Continue`/`Break` idioms, are not flagged.
- `else` bodies, dispatch chains, and `case`-`else` are not flagged.
- Trailing `//`, `{ }`, and `(* *)` comments are stripped before checking.
- Exit 0 = clean, 1 = at least one violation (CI-friendly).

Indentation alignment (`begin` 3-past-control, body level with `begin`/`end`) was prototyped but **deferred** — it's correct but extremely noisy against the pervasive legacy `begin`-aligned-with-`if` style (362 hits in `LOGWIND.PAS` alone). That's better handled by a one-time formatter sweep than a per-edit check.

## How it's used

Currently driven by a local Claude Code `PostToolUse` hook that runs it on edited Pascal files, **scoped to the lines changed vs `HEAD`** (so pre-existing legacy violations are never reported — only newly introduced ones). The hook wrapper and config are machine-local; this committed script is the reusable core and could later back a GitHub CI check (same script, run over a PR's diff).

## Testing

Validated against good/bad fixtures and real units: catches both rule classes, no false positives on the documented carve-outs, and correctly stays silent on the 174 legacy #1-style and 162 legacy #2-style occurrences when diff-scoped.
