### PR TITLE
trmaster: add curated callsign-history name layer + QRZ club/org cache fix

### DIFF
--- a/tr4w/tools/trmaster/README.md
+++ b/tr4w/tools/trmaster/README.md
@@ -4,9 +4,11 @@ Offline tooling to (re)generate `TRMASTER.DTA` without depending on an external
 maintainer's pipeline. **Nothing here runs inside TR4W** — run it before a build.
 
 It unions a fresh callsign list (supercheckpartial) with the membership/name
-layer (CWops, FOC, HSC) and a curated name seed, optionally prunes lapsed
-US/UK/CA calls, backfills names from QRZ, and writes the same **K1EA
-"CT / TRlog" `.dta`** TR4W already reads (no program changes).
+layer (CWops, FOC, HSC), a curated name seed, and curated callsign-history name
+files (ICWC-MST, K1USN SST, VE2FK Names) whose on-air names are more precise than
+QRZ, optionally prunes lapsed US/UK/CA calls, backfills the rest from QRZ, and
+writes the same **K1EA "CT / TRlog" `.dta`** TR4W already reads (no program
+changes).
 
 ## Files
 
@@ -62,6 +64,14 @@ makes later runs fast.
   (no header): `[2]=call, [3]=CWops#, [4]=first name`. Refreshed every run.
 - **FOC / HSC** — seeded from the curated seed file (no live feed: the FOC page is
   a Cloudflare/AJAX wall). Override with `--foc-csv` / `--hsc-csv CALL,NUM[,NAME]`.
