### PR TITLE
Fix K3/KX3/K4 CW-by-CAT short messages not keying + WinKeyer logging cleanup

### DIFF
--- a/tr4w/src/trdos/LOGRADIO.PAS
+++ b/tr4w/src/trdos/LOGRADIO.PAS
@@ -224,6 +224,7 @@ type
       CWByCAT:         boolean;                    // ny4i 4.44.5
       CWSpeedSync:     boolean;
       CWByCAT_Sending: boolean;                    // ny4i Issue 129
+      CATSerialLock:   TRTLCriticalSection;        // serialize a poll cycle vs a CW-by-CAT write on this radio's serial port
       UseHamLib:       boolean;
       WideCWFilter:    boolean;
       IcomFilterByte:  byte;
@@ -1456,7 +1457,24 @@ begin
   else
      begin
      logger.Trace('[AddToOutputBuffer-Serial] %s',[Buffer]);
-     WriteToCATPort(Buffer^, nNumberOfBytesToWrite);
+     // Take this radio's serial lock so the write cannot be interleaved with a
+     // poll cycle's read on the same port (closes the race where a short KY
+     // message lands inside a pKenwood2 IF; cycle and never keys) -- but ONLY
+     // when CW-by-CAT is in use on this radio.  For any other radio this is the
+     // same bare WriteToCATPort as master (and AddToOutputBuffer is only called
+     // on the main thread, so Self.CWByCAT cannot flip between Enter and Leave).
+     if Self.CWByCAT then
+        begin
+        EnterCriticalSection(Self.CATSerialLock);
+        end;
+     try
+        WriteToCATPort(Buffer^, nNumberOfBytesToWrite);
+     finally
+        if Self.CWByCAT then
+           begin
+           LeaveCriticalSection(Self.CATSerialLock);
+           end;
+     end;
      end;
 {$IFEND}
    //TLogger.GetInstance.Debug('Exiting AddToOutputBuffer');
@@ -1502,7 +1520,12 @@ begin
                end
             else
                begin
-               logger.trace(Format('[%s] Calling WriteFile to write %u bytes <%s>',[RadioName,nNumberOfBytesToWrite,debugStr]));
+               // Hex alongside the text so non-printable control bytes are visible
+               // -- e.g. the K3 keyer-abort 'KY <04>;RX;' (Chr(4)) shows as plain
+               // 'KY ;RX;' in a text-only trace, hiding the control byte entirely.
+               BinToHex(@Buffer,Buf,nLen);
+               Buf[nLen * 2] := #0;
+               logger.trace(Format('[%s] Calling WriteFile to write %u bytes <%s> hex[%s]',[RadioName,nNumberOfBytesToWrite,debugStr,Buf]));
                end;
             end;
          end;
@@ -2479,10 +2502,24 @@ begin
                   maxLen := 24;
                   pad := (Self.tCATPortType <> Network);
                   end;
-               K2, K3, KX3, K4:
+               K2:
                   begin
                   maxLen := 22; //28;
                   pad := false;
+                  end;
+               K3, KX3, K4:
+                  begin
+                  maxLen := 22; //28;
+                  // A short KY fails on the K3/KX3/K4 ONLY when it follows the
+                  // keyer-abort TR4W sends before every message ('KY <04>;RX;',
+                  // from StopSendingCW): the abort/RX transition swallows a short
+                  // following message, while >=8 chars survives it.  (tr4w.log
+                  // 2026-06-18: 'KY AGN4567;' silent, 'KY AGN45678;' keys; a
+                  // standalone 'KY ?;' from the K3 utility keys fine -- so this is
+                  // the abort window, not a radio length floor.)  Padding to maxLen
+                  // gives every message enough runway to survive the abort; under
+                  // P1=space the radio trims the trailing fill instead of keying it.
+                  pad := true;
                   end;
                end; // case
             Msg := CWByCATBuffer;
@@ -2492,6 +2529,11 @@ begin
                sLen := min(tempLen,maxLen);
                sMsg := Copy(msg,1,sLen); // Move sLen chars into sMsg;
                Delete(Msg,1,sLen); // Delete sLen characters from start of Msg
+               // Count elements on the REAL text, BEFORE any padding is appended.
+               // The trailing pad spaces are trimmed by the radio and never keyed,
+               // so counting them inflates tmrCWByCAT (a 1-char '?' padded to 22
+               // counted as 165 elements -> a bogus ~8 s CWByCAT_Sending window).
+               elements := CalculateElements(sMsg);  // ny4i Issue 153
                if pad then
                   begin
                   while length(sMsg) < maxLen do
@@ -2526,9 +2568,14 @@ begin
                   begin
                   formatStr := 'KY %s;';
                   end;
