### PR TITLE
Network Icom liveness: freq display goes red / UDP IsConnected=false when radio powered off (#1062)

### DIFF
--- a/tr4w/src/uIcomNetworkTransport.pas
+++ b/tr4w/src/uIcomNetworkTransport.pas
@@ -143,6 +143,7 @@ type
     // Internal - state management
     procedure SetState(NewState: TIcomConnectionState);
     function GetIsConnected: Boolean;
+    function GetCivDataFresh: Boolean;
 
     // Internal - timer callbacks
     procedure StopTimers;
@@ -190,6 +191,10 @@ type
     // Properties
     property State: TIcomConnectionState read FState;
     property IsConnected: Boolean read GetIsConnected;
+    // True while inbound CI-V data has been seen recently (the radio is actually
+    // answering).  Goes False when the radio stops responding -- the liveness
+    // signal the connectionless UDP transport otherwise lacks.  Issue #1062.
+    property CivDataFresh: Boolean read GetCivDataFresh;
     property RadioName: string read FRadioName write FRadioName;
     property CivAddress: Byte read FCivAddress;
     property OnCivData: TProcessMsgRef read FOnCivData write FOnCivData;
@@ -1567,6 +1572,18 @@ end;
 function TIcomNetworkTransport.GetIsConnected: Boolean;
 begin
   Result := (FState = icsConnected) and FCivStreamOpen;
+end;
+
+// CI-V data is the heartbeat for "the radio is actually answering".  FLastCivData
+// is stamped only by real CI-V data frames (HandleDataPacket), not by pings or
+// keepalives, so it goes stale the moment the radio stops responding (e.g. powered
+// off) even though the connectionless UDP session lingers in icsConnected.  Read
+// from the polling thread; FLastCivData is a LongWord written by the RX thread --
+// an aligned 32-bit read/write is atomic on x86, so no lock is needed.  Unsigned
+// subtraction handles GetTickCount wraparound.  Issue #1062.
+function TIcomNetworkTransport.GetCivDataFresh: Boolean;
+begin
+  Result := (GetTickCount - FLastCivData) < ICOM_CIV_OPERATIONAL_TIMEOUT_MS;
 end;
 
 // ============================================================================

--- a/tr4w/src/uIcomNetworkTypes.pas
+++ b/tr4w/src/uIcomNetworkTypes.pas
@@ -54,6 +54,7 @@ const
   ICOM_CIV_WATCHDOG_INTERVAL     = 500;
   ICOM_CIV_TIMEOUT_THRESHOLD     = 2000;    // 2 seconds
   ICOM_PING_DEAD_TIMEOUT_MS      = 3000;    // 3 seconds without a ping -> declare link lost.  Radio sends pings every 100 ms, so 30 missed pings is unambiguous; a transient sub-3-second network glitch won't trigger a false reconnect cycle.  Was 15000 -- felt sluggish to operators turning the radio off (Issue: IC-7760 disconnect detection delay).
+  ICOM_CIV_OPERATIONAL_TIMEOUT_MS = 3000;   // No inbound CI-V data for this long => the radio is no longer answering (powered off / link lost), so report not-operational.  The polling thread queries the radio (PollRadioState) every ~500 ms and a powered radio answers each with CI-V data, so 3 s = ~6 missed poll cycles: comfortably clears an idle-but-connected radio while catching a powered-off one within a few seconds.  Drives the freq-display alert color and the UDP RadioInfo IsConnected field.  Issue #1062.
 
   // "Are You There" retry config
   ICOM_AYT_MAX_RETRIES    = 10;

--- a/tr4w/src/uRadioIcomBase.pas
+++ b/tr4w/src/uRadioIcomBase.pas
@@ -570,8 +570,16 @@ end;
 function TIcomRadio.GetIsOperational: boolean;
 begin
   if IsNetworkConnection then
+    // Operational requires BOTH a completed handshake (state = icsConnected)
+    // AND fresh inbound CI-V data.  Icom's UDP transport is connectionless and
+    // has no socket-close signal, so a powered-off radio leaves the session in
+    // icsConnected indefinitely (unlike the K4's TCP socket, which simply
+    // breaks).  The CI-V-freshness gate is what surfaces "radio lost" -- it
+    // drives the red freq display and the UDP RadioInfo IsConnected=False via
+    // the polling thread's SetRadioAlertState.  Issue #1062.
     Result := (FNetworkTransport <> nil) and
-              (FNetworkTransport.State = icsConnected)
+              (FNetworkTransport.State = icsConnected) and
+              FNetworkTransport.CivDataFresh
   else
     Result := inherited GetIsOperational;
 end;


### PR DESCRIPTION
Fixes #1062.

## Summary

A network-connected Icom (reproduced on the **IC-7760**, CI-V over IP) did not reflect a powered-off radio:

- the frequency display stayed its normal color instead of turning the alert color (red);
- the UDP `RadioInfo` broadcast kept reporting `<IsConnected>true</IsConnected>`.

A **network K4** behaves correctly in the same scenario. The difference is the transport: the K4 is **TCP**, so power-off breaks the socket and `socket.Connected` flips false directly. Icom's UDP transport is **connectionless** — there is no socket-close signal — so a powered-off radio leaves the session in `icsConnected` indefinitely.

## Root cause (confirmed from a controlled repro log)

`TIcomRadio.GetIsOperational` (network path) keyed **solely** on `state = icsConnected`, so it never went False. The polling thread therefore never set `RadioDisconnected` → no red, and the UDP packet's `<IsConnected>` (sourced from the same `RadioDisconnected` flag) stayed `true`.

Inbound CI-V data *does* stop the instant the radio powers off (last `$00 freq push` then ~40 s of silence in the capture), and `FLastCivData` is stamped only by real CI-V frames — so it genuinely went stale. But the CI-V watchdog only re-sends `CivOpen` (it never declares the radio dead), and in the capture it did not fire at all over 40 s.

## Fix

Gate operational state on **CI-V data freshness**, evaluated on the **reliable polling thread** rather than the transport timers:

- **`uIcomNetworkTypes.pas`** — `ICOM_CIV_OPERATIONAL_TIMEOUT_MS = 3000` (~6 missed poll cycles at the ~500 ms `PollRadioState` cadence).
- **`uIcomNetworkTransport.pas`** — new read-only `CivDataFresh` property; True only if inbound CI-V data was seen within the threshold.
- **`uRadioIcomBase.pas`** — `GetIsOperational` (network path) now requires **both** `state = icsConnected` **and** `CivDataFresh`.

A connected-but-idle radio answers every `PollRadioState` query with CI-V data, so it stays fresh (no false alarms); a powered-off radio goes stale within a few seconds → red freq display + UDP `IsConnected=false`, with automatic recovery via the existing stuck-handshake recycle when the radio returns.

This mirrors the serial-radio liveness approach (PR #1055) and the existing `FLastValidResponse` timeout in `TNetRadioBase`, applied consistently to network Icom. The deeper watchdog / timer-pump behavior is noted in #1062 as a separate follow-up; this fix deliberately does not depend on it.

## Testing

Full build green (all languages + unit tests + server). Verified on **IC-7760 hardware**: powering the radio off turns the freq display red within a few seconds and the UDP RadioInfo reports `IsConnected=false`; powering back on reconnects and clears the alert.