### PR TITLE
WSJT-X colorization: reply to the decode's source IP, not hard-coded 127.0.0.1

### DIFF
--- a/tr4w/src/uWSJTX.pas
+++ b/tr4w/src/uWSJTX.pas
@@ -39,6 +39,7 @@ type
     tcpServ: TIdTCPServer;
     started: boolean;
     peerPort: word;
+    peerIP: string;   // source IP of the WSJT-X instance; colorization replies go here, not a hard-coded loopback
     FUDPPort: integer;
     FTCPPort: integer;
     SNR: LongInt;
@@ -388,6 +389,7 @@ begin
   //FUDP.IdUDPServer1.Bindings := '127.0.0.1:2237,[::]:2237';
   index := 0;
   peerPort := ABinding.PeerPort;
+  peerIP := ABinding.PeerIP;   // reply colorization to the instance that sent the decode (local or remote)
   newMessage := '';
   //  peerPort := 2237;
 
@@ -906,7 +908,7 @@ begin
 
   Pack(AData, true); // Highlight last only
   logger.trace('[uWSJTX] Sending command to highlight ' + Trim(sCall));
-  udpServ.SendBuffer('127.0.0.1', PeerPort, AData);
+  udpServ.SendBuffer(peerIP, PeerPort, AData);
 
 end;
 
@@ -956,7 +958,7 @@ begin
   Pack(AData, true); // Highlight last only
   logger.debug('[uWSJTX] Sending Reset Colors');
 
-  udpServ.SendBuffer('127.0.0.1', PeerPort, AData);
+  udpServ.SendBuffer(peerIP, PeerPort, AData);
 
 end;
 


### PR DESCRIPTION
## Summary

The WSJT-X dupe/multiplier highlight (and color-reset) replies were sent to a **hard-coded `127.0.0.1`**, while only the **source port** was captured from the incoming WSJT-X packet (`uWSJTX.pas`).

That works only when WSJT-X runs on the **same machine** as TR4W. If WSJT-X is on a **different computer**, the decodes still arrive at TR4W (over the LAN), TR4W processes them and logs that it's highlighting — but the colorization reply goes to TR4W's **own loopback** and never reaches the remote instance, so nothing gets colored.

## Change

- Capture `ABinding.PeerIP` alongside the port in the UDP read handler.
- Send the `HighlightCall` and `ClearColors` replies to that address instead of `'127.0.0.1'`.

`peerIP` is set at the top of the same read handler that later calls `HighlightCall`/`ClearColors` (a highlight only happens while processing a decode), so it's always valid before use. For a local WSJT-X this resolves to `127.0.0.1` exactly as before; for a remote one it now reaches it.

## Scope / honesty note

This fixes the **separate-machine** case. It does **not** explain the recent Field Day report, which was a **single-PC** setup — that remains under investigation (TR4W's log shows it sent the highlights correctly and without error; the breakdown is downstream of TR4W and needs a packet capture to pin down). This PR stands on its own as a correctness fix.

Related: #771 (highlighting that worked on a co-located WSJT-X but not a separate-machine station).

## Testing

Full build green (all languages + unit tests + server).