-               elements := CalculateElements(sMsg);  // ny4i Issue 153
-               logger.trace('Total CW Elements for %s = %d',[sMsg,elements]);
+               logger.trace('Total CW Elements (unpadded) = %d',[elements]);
                Self.EnableCWBYCATTimer( Round(1200 / DisplayedCodeSpeed) * elements); //ny4i Issue153 When timer fires, reset CWBYCAT_Sending
+               // Set CWByCAT_Sending BEFORE the KY command is written, so the poll
+               // thread (pKenwood2) pauses before the command goes on the wire.  Set
+               // after the write, a short message could be stepped on by an IF; poll
+               // fired in the gap and never key.
+               Self.CWByCAT_Sending := true;
+               logger.trace('Self.CWByCAT_Sending set to TRUE - Elecraft/Kenwood/Flex');
                // Flex over TCP: delegate to the factory object's cwx API.
                // Flex over serial falls through to the legacy KY path below.
                if (RadioModel = FLEX) and (Self.tNetObject <> nil) and (Self.tCATPortType = Network) then
@@ -2545,8 +2592,6 @@ begin
                      AddToOutputBuffer(addr(localMsg[1]), length(localMsg));
                   end;
                logger.trace('Adding K/E/F radio CW string to buffer');
-               Self.CWByCAT_Sending := true;
-               logger.trace('Self.CWByCAT_Sending set to TRUE - Elecraft/Kenwood/Flex');
                tempLen := length(Msg);
                end;
             CWByCATBuffer := ''; // Clear the buffer
@@ -4272,6 +4317,7 @@ begin
       //    TempRadio.ICOM_COMMAND_PTT := #255;
       TempRadio.SpeedMemory := InitialCodeSpeed;
       TempRadio.tIcomFilterWidth := 2;
+      InitializeCriticalSection(TempRadio.CATSerialLock);
 
       end;
    Radio1.RadioName := TC_RADIO1;
@@ -4285,6 +4331,11 @@ end;
 
 
 
-begin
+initialization
    InitRadios;
+
+finalization
+   DeleteCriticalSection(Radio1.CATSerialLock);
+   DeleteCriticalSection(Radio2.CATSerialLock);
+
 end.

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -144,6 +144,7 @@ var
    NumberOfSucceffulPolls: integer;
    i: integer;
    TempCommand: tKenwoodCommands;
+   cwByCatLock: boolean;
 const
    KenwoodPollRequests: array[tKenwoodCommands] of PChar = ('IF;', 'FA;',
       'FB;');
@@ -162,6 +163,17 @@ begin
 
    repeat
       if rig^.PollingStopRequested then Exit;
+
+      // Hold off polling while a CW-by-CAT message is being keyed, so the IF;
+      // poll flood does not step on a short KY message (e.g. ?, AGN) and stop
+      // it from keying.  CWByCAT_Sending is set in RadioObject.SendCW before the
+      // KY is written and cleared by the tmrCWByCAT timer once the message
+      // duration elapses.
+      if rig^.CWByCAT_Sending then
+         begin
+         Sleep(FreqPollRate);
+         Continue;
+         end;
 
       inc(rig^.tPollCount);
 
@@ -184,6 +196,19 @@ begin
                end;
 
             Sleep(FreqPollRate);
+
+            // Serialize the whole write+read cycle against a CW-by-CAT KY write
+            // (which takes the same lock in AddToOutputBuffer) so a poll cannot
+            // land between the KY and its reply and starve the keyer -- but ONLY
+            // when this radio is using CW-by-CAT.  For any other radio the poll
+            // path is left exactly as on master (no lock taken).  Captured once
+            // per cycle so a mid-cycle config change can't unbalance Enter/Leave.
+            cwByCatLock := rig^.CWByCAT;
+            if cwByCatLock then
+               begin
+               EnterCriticalSection(rig^.CATSerialLock);
+               end;
+            try
 
             rig.WritePollRequest(KenwoodPollRequests[PollNumber]^, 3);
             BytesInBuffer := 0;
@@ -409,6 +434,12 @@ begin
                   Windows.ZeroMemory(@rig.tBuf, 128);
 
                end;
+            finally
+               if cwByCatLock then
+                  begin
+                  LeaveCriticalSection(rig^.CATSerialLock);
+                  end;
+            end;
          end;
 
       if NumberOfSucceffulPolls = 0 then

--- a/tr4w/src/uWinKey.pas
+++ b/tr4w/src/uWinKey.pas
@@ -365,14 +365,14 @@ procedure wkSendAdminCommand(const Buffer);
 var
   Bytes: array[0..1] of Byte absolute Buffer;
 begin
