### PR TITLE
K4 serial: band label tracks band changes (derive band from frequency)

### DIFF
--- a/tr4w/src/uRadioElecraftK4.pas
+++ b/tr4w/src/uRadioElecraftK4.pas
@@ -534,6 +534,11 @@ if applicable (0=DATA A, 1=AFSK A, 2= FSK D, 3=PSK D)
       end;
 
    vfo.frequency := hz;
+   vfo.band := FreqToRadioBand(hz);
+      // Serial polling only sends IF;FB; (AI off), so BN never arrives on a
+      // band change -- derive band from frequency here, as every other modern
+      // radio class does (Icom/Flex/TS-890).  Keeps the band label in sync when
+      // the operator changes bands on the radio over a serial connection.
    vfo.mode := ModeStrToMode(sMode,sDataMode);
 
 
@@ -675,6 +680,7 @@ begin
          if hz >= 0 then
             begin
             Self.vfo[nrVFOA].frequency := hz;
+            Self.vfo[nrVFOA].band := FreqToRadioBand(hz);   // keep band in sync with frequency (see ParseIFCommand note)
             end
          else
             begin
@@ -686,6 +692,7 @@ begin
          if hz >= 0 then
             begin
             Self.vfo[nrVFOB].frequency := hz;
+            Self.vfo[nrVFOB].band := FreqToRadioBand(hz);   // keep band in sync with frequency (see ParseIFCommand note)
             end
          else
             begin


### PR DESCRIPTION
## Problem

On a K4 **serial** connection, changing bands on the radio updated the frequency display but left the **band label stale** — e.g. the radio on 21.278 MHz (15m) still showed `20SSB`.

Confirmed from a trace log (steady state while parked on 15m):

```
[ProcessFilteredStatus] rig=K4-232 ... FS.Freq=21278049, FS.Band=3 ...
```

`FS.Freq=21278049` = 21.278 MHz (15m) but `FS.Band=3` = Band20 (20m). Log also confirmed this radio runs through the modern `TK4Radio` object (`ParseIFCommand` / `IF;FB;` markers present; legacy `pKenwood2` markers absent).

## Root cause

On serial the K4 runs with AI off and `PollRadioState` polls only `IF;FB;`, so a `BN` (band-number) response arrives **only once at connect**. Band froze at the startup band while frequency kept updating. Network works because AI5 pushes `BN` on every band change.

`TK4Radio` was the only modern radio class that set a VFO `.frequency` without also setting `.band`.

## Fix

Derive band from frequency via `FreqToRadioBand` at each frequency-assignment site in `uRadioElecraftK4.pas` (`ParseIFCommand` active VFO, `FA` VFO A, `FB` VFO B) — the same pattern already used by the Icom, Flex, and TS-890 classes. Band is now authoritative from the actual frequency on both serial and network paths, independent of `BN`. The `BN` handler is unchanged.

## Testing

- Builds cleanly (FullBuild, all languages).
- Verified on real K4 hardware over serial: band label now follows band changes made on the radio.