### PR TITLE
External logger: off-thread send queue + atomic QSO-edit replace for DXKeeper (#957)

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/dxkeeper_edit_repro.py
+++ b/tools/dxkeeper_edit_repro.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+DXKeeper "edit a QSO" harness  (TR4W Issue #957)
+================================================
+
+Standalone driver for DXKeeper's TCP/IP Network Service. No TR4W required --
+this speaks DXKeeper's protocol directly so the edit-a-QSO behavior can be
+reproduced and verified independently of TR4W.
+
+Sequence:
+
+  STEP 1  Log a contact for W7SPA           (externallog, MODE = CW)
+  STEP 2  Wait (default 10 s)               (operator reviews the QSO)
+  STEP 3  Edit it: deleteqso, then re-log    <-- TR4W's edit mechanism deletes
+          the contact with ONE field             the old record and re-logs the
+          changed (MODE CW -> FT8)                edited one
+
+Why connection handling matters (Issue #957)
+--------------------------------------------
+Tracing showed DXKeeper reads exactly ONE command per TCP connection, processes
+it, and then CLOSES the connection -- discarding anything else already in the
+read buffer. So if a client sends `deleteqso` immediately followed by
+`externallog` on the same connection, the two coalesce into one TCP segment;
+DXKeeper runs the delete and silently drops the trailing re-log.
+
+DEFAULT (works): each command is sent on its OWN fresh connection, waiting for
+DXKeeper to close after each (which confirms it was processed). The delete and
+the re-log therefore never share a connection, so both take effect.
+
+--single-connection (reproduces the bug): send the delete and the re-log
+back-to-back on one connection -- DXKeeper logs the delete and drops the re-log.
+
+Message format matches TR4W (uExternalLogger.pas), per the DXKeeper TCP/IP
+Messages v5 spec:
+  externallog : <command:11>externallog<parameters:N><ExternalLogADIF:M>...<EOR><options>
+  deleteqso   : <command:9>deleteqso<parameters:N><CALL..><QSO_DATE..><TIME_ON..><EOR>
+deleteqso matches the logged QSO by CALL + QSO_DATE + TIME_ON, so all three
+messages share one fixed date/time stamped at start.
+
+DXKeeper listens on the 2nd port of its block: default base 52000 -> 52001.
+(Change the base in DXKeeper's Configuration > Defaults > Network Service.)
+
+Usage:
+  python dxkeeper_edit_repro.py                    # default: edit succeeds (one connection per command)
+  python dxkeeper_edit_repro.py --single-connection  # reproduce the bug (re-log dropped)
+  python dxkeeper_edit_repro.py --host 192.168.1.50 --port 52001 --station AA6YQ
+
+Python 3, standard library only.
+"""
+
+import argparse
+import socket
+import threading
+import time
+from datetime import datetime, timezone
+
+# TR4W sends each message via Indy's WriteLn, which appends a line break. The
+# protocol is self-delimiting (every field carries its own length), so this is
+# cosmetic -- included only to match TR4W's bytes on the wire.
+TERMINATOR = "\r\n"
+
+# Option flags TR4W currently sends with externallog. Enrichment + membership
+# lookups ON; QSL-server uploads OFF (so there is time to edit before upload).
+OPTIONS = (
+    "<DeduceMissing:1>Y<QueryCallbook:1>Y<CheckOverrides:1>Y"
+    "<UpdateeQSL:1>Y<UpdateLoTW:1>Y"
+    "<UploadeQSL:1>N<UploadLoTW:1>N<UploadClubLog:1>N<UploadQRZ:1>N"
+)
+
+
+def ts():
+    return datetime.now().strftime("%H:%M:%S.%f")[:-3]
+
+
+def log(msg):
+    print("[%s] %s" % (ts(), msg), flush=True)
+
+
+def adif(field, value):
+    """One ADIF field: <FIELD:len>value (length is the character count of value)."""
+    return "<%s:%d>%s" % (field, len(value), value)
+
+
+def build_core_adif(call, rst_s, rst_r, freq, band, mode, qso_date, time_on, station):
+    return (
+        adif("CALL", call)
+        + adif("RST_SENT", rst_s)
+        + adif("RST_RCVD", rst_r)
+        + adif("FREQ", freq)
+        + adif("BAND", band)
+        + adif("MODE", mode)
+        + adif("QSO_DATE", qso_date)
+        + adif("TIME_ON", time_on)
+        + adif("STATION_CALLSIGN", station)
+        + "<EOR>"
+    )
+
+
+def build_externallog(core_adif, options):
+    # <parameters:N> = length of everything from the ExternalLogADIF field onward
+    # (the wrapped ADIF record + the option fields), per the v5 spec.
+    ext_field = adif("ExternalLogADIF", core_adif)
+    params = ext_field + options
+    return "<command:11>externallog<parameters:%d>%s" % (len(params), params)
+
+
+def build_deleteqso(call, qso_date, time_on):
+    core = (
+        adif("CALL", call)
+        + adif("QSO_DATE", qso_date)
+        + adif("TIME_ON", time_on)
+        + "<EOR>"
+    )
+    return "<command:9>deleteqso<parameters:%d>%s" % (len(core), core)
+
+
+class DXKeeperClient:
+    """Talks to DXKeeper's Network Service.
+
+    A single background reader prints whatever DXKeeper sends back and notices
+    when DXKeeper closes the connection (recv returns 0). It tolerates the
+    socket being replaced on reconnect.
+    """
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.sock = None
+        self.peer_closed = False
+        self.stop = threading.Event()
+        self.reader_thread = None
+
+    def connect(self, attempts=5, delay=1.0):
+        """Open a fresh connection, retrying if DXKeeper is not yet ready."""
+        self._close_socket()
+        last = None
+        for i in range(1, attempts + 1):
+            try:
+                s = socket.create_connection((self.host, self.port), timeout=10)
+                s.settimeout(0.5)
+                self.peer_closed = False
+                self.sock = s
+                log("Connected to %s:%d" % (self.host, self.port))
+                if self.reader_thread is None:
+                    self.reader_thread = threading.Thread(target=self._reader, daemon=True)
+                    self.reader_thread.start()
+                return
+            except OSError as e:
+                last = e
+                log("  connect failed (attempt %d/%d): %s -- retrying in %.1f s"
+                    % (i, attempts, e, delay))
+                time.sleep(delay)
+        raise SystemExit("Could not connect to DXKeeper at %s:%d (%s). "
+                         "Is DXKeeper running with the Network Service enabled?"
+                         % (self.host, self.port, last))
+
+    def _close_socket(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+            self.sock = None
+
+    def _reader(self):
+        while not self.stop.is_set():
+            s = self.sock
+            if s is None:
+                time.sleep(0.05)
+                continue
+            try:
+                data = s.recv(4096)
+            except socket.timeout:
+                continue
+            except OSError:
+                time.sleep(0.05)
+                continue
+            if not data:
+                # recv of 0 bytes => DXKeeper performed an orderly close.
+                if s is self.sock and not self.peer_closed:
+                    log("<< DXKeeper closed the connection")
+                    self.peer_closed = True
+                time.sleep(0.05)
+                continue
+            log("<< RESPONSE: " + data.decode("latin-1", "replace").strip())
+
+    def _raw_send(self, label, msg):
+        log(">> %s" % label)
+        log("   %s" % msg)
+        if self.sock is None:
+            log("   !! no socket; cannot send")
+            return
+        try:
+            self.sock.sendall((msg + TERMINATOR).encode("latin-1"))
+        except OSError as e:
+            log("   !! send failed: %s" % e)
+
+    def wait_for_close(self, timeout=5.0):
+        """Block until DXKeeper closes the connection (it does so after processing
+        one command), or until timeout. Returns True if it closed."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.peer_closed:
+                return True
+            time.sleep(0.02)
+        return False
+
+    def send_command(self, label, msg, new_connection=True, wait_close=True, timeout=5.0):
+        """Send one command. By default on its own fresh connection -- which is
+        how DXKeeper expects it (one command per connection)."""
+        if new_connection or self.sock is None or self.peer_closed:
+            self.connect()
+        self._raw_send(label, msg)
+        if wait_close:
+            if self.wait_for_close(timeout):
+                log("   (DXKeeper closed after this command -- processed)")
+            else:
+                log("   (no close within %.1f s; continuing)" % timeout)
+
+    def close(self):
+        self.stop.set()
+        self._close_socket()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Drive DXKeeper's edit-a-QSO sequence (TR4W Issue #957).")
+    ap.add_argument("--host", default="127.0.0.1",
+                    help="DXKeeper host (default 127.0.0.1)")
+    ap.add_argument("--port", type=int, default=52001,
+                    help="DXKeeper Network Service port (default 52001 = base 52000 + 1)")
+    ap.add_argument("--call", default="W7SPA",
+                    help="Worked station callsign (default W7SPA)")
+    ap.add_argument("--station", default="NY4I",
+                    help="STATION_CALLSIGN -- the logging station (default NY4I; set to your call)")
+    ap.add_argument("--freq", default="14.074",
+                    help="Frequency in MHz, unchanged across the edit (default 14.074)")
+    ap.add_argument("--band", default="20M",
+                    help="Band, unchanged across the edit (default 20M)")
+    ap.add_argument("--wait", type=float, default=10.0,
+                    help="Seconds to wait after logging before the edit (default 10)")
+    ap.add_argument("--gap", type=float, default=0.0,
+                    help="Extra seconds between the deleteqso and the re-log "
+                         "(default 0; not needed in the default one-connection-per-command mode)")
+    ap.add_argument("--single-connection", action="store_true",
+                    help="Send the delete and re-log back-to-back on ONE connection "
+                         "to reproduce the bug (DXKeeper drops the re-log).")
+    args = ap.parse_args()
+
+    # Fixed QSO identity: deleteqso matches the create by CALL + QSO_DATE + TIME_ON,
+    # so the create, delete, and re-log must all carry the same date/time.
+    now = datetime.now(timezone.utc)
+    qso_date = now.strftime("%Y%m%d")
+    time_on = now.strftime("%H%M%S")
+
+    core_cw = build_core_adif(args.call, "599", "599", args.freq, args.band,
+                              "CW", qso_date, time_on, args.station)
+    core_ft8 = build_core_adif(args.call, "599", "599", args.freq, args.band,
+                               "FT8", qso_date, time_on, args.station)
+
+    create = build_externallog(core_cw, OPTIONS)
+    delete = build_deleteqso(args.call, qso_date, time_on)
+    recreate = build_externallog(core_ft8, OPTIONS)
+
+    mode = "SINGLE CONNECTION (reproduce bug)" if args.single_connection \
+        else "one connection per command (edit should succeed)"
+    log("Mode: %s" % mode)
+
+    client = DXKeeperClient(args.host, args.port)
+    try:
+        log("STEP 1: log QSO  call=%s  MODE=CW  QSO_DATE=%s  TIME_ON=%s"
+            % (args.call, qso_date, time_on))
+        client.send_command("externallog (create, MODE=CW)", create)
+
+        log("STEP 2: waiting %.0f s (operator reviews the QSO)..." % args.wait)
+        time.sleep(args.wait)
+
+        log("STEP 3: edit -> deleteqso, then re-log with MODE CW -> FT8")
+        if args.single_connection:
+            # Both on one connection, back-to-back -> reproduces the drop.
+            client.send_command("deleteqso", delete, new_connection=True, wait_close=False)
+            if args.gap > 0:
+                time.sleep(args.gap)
+            client.send_command("externallog (re-log, MODE=FT8)", recreate,
+                                new_connection=False, wait_close=False)
+        else:
+            # Each on its own fresh connection -> both take effect.
+            client.send_command("deleteqso", delete)
+            if args.gap > 0:
+                time.sleep(args.gap)
+            client.send_command("externallog (re-log, MODE=FT8)", recreate)
+
+        log("Done sending. Listening 3 s for any final responses...")
+        time.sleep(3)
+    finally:
+        client.close()
+        log("Closed. Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tr4w/src/uEditQSO.pas
+++ b/tr4w/src/uEditQSO.pas
@@ -736,8 +736,12 @@ begin
      LogEditedContactToUDP(EditableQSORxData);
      if Assigned(externalLogger) then
         begin
-        externalLogger.DeleteQSO(EditableQSORXData);
-        externalLogger.LogQSO(EditableQSORXData);
+        // Issue #957 -- an edit is a delete of the original record followed by a
+        // re-log of the edited one.  ReplaceQSO queues this as ONE atomic operation
+        // delivered off the main thread: the delete and re-log go on separate
+        // connections (DXKeeper reads one command per connection), and the re-log is
+        // sent only if the delete succeeds.  Non-blocking -- no UI freeze.
+        externalLogger.ReplaceQSO(EditableQSORXData);
         end;
      // Issue #783 -- HamScore RTC: send <contactreplace> next cycle.
      HamScoreOnEdit(EditableQSORxData);

--- a/tr4w/src/uExternalLogger.pas
+++ b/tr4w/src/uExternalLogger.pas
@@ -1,7 +1,8 @@
 unit uExternalLogger;
 
 interface
-uses uExternalLoggerBase, StrUtils, SysUtils, Math, TF, VC, LOGSUBS2, LogWind, LogDupe, Tree, uCFG, PostUnit;
+uses uExternalLoggerBase, StrUtils, SysUtils, Math, TF, VC, LOGSUBS2, LogWind, LogDupe, Tree, uCFG, PostUnit,
+     IdTCPClient;
 
 
 Type TExternalLogger = class(TExternalLoggerBase)
@@ -12,9 +13,10 @@ Type TExternalLogger = class(TExternalLoggerBase)
       function AddADIFField(sFieldName: string; sValue: string): string; overload;
       function AddADIFField(sFieldName: string; nValue: integer): string; overload;
 
-      // DXKeeper
-      function LogQSOToDXKeeper(ce: ContestExchange): integer;
-      function DeleteQSOToDXKeeper(ce: ContestExchange): integer; // There functions hsould be changed to an interface so we just call one based onthe interface (by log type). ny4i
+      // DXKeeper -- these now BUILD and return the DXKeeper message; the actual
+      // send is queued (one connect-per-command op on the sender thread). Issue #957.
+      function BuildDXKeeperLogMessage(ce: ContestExchange): string;
+      function BuildDXKeeperDeleteMessage(ce: ContestExchange): string; // These functions should be changed to an interface so we just call one based on the interface (by log type). ny4i
       function LookupCallsignToDXKeeper(ce: ContestExchange): integer;
 
       // ACLog
@@ -28,6 +30,11 @@ Type TExternalLogger = class(TExternalLoggerBase)
       // Add a QueueQSO to copy the record then return to the caller. This allows the actual sending of the TCP message ot be done from a different thread to not slow down the program.
 
       // I could also generalize this into post QSO Processing and let the UDP happen from the thread too. Worth exploring the actual amont of time per QSO to send to UDP and TCP. If it is very fast, this complication may not be necessary.
+   protected
+      // DXKeeper transport: one connect -> send one command -> let DXKeeper close
+      // (its by-design model; confirmed with AA6YQ). Issue #957.
+      function DeliverCommand(const cmd: string): boolean; override;
+
    public
       Constructor Create(); overload;
       Constructor Create(logType: ExternalLoggerType{sLoggerType: string}); overload;
@@ -36,6 +43,7 @@ Type TExternalLogger = class(TExternalLoggerBase)
       procedure ProcessMessage(sMessage: string);
       function LogQSO(ce: ContestExchange): integer;
       function DeleteQSO(ce: ContestExchange): integer;
+      function ReplaceQSO(ce: ContestExchange): integer;   // Issue #957 -- edit = atomic delete + re-log
       function LookupCallsign(ce:ContestExchange): integer;
 
 end;
@@ -93,6 +101,80 @@ begin
 
 end;
 
+const
+   DXK_CONNECT_TIMEOUT_MS = 2000;   // DXKeeper is normally local; fail fast and retry
+   DXK_READ_TIMEOUT_MS    = 1000;   // bound the wait for a response / the close
+
+function TExternalLogger.DeliverCommand(const cmd: string): boolean;
+var
+   client: TIdTCPClient;
+   resp: string;
+begin
+   // Issue #957 -- DXKeeper reads exactly one command per connection, then closes
+   // (its by-design model, confirmed with AA6YQ).  So each command gets its own
+   // fresh connection: connect -> send -> read any response until DXKeeper closes.
+   // Runs on the sender thread, never the main thread.  The caller (DeliverWithRetry)
+   // handles bounded retry on failure.
+   Result := False;
+   client := TIdTCPClient.Create(nil);
+   try
+      client.Host := Self.loggerAddress;
+      client.Port := Self.loggerPort;
+      client.ConnectTimeout := DXK_CONNECT_TIMEOUT_MS;
+      client.ReadTimeout := DXK_READ_TIMEOUT_MS;
+      try
+         client.Connect;
+         try
+            client.IOHandler.WriteLn(cmd);
+            Result := True;   // the command is on the wire = success
+            logger.Debug('[DXKeeper.DeliverCommand] sent: %s', [cmd]);
+            // Best-effort: read any response until DXKeeper closes (bounded).
+            try
+               while client.Connected do
+                  begin
+                  resp := client.IOHandler.ReadLn(';', DXK_READ_TIMEOUT_MS);
+                  if client.IOHandler.ReadLnTimedout then
+                     begin
+                     Break;
+                     end;
+                  if resp <> '' then
+                     begin
+                     logger.Debug('[DXKeeper.DeliverCommand] response: %s', [resp]);
+                     Self.ProcessMessage(resp);
+                     end;
+                  end;
+            except
+               on Exception do
+                  begin
+                  // DXKeeper closing after the command is the normal/expected path.
+                  end;
+            end;
+         finally
+            try
+               if client.Connected then
+                  begin
+                  client.Disconnect;
+                  end;
+            except
+               on Exception do
+                  begin
+                  // ignore disconnect errors
+                  end;
+            end;
+         end;
+      except
+         on E: Exception do
+            begin
+            logger.Warn('[DXKeeper.DeliverCommand] %s:%d failed: %s - %s',
+                        [Self.loggerAddress, Self.loggerPort, E.ClassName, E.Message]);
+            // Result stays False unless WriteLn already succeeded -> caller retries.
+            end;
+      end;
+   finally
+      client.Free;
+   end;
+end;
+
 procedure TExternalLogger.SendToLogger(sCmd: string; sData: string);
 begin
    if not Self.IsConnected then
@@ -111,7 +193,11 @@ begin
          Result := -1;
          logger.Error('Within TExternalLogger.LogQSO, logType set to NoExternalLogger');
          end;
-      lt_DxKeeper: Result := Self.LogQSOToDXKeeper(ce);
+      lt_DxKeeper:
+         begin
+         Self.QueueSingleCommand(Self.BuildDXKeeperLogMessage(ce), 'Log ' + ce.Callsign);
+         Result := 0;
+         end;
       lt_ACLog: Result := Self.LogQSOToACLog(ce);
       lt_HRD: Result := Self.LogQSOToHRD(ce);
    end;
@@ -125,9 +211,42 @@ begin
          Result := -1;
          logger.Error('Within TExternalLogger.DeleteQSO, logType set to NoExternalLogger');
          end;
-      lt_DxKeeper: Result := Self.DeleteQSOToDXKeeper(ce);
+      lt_DxKeeper:
+         begin
+         Self.QueueSingleCommand(Self.BuildDXKeeperDeleteMessage(ce), 'Delete ' + ce.Callsign);
+         Result := 0;
+         end;
       //lt_ACLog: Result := Self.LogQSOToACLog(ce);
       //lt_HRD: Result := Self.LogQSOToHRD(ce);
+   end;
+end;
+
+function TExternalLogger.ReplaceQSO(ce: ContestExchange): integer;
+begin
+   // Issue #957 -- an edit is a delete of the original followed by a re-log of the
+   // edited QSO.  Queue it as ONE atomic replace so the re-log is sent only if the
+   // delete succeeds, and so the two never share a TCP connection (DXKeeper reads
+   // exactly one command per connection, then closes).
+   case Self.logType of
+      lt_NoExternalLogger:
+         begin
+         Result := -1;
+         logger.Error('Within TExternalLogger.ReplaceQSO, logType set to NoExternalLogger');
+         end;
+      lt_DxKeeper:
+         begin
+         Self.QueueReplace(Self.BuildDXKeeperDeleteMessage(ce),
+                           Self.BuildDXKeeperLogMessage(ce),
+                           'Replace ' + ce.Callsign);
+         Result := 0;
+         end;
+      else
+         begin
+         // Other loggers: best-effort delete then re-log (no atomic guarantee yet).
+         Self.DeleteQSO(ce);
+         Self.LogQSO(ce);
+         Result := 0;
+         end;
    end;
 end;
 
@@ -146,7 +265,7 @@ begin
 
 end;
 
-function TExternalLogger.LogQSOToDXKeeper(ce: ContestExchange): integer;
+function TExternalLogger.BuildDXKeeperLogMessage(ce: ContestExchange): string;
 var sCoreADIF: string;
     //n: integer;
     sMode: string;
@@ -279,23 +398,34 @@ This is all we need to send as we DO NOT want to send every contact to any of th
   nCoreADIFLength := length(sCoreADIF);
   sCoreADIF := '<ExternalLogADIF:' + IntToStr(nCoreADIFLength) + '>' + sCoreADIF;
   nCoreADIFLength := length(sCoreADIF); // Update to include the ExternalLogADIF field
+  // Issue #957 -- option flags for the externallog command.
+  // Enrichment + membership lookups are ON (Y): DeduceMissing, QueryCallbook,
+  // CheckOverrides, UpdateeQSL, UpdateLoTW.  These only fill in or annotate
+  // DXKeeper's local copy of the record, so they add useful data without the
+  // edit-window concern below.  (An earlier "command in progress" rejection that
+  // these appeared to trigger turned out to be a DXKeeper-side bug, since fixed.)
+  // QSL-server UPLOADS are OFF (N): UploadeQSL, UploadLoTW, UploadClubLog,
+  // UploadQRZ.  Uploading the instant the QSO is logged would leave no window to
+  // edit it first; the operator uploads later (or via DXKeeper's own workflow).
+  // NOTE: if DXKeeper's AutoUpload options are checked, the Upload* N values are
+  // not honored.
   sOptions :=   AddADIFField('DeduceMissing','Y')
               + AddADIFField('QueryCallbook','Y')
               + AddADIFField('CheckOverrides','Y')
+              + AddADIFField('UpdateeQSL','Y')
+              + AddADIFField('UpdateLoTW','Y')
               + AddADIFField('UploadeQSL','N')
               + AddADIFField('UploadLoTW','N')
               + AddADIFField('UploadClubLog','N')
-              + AddADIFField('UploadQRZ','N')     // Note if the AutoUpload options in DXkeeper are checked, this is not honored.
+              + AddADIFField('UploadQRZ','N')
               ;
   nOptionsLength := length(sOptions);
   sMessage := '<command:11>externallog<parameters:' + IntToStr(nCoreADIFLength + nOptionsLength) + '>' + sCoreADIF + sOptions;
-  logger.Debug('[TExternalLogger.LogQSO] Sending message to external logger: [%s]',[sMessage]);
-  Self.SendToLogger(sMessage);
-
+  Result := sMessage;
 end;
 
 //-------------------------------
-function TExternalLogger.DeleteQSOToDXKeeper(ce: ContestExchange): integer;
+function TExternalLogger.BuildDXKeeperDeleteMessage(ce: ContestExchange): string;
 var sCoreADIF: string;
     //n: integer;
 
@@ -323,9 +453,7 @@ begin
  // sCoreADIF := '<ExternalLogADIF:' + IntToStr(nCoreADIFLength) + '>' + sCoreADIF;
   nCoreADIFLength := length(sCoreADIF); // Update to include the ExternalLogADIF field
   sMessage := '<command:9>deleteqso<parameters:' + IntToStr(nCoreADIFLength {+ nOptionsLength}) + '>' + sCoreADIF;
-  logger.Debug('[TExternalLogger.DeleteQSO] Sending message to external logger: [%s]',[sMessage]);
-  Self.SendToLogger(sMessage);
-
+  Result := sMessage;
 end;
 
 function TExternalLogger.LookupCallsignToDXKeeper(ce: ContestExchange): integer;

--- a/tr4w/src/uExternalLoggerBase.pas
+++ b/tr4w/src/uExternalLoggerBase.pas
@@ -4,9 +4,34 @@ interface
 
 uses
    IdTCPClient, IdComponent, IdTCPConnection,IdThreadComponent, IdExceptionCore, SysUtils,
-   Classes, StrUtils, Log4D, VC, Tree, IdException, IdStack;
+   Classes, StrUtils, Log4D, VC, Tree, IdException, IdStack, SyncObjs, Windows;
 
 Type TProcessMsgRef = procedure (sMessage: string) of Object;
+
+   // Issue #957 -- outbound operation queue.
+   // External loggers receive commands off the main thread: the main thread only
+   // ENQUEUES an operation (a cheap locked append) and returns; a dedicated sender
+   // thread connects, sends, and retries.  DXKeeper closes the TCP connection after
+   // each command (by design, confirmed with AA6YQ), so the sender does one
+   // connect->send->close per command (see TExternalLogger.DeliverCommand).
+   //
+   // A Replace (the QSO-edit path) is ONE atomic operation: the re-log is sent only
+   // if the delete succeeded.  Order is forced -- the QSO identity is
+   // CALL+QSO_DATE+TIME_ON, unchanged by a mode edit, so a relog-first-then-delete
+   // would delete both records.  DXKeeper has no atomic replace, so a
+   // delete-succeeded / relog-failed window is unavoidable; it is logged loudly
+   // (anti-silent-loss) rather than swallowed.  A replayable persistent queue is
+   // deferred to the Delphi 12 conversion (SQLite global state).
+Type
+   TExternalLogOpKind = (eloSingle, eloReplace);
+
+   TExternalLogOp = class(TObject)
+   public
+      Kind: TExternalLogOpKind;
+      Cmd1: string;          // single command, or the delete (for eloReplace)
+      Cmd2: string;          // the re-log (for eloReplace); unused for eloSingle
+      Description: string;   // human-readable, for logging
+   end;
 
 
 Type TSimpleEventProc = procedure(const aStrParam:string) of object;
@@ -36,7 +61,28 @@ const ExternalLoggerTypeSA                     : array[ExternalLoggerType] of PC
    RECONNECT_MAX_DELAY = 30000;       // 30 seconds max delay
    RECONNECT_BACKOFF_MULTIPLIER = 2;  // Double delay each retry
 
-Type TExternalLoggerBase = class(TObject)
+const
+   // Issue #957 -- bounded outbound-send retry (we do not try very hard; a
+   // replayable persistent queue is deferred to the D12/SQLite work).
+   SEND_MAX_ATTEMPTS         = 3;       // attempts per command before giving up
+   SEND_RETRY_BASE_DELAY     = 500;     // ms; backoff delay = attempt * this
+   SHUTDOWN_DRAIN_TIMEOUT_MS = 3000;    // bounded wait to flush the queue at shutdown
+
+Type
+   TExternalLoggerBase = class;   // forward, for TSenderThread.FOwner
+
+   // Drains the outbound operation queue off the main thread.  One sender thread
+   // per logger instance; it is the sole owner of the send path.
+   TSenderThread = class(TThread)
+   private
+      FOwner: TExternalLoggerBase;
+   protected
+      procedure Execute; override;
+   public
+      constructor Create(AOwner: TExternalLoggerBase);
+   end;
+
+   TExternalLoggerBase = class(TObject)
    private
       //socket: TIdTCPClient;
       //idThreadComponent   : TIdThreadComponent;
@@ -45,6 +91,19 @@ Type TExternalLoggerBase = class(TObject)
       localLoggerID: string;
       rt: TReadingThread;
       baseProcMsg: TProcessMsgRef;
+
+      // Issue #957 -- outbound operation queue + its sender thread.
+      FOpQueue: TList;              // of TExternalLogOp (owned; freed after processing)
+      FQueueLock: TCriticalSection; // guards FOpQueue
+      FQueueEvent: TEvent;          // signalled when an op is enqueued
+      FSenderThread: TSenderThread;
+      FShuttingDown: boolean;
+
+      procedure InitOutboundQueue;
+      procedure ProcessOp(op: TExternalLogOp);
+      function DequeueOp: TExternalLogOp;
+      function DeliverWithRetry(const cmd: string): boolean;
+      function SenderTerminating: boolean;
 
       function GetLoggerPort: integer;
       procedure SetLoggerPort(Value: Integer);
@@ -64,10 +123,20 @@ Type TExternalLoggerBase = class(TObject)
       logTypeSet: boolean;
       logType: ExternalLoggerType;
 
+      // Transport strategy: deliver one command and return True on success.
+      // The base default uses the persistent socket (for future ACLog/HRD);
+      // DXKeeper overrides it with a connect-per-command transport (Issue #957).
+      function DeliverCommand(const cmd: string): boolean; virtual;
+
    public
       constructor Create(ProcRef: TProcessMsgRef); overload;
       constructor Create(address: string; port: integer;ProcRef: TProcessMsgRef); overload;
       Destructor Destroy; overload; Virtual;
+
+      // Issue #957 -- enqueue from the main thread (cheap; returns immediately).
+      procedure QueueSingleCommand(const cmd, description: string);
+      procedure QueueReplace(const deleteCmd, relogCmd, description: string);
+      procedure ShutdownDrain(timeoutMs: integer);
 
       procedure SendToLogger(s: string); overload;
       property loggerPort: integer read GetLoggerPort write SetLoggerPort;
@@ -95,13 +164,14 @@ Uses MainUnit;
 Constructor TExternalLoggerBase.Create(ProcRef: TProcessMsgRef);
 begin
    baseProcMsg := ProcRef;
-   
+
    socket := TIdTCPClient.Create();
    socket.ConnectTimeout := 10000;  // TODO Make this a property
    socket.OnDisconnected := Self.OnLoggerDisconnected;
    socket.OnConnected := Self.OnLoggerConnected;
    socket.OnStatus := Self.OnLoggerStatus;
 
+   InitOutboundQueue;
 end;
 
 {Constructor TExternalLoggerBase.Create(ProcRef: TProcessMsgRef);
@@ -119,6 +189,20 @@ end;
 
 Destructor TExternalLoggerBase.Destroy;
 begin
+   // Issue #957 -- flush and stop the outbound sender before tearing anything else
+   // down (the sender owns the send path).  ShutdownDrain logs anything undelivered.
+   ShutdownDrain(SHUTDOWN_DRAIN_TIMEOUT_MS);
+   if FOpQueue <> nil then
+      begin
+      while FOpQueue.Count > 0 do
+         begin
+         TExternalLogOp(FOpQueue[0]).Free;
+         FOpQueue.Delete(0);
+         end;
+      FreeAndNil(FOpQueue);
+      end;
+   FreeAndNil(FQueueLock);
+   FreeAndNil(FQueueEvent);
 
    if socket <> nil then
       begin
@@ -460,6 +544,282 @@ procedure TReadingThread.DoTerminate;
 begin
   logger.debug('DEBUG: TExternalLoggerBase.TReadingThread.DoTerminate');
   inherited;
+end;
+
+// ============================================================================
+// Issue #957 -- outbound operation queue + sender thread
+// ============================================================================
+
+procedure TExternalLoggerBase.InitOutboundQueue;
+begin
+   FShuttingDown := False;
+   FOpQueue := TList.Create;
+   FQueueLock := TCriticalSection.Create;
+   FQueueEvent := TEvent.Create(nil, False, False, '');   // auto-reset, initially clear
+   FSenderThread := TSenderThread.Create(Self);           // starts immediately
+end;
+
+procedure TExternalLoggerBase.QueueSingleCommand(const cmd, description: string);
+var op: TExternalLogOp;
+begin
+   if FShuttingDown then
+      begin
+      logger.Warn('[ExternalLogger] Shutting down -- dropping queued command: %s', [description]);
+      Exit;
+      end;
+   op := TExternalLogOp.Create;
+   op.Kind := eloSingle;
+   op.Cmd1 := cmd;
+   op.Description := description;
+   FQueueLock.Enter;
+   try
+      FOpQueue.Add(op);
+   finally
+      FQueueLock.Leave;
+   end;
+   FQueueEvent.SetEvent;
+   logger.Debug('[ExternalLogger] Queued: %s', [description]);
+end;
+
+procedure TExternalLoggerBase.QueueReplace(const deleteCmd, relogCmd, description: string);
+var op: TExternalLogOp;
+begin
+   if FShuttingDown then
+      begin
+      logger.Warn('[ExternalLogger] Shutting down -- dropping queued replace: %s', [description]);
+      Exit;
+      end;
+   op := TExternalLogOp.Create;
+   op.Kind := eloReplace;
+   op.Cmd1 := deleteCmd;
+   op.Cmd2 := relogCmd;
+   op.Description := description;
+   FQueueLock.Enter;
+   try
+      FOpQueue.Add(op);
+   finally
+      FQueueLock.Leave;
+   end;
+   FQueueEvent.SetEvent;
+   logger.Debug('[ExternalLogger] Queued (replace): %s', [description]);
+end;
+
+function TExternalLoggerBase.DequeueOp: TExternalLogOp;
+begin
+   FQueueLock.Enter;
+   try
+      if FOpQueue.Count > 0 then
+         begin
+         Result := TExternalLogOp(FOpQueue[0]);
+         FOpQueue.Delete(0);
+         end
+      else
+         begin
+         Result := nil;
+         end;
+   finally
+      FQueueLock.Leave;
+   end;
+end;
+
+function TExternalLoggerBase.SenderTerminating: boolean;
+begin
+   Result := (FSenderThread <> nil) and FSenderThread.Terminated;
+end;
+
+function TExternalLoggerBase.DeliverWithRetry(const cmd: string): boolean;
+var
+   attempt: integer;
+   slept, target: integer;
+begin
+   Result := False;
+   for attempt := 1 to SEND_MAX_ATTEMPTS do
+      begin
+      if SenderTerminating then
+         begin
+         Exit;
+         end;
+      if DeliverCommand(cmd) then
+         begin
+         Result := True;
+         Exit;
+         end;
+      if attempt < SEND_MAX_ATTEMPTS then
+         begin
+         logger.Warn('[ExternalLogger] Send attempt %d/%d failed; retrying', [attempt, SEND_MAX_ATTEMPTS]);
+         // Interruptible backoff so shutdown stays responsive.
+         target := attempt * SEND_RETRY_BASE_DELAY;
+         slept := 0;
+         while (slept < target) and not SenderTerminating do
+            begin
+            Sleep(50);
+            Inc(slept, 50);
+            end;
+         end;
+      end;
+end;
+
+procedure TExternalLoggerBase.ProcessOp(op: TExternalLogOp);
+begin
+   case op.Kind of
+      eloSingle:
+         begin
+         if not DeliverWithRetry(op.Cmd1) then
+            begin
+            logger.Error('[ExternalLogger] FAILED to deliver to external log after %d attempts: %s',
+                         [SEND_MAX_ATTEMPTS, op.Description]);
+            end;
+         end;
+      eloReplace:
+         begin
+         // Atomic: re-log only if the delete went through.  Delete must be first
+         // (the QSO identity is unchanged by the edit, so relog-first would let
+         // the delete remove both records).
+         if not DeliverWithRetry(op.Cmd1) then
+            begin
+            logger.Error('[ExternalLogger] Replace ABORTED -- delete failed, re-log NOT sent (%s). '
+                         + 'The external log may still hold the ORIGINAL QSO.', [op.Description]);
+            end
+         else if not DeliverWithRetry(op.Cmd2) then
+            begin
+            logger.Error('[ExternalLogger] Replace HALF-DONE -- delete succeeded but re-log FAILED (%s). '
+                         + 'The QSO is now MISSING from the external log and must be re-entered there.', [op.Description]);
+            end;
+         end;
+   end;
+end;
+
+function TExternalLoggerBase.DeliverCommand(const cmd: string): boolean;
+begin
+   // Default transport: persistent socket (for future ACLog/HRD).  DXKeeper
+   // overrides this with a connect-per-command transport (Issue #957).
+   Result := False;
+   try
+      if not socket.Connected then
+         begin
+         Self.Connect;
+         end;
+      if socket.Connected then
+         begin
+         socket.IOHandler.WriteLn(cmd);
+         Result := True;
+         end
+      else
+         begin
+         logger.Error('[DeliverCommand] not connected; cannot send (%s)', [cmd]);
+         end;
+   except
+      on E: Exception do
+         begin
+         logger.Error('[DeliverCommand] %s - %s', [E.ClassName, E.Message]);
+         end;
+   end;
+end;
+
+procedure TExternalLoggerBase.ShutdownDrain(timeoutMs: integer);
+var
+   deadline: Cardinal;
+   pending: integer;
+begin
+   if FShuttingDown then
+      begin
+      Exit;   // idempotent
+      end;
+   FShuttingDown := True;
+
+   FQueueLock.Enter;
+   try
+      pending := FOpQueue.Count;
+   finally
+      FQueueLock.Leave;
+   end;
+   if pending > 0 then
+      begin
+      logger.Info('[ExternalLogger] Shutdown: draining %d queued external-log operation(s) (up to %d ms)',
+                  [pending, timeoutMs]);
+      end;
+
+   // Let the sender finish what is queued, bounded.
+   if FQueueEvent <> nil then
+      begin
+      FQueueEvent.SetEvent;
+      end;
+   deadline := GetTickCount + Cardinal(timeoutMs);
+   while GetTickCount < deadline do
+      begin
+      FQueueLock.Enter;
+      try
+         pending := FOpQueue.Count;
+      finally
+         FQueueLock.Leave;
+      end;
+      if pending = 0 then
+         begin
+         Break;
+         end;
+      Sleep(50);
+      end;
+
+   // Stop the sender thread (its current op bails promptly via SenderTerminating).
+   if FSenderThread <> nil then
+      begin
+      FSenderThread.Terminate;
+      if FQueueEvent <> nil then
+         begin
+         FQueueEvent.SetEvent;
+         end;
+      FSenderThread.WaitFor;
+      FreeAndNil(FSenderThread);
+      end;
+
+   FQueueLock.Enter;
+   try
+      pending := FOpQueue.Count;
+   finally
+      FQueueLock.Leave;
+   end;
+   if pending > 0 then
+      begin
+      logger.Error('[ExternalLogger] Shutdown: %d external-log operation(s) were NOT delivered '
+                   + '(in-memory queue; persistent replay is a Delphi 12 item).', [pending]);
+      end;
+end;
+
+constructor TSenderThread.Create(AOwner: TExternalLoggerBase);
+begin
+   FOwner := AOwner;
+   inherited Create(False);   // start running
+end;
+
+procedure TSenderThread.Execute;
+var op: TExternalLogOp;
+begin
+   while not Terminated do
+      begin
+      // Wake on enqueue, or every 250 ms to re-check Terminated.
+      FOwner.FQueueEvent.WaitFor(250);
+      while not Terminated do
+         begin
+         op := FOwner.DequeueOp;
+         if op = nil then
+            begin
+            Break;
+            end;
+         try
+            try
+               FOwner.ProcessOp(op);
+            except
+               on E: Exception do
+                  begin
+                  logger.Error('[ExternalLogger.Sender] Exception processing %s: %s - %s',
+                               [op.Description, E.ClassName, E.Message]);
+                  end;
+            end;
+         finally
+            op.Free;
+         end;
+         end;
+      end;
 end;
 
 function BoolToString(b: boolean): string;


### PR DESCRIPTION
Closes #957.

## Problem

DXKeeper's TCP/IP Network Service reads **exactly one command per connection**, processes it, then **closes the socket — discarding anything else already in the read buffer**. This is by design (confirmed with AA6YQ).

TR4W's edit-a-QSO mechanism sent `deleteqso` and the re-log `externallog` back-to-back on one connection. They coalesced into a single TCP segment, so DXKeeper ran the delete and **silently dropped the re-log** — edits never reached DXKeeper. (Reproduced end-to-end with a standalone Python harness and DXKeeper's own TCP log; full root-cause writeup in #957.)

## Fix

Replace the persistent-connection assumption with an **outbound operation queue drained off the main thread**, one **connect-per-command**, matching DXKeeper's model.

**`uExternalLoggerBase.pas`**
- Outbound operation queue (`Log` / `Delete` / `Replace`) guarded by a critical section + event, drained by a dedicated `TSenderThread`. The main thread only enqueues and returns — no socket I/O on the UI thread.
- `Replace` is **atomic**: the re-log is sent only if the delete succeeded. Order is forced (delete first) because the QSO identity is `CALL`+`QSO_DATE`+`TIME_ON`, unchanged by a mode edit. A half-done replace is logged **loudly** so it is never silent.
- `DeliverWithRetry`: bounded retry with interruptible backoff. `DeliverCommand` is virtual (base default = persistent socket, for future ACLog/HRD).
- `ShutdownDrain`: bounded flush on destroy, then stops the sender and logs any undelivered operations. A replayable persistent queue is deferred to the Delphi 12 / SQLite work.

**`uExternalLogger.pas`**
- DXKeeper overrides `DeliverCommand` with connect-per-command (fresh `TIdTCPClient`: connect → send one command → read any response until DXKeeper closes).
- `LogQSO` / `DeleteQSO` now enqueue; the builders return the message string; new `ReplaceQSO` enqueues an atomic replace.
- `externallog` option flags: enrichment + membership lookups `Y` (DeduceMissing, QueryCallbook, CheckOverrides, UpdateeQSL, UpdateLoTW); QSL-server uploads `N` (UploadeQSL, UploadLoTW, UploadClubLog, UploadQRZ) so there is time to edit before upload.

**`uEditQSO.pas`**
- The edit path is a single non-blocking `externalLogger.ReplaceQSO`; the earlier 2 s main-thread `Sleep` workaround is removed.

**`tools/dxkeeper_edit_repro.py`**
- Standalone harness that reproduces / verifies the DXKeeper edit sequence independently of TR4W.

## Scope notes
- `LookupCallsign` (DXKeeper) left on the old path — not the bug, rarely used; a follow-up.
- The persistent socket / reading thread are now vestigial for DXKeeper (kept for future persistent loggers).
- Shutdown uses a tight bounded drain + loud logging rather than a non-modal notice (the drain is fast in practice).

## Testing
Full build green (all languages + unit tests + server). Verified against DXKeeper hardware: delete, edit, and edit-then-immediate-shutdown all propagate correctly; the queue drains at shutdown; the UI no longer freezes on an edit.