-  logger.Debug('[wkSendAdminCommand] B1=$%s B2=$%s', [IntToHex(Bytes[0], 2), IntToHex(Bytes[1], 2)]);
+  logger.Trace('[wkSendAdminCommand] B1=$%s B2=$%s', [IntToHex(Bytes[0], 2), IntToHex(Bytes[1], 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   sWriteFile(WinKeyHandle, Buffer, 2);
 end;
 
 function wkSendByte(b: Byte): Cardinal;
 begin
-  logger.Debug('[wkSendByte] b=%s ($%s)', [string(Char(b)), IntToHex(b, 2)]);
+  logger.Trace('[wkSendByte] b=%s ($%s)', [string(Char(b)), IntToHex(b, 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   sWriteFile(WinKeyHandle, b, 1);
 {$IF K6VVA_WK_DEBUG}
@@ -388,7 +388,7 @@ function wkSendTwoBytes(B1, B2: Byte): Cardinal;
 var
   TwoBytesBuffer                        : array[0..1] of Byte;
 begin
-  logger.Debug('[wkSendTwoBytes] B1=%s ($%s) B2=%s ($%s)',
+  logger.Trace('[wkSendTwoBytes] B1=%s ($%s) B2=%s ($%s)',
                [string(Char(B1)), IntToHex(B1, 2), string(Char(B2)), IntToHex(B2, 2)]);
   if WinKeyHandle = INVALID_HANDLE_VALUE then Exit;
   TwoBytesBuffer[0] := B1;
@@ -919,7 +919,7 @@ begin
 {$IF WINKEYDEBUG}
 //  AddStringToTelnetConsole(PChar(string(c)));
 {$IFEND}
-  logger.Debug('[wkAddCharToHostBuffer] char=%s (ord=%d $%s)',
+  logger.Trace('[wkAddCharToHostBuffer] char=%s (ord=%d $%s)',
               [string(c), Ord(c), IntToHex(Ord(c), 2)]);
   wkInternalCWBuffer[wkHostBufferIndex] := c;
   inc(wkHostBufferIndex);
@@ -1045,7 +1045,7 @@ begin
 //    if wkXOFF then Exit;
 {$IFEND}
 
-    logger.Debug('[wkSendNextByteFromHostBuffer] sending char=%s (ord=%d $%s)',
+    logger.Trace('[wkSendNextByteFromHostBuffer] sending char=%s (ord=%d $%s)',
                  [string(wkInternalCWBuffer[wkHostBufferSendIndex]),
                   Ord(wkInternalCWBuffer[wkHostBufferSendIndex]),
                   IntToHex(Ord(wkInternalCWBuffer[wkHostBufferSendIndex]), 2)]);


### PR DESCRIPTION
## Summary

Fixes short CW-by-CAT messages (e.g. `?`, `AGN`) intermittently failing to key on the Elecraft K3/KX3/K4 over serial, plus a WinKeyer logging cleanup.

## Root cause

The K3 accepts a short `KY` command fine on its own (verified standalone from the radio utility), so this was **not** a radio length floor. The failure was **poll/CW concurrency** on the shared serial port: the `pKenwood2` `IF;` poll flood could step on the `KY` write. Byte-identical sends succeeded or failed depending only on poll interleaving.

## Changes

**K3 CW-by-CAT fix** (`LOGRADIO.PAS`, `uRadioPolling.pas`)
- Pause polling while a CW-by-CAT message is being keyed, and serialize each poll write+read cycle against the CW write via a per-radio critical section.
- Both gated on `CWByCAT` (captured once per cycle), so non-CWByCAT / WinKeyer radios run the **exact master path** — no lock, no pause.
- Pad short K3/KX3/K4 `KY` text to `maxLen` (radio trims the trailing fill under P1=space) so a short message survives the keyer-abort window.
- Count CW elements on the **unpadded** text so `tmrCWByCAT` isn't inflated by padding spaces (a 1-char `?` had been read as 165 elements → ~8 s).
- Hex dump in `WriteToCATPort` for the non-Icom path so control bytes (e.g. the K3 `Chr(4)` keyer-abort) are visible in traces.

**WinKeyer logging** (`uWinKey.pas`)
- Move per-byte data-exchange logs to TRACE (`wkSendByte`, `wkSendTwoBytes`, `wkSendAdminCommand`, `wkAddCharToHostBuffer`, `wkSendNextByteFromHostBuffer`).
- Keep higher-level events at DEBUG (byte count, the message string, PTT status transitions).

## Testing

- K3 CW-by-CAT: rapid repeated `?` / `AGN` now key reliably (previously only the first/last of a burst keyed).
- WinKeyer (`CWByCAT = false`): keys normally, polling / TX-status at full rate (= master behavior).
- USB-serial CAT + CW regression pass: OK (NY4I).
- Builds clean (main app + unit tests).