+- **Callsign-history name files** — N1MM-style `CALL,NAME,...` text files kept in
+  `seed\` (`ICWC-MST-*.txt`, `K1USNSST-*.txt`, `Names_VE2FK-*.txt`). Curated
+  on-air CW names (nicknames), **more precise than QRZ**. Passed via `--history-glob
+  PATTERN` (repeatable; pattern order = priority, ICWC > K1USN > VE2FK). Each
+  pattern resolves to its **single newest** match, so **dropping an updated copy
+  into `seed\` each month supersedes the prior one** — a name corrected/removed in
+  the new file is not resurrected from a stale old copy. Like the CWops/FOC/HSC
+  rosters, these calls **expand** the TRMASTER universe (curated → never pruned).
 
 ## Pruning lapsed calls (`--prune-qrz-unverified SCP.DB`)
 
@@ -82,11 +92,17 @@ name, not the nickname — exportable to a `--names-csv`.)*
 
 ## Merge precedence (per call)
 
+Name precedence, highest → lowest: **CWops > FOC > history > seed > QRZ**.
+
 1. curated **seed** (preserve accumulated Name + memberships + orphan names)
-2. CWops CSV → `User1` (CWops #) + Name (current roster wins)
-3. FOC → `FOC` # + Name (fills if missing)
-4. HSC → `User2` (HSC #)
-5. `--names-csv` (QRZ) fills any remaining nameless call
+2. **callsign-history files** → Name (curated on-air names; **override** the
+   accumulated seed/QRZ name, but the authoritative CWops/FOC rosters below still
+   win). Within the history layer the first file to name a call wins (ICWC >
+   K1USN > VE2FK). These calls also expand the universe.
+3. CWops CSV → `User1` (CWops #) + Name (current roster wins)
+4. FOC → `FOC` # + Name (roster name wins over history)
+5. HSC → `User2` (HSC #)
+6. `--names-csv` (QRZ) fills any remaining nameless call
 
 Calls present only in the SCP source stay **bare** — still work for Super Check
 Partial, just no prefill.
@@ -100,6 +116,8 @@ to keep old copies (one `.bak` is kept for rollback). The files that carry
 non-regenerable history — **back these up**:
 
 - `seed\TRMASTER_seed.DTA` — frozen curated names / FOC / HSC / orphan names.
+- `seed\ICWC-MST-*.txt`, `seed\K1USNSST-*.txt`, `seed\Names_VE2FK-*.txt` — the
+  curated callsign-history name files (drop updated copies here monthly).
 - `~\.publicLogProcessor\qrz_name_cache.json` — accumulated QRZ lookups (the
   expensive part; otherwise re-querying ~44k calls).
 

--- a/tr4w/tools/trmaster/build_trmaster.cmd
+++ b/tr4w/tools/trmaster/build_trmaster.cmd
@@ -7,13 +7,16 @@ REM  tr4w\target\ -- copying the result into place is YOUR deploy step.
 REM
 REM  Pipeline:
 REM    1. download supercheckpartial SCP.DB (MASTER.DTA + CWops auto-download)
-REM    2. build pass 1: MASTER universe + curated seed/rosters, US/UK/CA
-REM       QRZ-verified prune  ->  identifies which calls still need names
-REM    3. QRZ name resolver fills the bare calls (cached; cheap on re-runs)
+REM    2. build pass 1: MASTER universe + curated seed/rosters + callsign-history
+REM       name files, US/UK/CA QRZ-verified prune  ->  identifies the calls that
+REM       STILL need names (history already names ~24k, so QRZ has far fewer)
+REM    3. QRZ name resolver fills the still-bare calls (cached; cheap on re-runs)
 REM    4. build pass 2: same inputs + the QRZ names  ->  TRMASTER.DTA
 REM
 REM  Inputs that carry history (back these up; see README):
 REM    seed\TRMASTER_seed.DTA                  curated names / FOC / HSC / orphans
+REM    seed\*.txt (ICWC-MST / K1USN / VE2FK)   curated on-air name files (drop
+REM                                            updated copies here monthly)
 REM    %USERPROFILE%\.publicLogProcessor\qrz_name_cache.json   accumulated QRZ names
 REM ===========================================================================
 
@@ -28,6 +31,11 @@ set "SCPDB=%WORK%\SCP.DB"
 set "NAMES=%WORK%\qrz_names.csv"
 set "QRZ_LIMIT=5000"
 set "CWOPS_URL=https://docs.google.com/spreadsheets/d/1Ew8b1WAorFRCixGRsr031atxmS0SsycvmOczS_fDqzc/export?format=csv"
+
+REM --- callsign-history name files (drop updated copies into seed\ monthly). --
+REM  Pattern order = priority (ICWC > K1USN > VE2FK); each pattern resolves to
+REM  its single newest match, so a fresh drop supersedes the prior month.
+set "HISTORY=--history-glob seed\ICWC-MST-*.txt --history-glob seed\K1USNSST-*.txt --history-glob seed\Names_VE2FK-*.txt"
 
 if not exist "%WORK%" mkdir "%WORK%"
 
@@ -46,7 +54,7 @@ curl -sL --fail -o "%SCPDB%" https://supercheckpartial.com/downloads/SCP.DB || g
 REM --- 2. first build (downloads MASTER.DTA + CWops; --force = fresh) ---------
 echo [2/4] build pass 1 (universe + rosters + prune) ...
 "%PYTHON%" trmaster_build.py --out "%OUT%" --existing "%SEED%" ^
-    --download-master --force --cwops-url "%CWOPS_URL%" ^
+    --download-master --force --cwops-url "%CWOPS_URL%" %HISTORY% ^
     --prune-qrz-unverified "%SCPDB%" || goto :error
 
 REM --- 3. QRZ name resolution for the bare calls (skips cleanly if no creds) --
@@ -57,7 +65,7 @@ echo [3/4] QRZ name lookups (limit %QRZ_LIMIT%) ...
 REM --- 4. final build with names --------------------------------------------
 echo [4/4] build pass 2 (with QRZ names) ...
 "%PYTHON%" trmaster_build.py --out "%OUT%" --existing "%SEED%" ^
-    --download-master --cwops-url "%CWOPS_URL%" ^
+    --download-master --cwops-url "%CWOPS_URL%" %HISTORY% ^
     --prune-qrz-unverified "%SCPDB%" --names-csv "%NAMES%" || goto :error
 
 echo.

--- a/tr4w/tools/trmaster/trmaster_build.py
+++ b/tr4w/tools/trmaster/trmaster_build.py
@@ -7,14 +7,18 @@ richer SCP.DB sqlite) with the membership/name layer (CWops roster CSV, FOC,
 HSC) and any previously-accumulated names from the existing TRMASTER.DTA, then
 writes a single K1EA .dta that TR4W's existing reader consumes unchanged.
 
-Pipeline (precedence shown):
+Pipeline (Name precedence shown, high -> low):  CWops > FOC > history > seed > QRZ
   call universe  = MASTER.DTA calls  (+ every roster/existing call)
   per call fields:
     1. existing TRMASTER.DTA            (preserve accumulated Name + memberships)
-    2. CWops CSV   -> User1 (CWops #) + Name (overrides; roster is current)
-    3. FOC         -> FOC #            + Name (fills if missing)
-    4. HSC         -> User2 (HSC #)
-    5. name resolver (optional --names-csv from your FCC/QRZ script) fills any
+    2. callsign-history files          -> Name (curated on-air names; override the
+       (ICWC-MST / K1USN SST / VE2FK)      accumulated seed/QRZ name, but the
+                                           authoritative CWops/FOC rosters below
+                                           still win)
+    3. CWops CSV   -> User1 (CWops #) + Name (overrides; roster is current)
+    4. FOC         -> FOC #            + Name (roster name wins)
+    5. HSC         -> User2 (HSC #)
+    6. name resolver (optional --names-csv from your FCC/QRZ script) fills any
        call still missing a Name
 
 Nothing here runs inside TR4W. Run it before the monthly build.
@@ -29,6 +33,7 @@ See README.md in this directory for source URLs and the FCC/QRZ hook.
 
 import argparse
 import csv
+import glob as globmod
 import os
 import re
 import sqlite3
@@ -176,32 +181,98 @@ def load_names_csv(path):
     return out
 
 
+def resolve_history_files(patterns):
+    """Resolve each --history-glob pattern to the single NEWEST matching file.
+
+    The monthly workflow is to drop an updated copy (new version suffix, e.g.
+    ICWC-MST-047.txt -> ICWC-MST-048.txt) into the seed dir. Picking only the
+    newest per pattern means the fresh drop fully supersedes the prior month:
+    a name corrected/removed there is not resurrected from a stale old copy left
+    behind. `sorted(..., reverse=True)` puts the highest (zero-padded) version
+    first; it also prefers 'ICWC-MST-047.txt' over the 'ICWC-MST-047 (1).txt'
+    accidental download dup. Returns files in the given pattern order = priority.
+    """
+    files = []
+    for pat in patterns or []:
+        matches = sorted(globmod.glob(pat), reverse=True)
+        if not matches:
+            log(f"  history: no file matches {pat}")
+            continue
+        if len(matches) > 1:
+            log(f"  history: {len(matches)} files match {pat}; using newest "
+                f"{os.path.basename(matches[0])} "
+                f"(ignoring {[os.path.basename(m) for m in matches[1:]]})")
+        files.append(matches[0])
+    return files
+
+
+def load_history_names(paths):
+    """N1MM-style callsign-history files (ICWC-MST, K1USN SST, VE2FK Names, ...).
+
+    Format: CSV, col0 = CALL, col1 = NAME; lines starting with '#' or '!!' are
+    comment/header lines and are skipped. `paths` is in PRIORITY order: the first
+    file to define a name for a call wins (later files only fill calls not yet
+    seen). Returns {CALL: NAME(upper)}.
+    """
+    out = {}
+    for path in paths:
+        if not path or not os.path.exists(path):
+            continue
+        n0 = len(out)
+        with open(path, newline="", encoding="utf-8", errors="replace") as f:
+            for row in csv.reader(f):
+                if not row:
+                    continue
+                c0 = row[0].strip()
+                if not c0 or c0.startswith("#") or c0.startswith("!!"):
+                    continue
+                call = c0.upper()
+                name = row[1].strip().upper() if len(row) > 1 else ""
+                if valid_call(call) and name and call not in out:
+                    out[call] = name
+        log(f"  history {os.path.basename(path)}: +{len(out) - n0} new names "
+            f"(total {len(out)})")
+    return out
+
+
 # --- merge ------------------------------------------------------------------
 
-def merge(universe, existing, cwops, foc, hsc, names):
-    """Build {CALL: fields} by the documented precedence."""
-    calls = set(universe) | set(existing) | set(cwops) | set(foc) | set(hsc)
+def merge(universe, existing, history, cwops, foc, hsc, names):
+    """Build {CALL: fields} by the documented precedence.
+
+    Name precedence (high -> low): CWops > FOC > history > seed(existing) > QRZ.
+
+    History calls, like the CWops/FOC/HSC rosters, expand the call universe
+    (curated active participants) and are therefore never pruned.
+    """
+    calls = (set(universe) | set(existing) | set(history)
+             | set(cwops) | set(foc) | set(hsc))
     out = {}
     for call in calls:
         f = {}
-        # 1. preserve accumulated data
+        # 1. preserve accumulated data (seed Name + memberships)
         if call in existing:
             f.update(existing[call])
-        # 2. CWops (current roster wins for number + name)
+        # 2. callsign-history files override the accumulated seed/QRZ name
+        #    (curated on-air names). Applied BEFORE CWops/FOC so those
+        #    authoritative rosters still win over the history name.
+        if call in history:
+            f["Name"] = history[call]
+        # 3. CWops (current roster wins for number + name)
         if call in cwops:
             f["User1"] = cwops[call]["User1"]
             if cwops[call].get("Name"):
                 f["Name"] = cwops[call]["Name"]
-        # 3. FOC
+        # 4. FOC (roster name wins over history)
         if call in foc:
             if foc[call].get("FOC"):
                 f["FOC"] = foc[call]["FOC"]
-            if foc[call].get("Name") and not f.get("Name"):
+            if foc[call].get("Name"):
                 f["Name"] = foc[call]["Name"]
-        # 4. HSC
+        # 5. HSC
         if call in hsc and hsc[call].get("User2"):
             f["User2"] = hsc[call]["User2"]
-        # 5. name resolver fills the gap
+        # 6. name resolver (QRZ) fills any call still nameless
         if not f.get("Name") and call in names:
             f["Name"] = names[call]
         out[call] = f
@@ -231,6 +302,13 @@ def main(argv=None):
     ap.add_argument("--cwops-url", help="CWops roster CSV export URL")
     ap.add_argument("--foc-csv", help="FOC export CSV (CALL,NUM[,NAME])")
     ap.add_argument("--hsc-csv", help="HSC export CSV (CALL,NUM[,NAME])")
+    ap.add_argument("--history-glob", action="append", default=[], metavar="PATTERN",
+                    help="callsign-history file glob (repeatable; pattern order = "
+                         "priority). Each pattern resolves to its single newest "
+                         "match, e.g. \"seed/ICWC-MST-*.txt\".")
+    ap.add_argument("--history-file", action="append", default=[], metavar="FILE",
+                    help="explicit callsign-history file (repeatable; order = "
+                         "priority; applied before --history-glob results).")
     ap.add_argument("--names-csv", help="name source CSV (CALL,NAME) from FCC/QRZ")
     ap.add_argument("--prune-qrz-unverified", metavar="SCP.DB",
                     help="drop universe calls that SCP.DB marks NOT QRZ-verified "
@@ -287,11 +365,18 @@ def main(argv=None):
     hsc.update(parse_simple_csv(args.hsc_csv, "User2"))
     log(f"  FOC entries: {len(foc)}   HSC entries: {len(hsc)}")
 
+    # callsign-history name layer (curated on-air names; override seed/QRZ,
+    # below CWops/FOC). Priority = explicit --history-file first, then each
+    # --history-glob's newest match, in the order given.
+    history_paths = list(args.history_file) + resolve_history_files(args.history_glob)
+    history = load_history_names(history_paths)
+    log(f"  history names: {len(history)}")
+
     names = load_names_csv(args.names_csv)
     log(f"  name-resolver names: {len(names)}")
 
     # 3. merge + write
-    merged = merge(universe, existing, cwops, foc, hsc, names)
+    merged = merge(universe, existing, history, cwops, foc, hsc, names)
     census(merged, "merged")
     size = tc.write_dta(args.out, merged)
     log(f"\nwrote {args.out}: {size} bytes")

--- a/tr4w/tools/trmaster/trmaster_names_qrz.py
+++ b/tr4w/tools/trmaster/trmaster_names_qrz.py
@@ -122,10 +122,36 @@ class QRZNameClient:
         os.replace(tmp, self._cache_path)   # atomic on same filesystem
         self._dirty = False
 
+    @staticmethod
+    def _entry_is_org(entry):
+        """A 'no name' entry that QRZ shows is a club/org: its `name` field
+        (stored as `qname`) contains a club word and there is no personal
+        nickname/fname. A club call never becomes a person, so its miss is
+        permanent and must NOT be re-queried on the short miss TTL.
+
+        Derived from the already-stored `qname`, so it applies retroactively to
+        entries cached before this logic existed — no re-lookup, no migration.
+        Conservative on purpose: only a definite club-word match qualifies, so a
+        real person is never mistaken for a club (a club we miss just keeps the
+        30-day recheck — a wasted lookup, not a wrong name).
+        """
+        q = (entry.get("qname") or "").strip().upper()
+        if not q:
+            return False
+        if entry.get("nickname") or entry.get("fname"):
+            return False
+        return bool(set(q.split()) & CLUB_WORDS)
+
     def _fresh(self, entry):
-        # entries WITH a name use the long (hit) TTL; "no name" entries use the
-        # shorter (miss) TTL.
-        ttl = self._hit_max_secs if entry.get("name") else self._miss_max_secs
+        # Named entries use the long (hit) TTL. "No name" entries use the short
+        # (miss) TTL so a call that later gains a name gets rechecked — EXCEPT
+        # confirmed clubs/orgs, which never become a person and so never expire.
+        if entry.get("name"):
+            ttl = self._hit_max_secs
+        elif self._entry_is_org(entry):
+            ttl = 0                       # confirmed club -> never re-query
+        else:
+            ttl = self._miss_max_secs
         if ttl <= 0:
             return True   # 0 = never expire
         return (self._now - int(entry.get("ts", 0))) <= ttl


### PR DESCRIPTION
## Summary

Improves the offline `TRMASTER.DTA` builder ahead of the monthly release by adding a curated on-air-name layer and a QRZ cache fix. **Tooling only — nothing here runs inside TR4W.**

## Changes

- **New callsign-history name layer** (`trmaster_build.py`, `build_trmaster.cmd`, `README.md`): sources curated on-air CW names from N1MM-style files (`ICWC-MST-*.txt`, `K1USNSST-*.txt`, `Names_VE2FK-*.txt`) kept in `seed\`. These names are more precise than QRZ and expand the call universe (never pruned), like the CWops/FOC/HSC rosters.
  - New `--history-glob` (repeatable; pattern order = priority; each resolves to its single newest match, so a fresh monthly drop supersedes the prior one) and `--history-file`.
  - Name precedence is now **CWops > FOC > history > seed > QRZ** — history is applied before the authoritative CWops/FOC rosters so those still win.
  - `build_trmaster.cmd` passes the history globs in both build passes; history names ~24k calls, leaving far fewer for QRZ to fill.
- **QRZ club/org cache fix** (`trmaster_names_qrz.py`): confirmed clubs/orgs get `ttl=0` (never re-queried), derived retroactively from the stored `qname` so no re-lookup or migration is needed.

## Notes

- The `seed\*.txt` history files are gitignored (same as `TRMASTER_seed.DTA`); the repo carries only the code. Curated inputs stay local per the existing "back these up" pattern.
- Tested locally against a full TRMASTER regeneration.