### PR TITLE
Issue #1033: decouple uCTYDAT country lookup + tests

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -4078,6 +4078,11 @@ QSOPartiesCount = 20;
 
   var
     tr4wBrushArray                      : array[tr4wColors] of HBRUSH;
+    // Issue #1034: relocated here from LogDupe so light units (uMults and the
+    // pre-migration test EXE) can read the active DX-multiplier mode without
+    // pulling LogDupe's monolith cone. DXMultType is defined above in this unit;
+    // zero-initialized to NoDXMults (its first value), matching the old default.
+    ActiveDXMult                        : DXMultType;
 
 implementation
 //rd4wa -

--- a/tr4w/src/trdos/LOGDUPE.PAS
+++ b/tr4w/src/trdos/LOGDUPE.PAS
@@ -235,7 +235,8 @@ var
   InitialExDupes                        : integer;
 
   tAllowDupeQSOs                        : boolean = False;
-  ActiveDXMult                          : DXMultType {= NoDXMults};
+  // Issue #1034: ActiveDXMult moved to VC.pas (light home) so uMults can read it
+  // without depending on LogDupe. All users resolve it via VC (universally used).
   ActivePrefixMult                      : PrefixMultType {= NoPrefixMults};
 
   AutoDupeEnableCQ                      : boolean = False;

--- a/tr4w/src/uCTYDAT.PAS
+++ b/tr4w/src/uCTYDAT.PAS
@@ -26,13 +26,12 @@ interface
 uses
 
   VC,
-  TF,
   uCommctrl,
   Windows,
   uCallSignRoutines,
   utils_text,
   utils_file,
-  LogGrid
+  SysUtils    // Issue #1033: StrPas for the RTL Val that replaces TF.ValExt
   ;
 {
 type
@@ -270,7 +269,85 @@ var
 
 implementation
 
-Uses MainUnit;
+// Issue #1033: uCTYDAT previously borrowed the global `logger` from MainUnit,
+// which coupled this otherwise self-contained country-lookup unit to the entire
+// application and blocked it from being linked into the unit-test EXE. Give it
+// its own Log4D logger -- the same pattern every modern unit uses (e.g.
+// uExternalLoggerFactory) -- so the unit no longer depends on MainUnit.
+uses
+   Log4D;
+
+var
+   logger: TLogLogger;
+
+// Issue #1033: local cdecl binding to wsprintfA. Delphi 7's Windows.wsprintf is
+// not declared varargs, so the former TF.Format (itself just wsprintfA) is bound
+// directly here for the one tDebugMode-only prefix-table dump below.
+function ctyDbgFmt(Output: PChar; Format: PChar; i1: integer; s: PChar; i2: integer): integer; cdecl; external 'user32.dll' name 'wsprintfA';
+
+// ---------------------------------------------------------------------------
+// Issue #1033: helpers lifted VERBATIM from TF / LogGrid so uCTYDAT no longer
+// depends on either -- both pull in MainUnit -> LogStuff and blocked uCTYDAT
+// from linking into the dependency-light unit-test EXE. Bodies are unchanged
+// (identical behavior + git blame); fold into a shared light unit during the
+// Delphi 12 refactor. See docs/tr4w-migration-strategy.md.
+// ---------------------------------------------------------------------------
+
+// Lifted from TF.PCharToInt: parse a leading (optionally '-') integer from a
+// PChar, stopping at the first non-digit.
+function PCharToInt(p: PChar): integer;
+label
+  1, 2;
+var
+  i                                     : integer;
+  Negative                              : boolean;
+begin
+  Result := 0;
+  i := 0;
+  Negative := False;
+
+  if p[i] = '-' then
+  begin
+    i := 1;
+    Negative := True;
+  end;
+
+  1:
+  if p[i] in ['0'..'9'] then Result := Result * 10 + (Ord(p[i]) - 48)
+  else goto 2;
+  inc(i);
+  goto 1;
+  2:
+  if Negative then Result := Result * -1;
+end;
+
+// Lifted from LogGrid.ConvertLatLonToGrid: Maidenhead grid from lat/lon.
+function ConvertLatLonToGrid(Lat, Lon: REAL): GridString;
+var
+  c                                     : integer;
+  G4, L4                                : REAL;
+  m1, m2, m3, m4, m5, m6                : Char;
+begin
+  G4 := 180 - Lon;
+  c := Trunc(G4 / 20);
+  m1 := CHR(c + Ord('A'));
+  G4 := G4 - c * 20;
+  c := Trunc(G4 / 2);
+  m3 := CHR(c + Ord('0'));
+  G4 := G4 - c * 2;
+  c := Trunc(G4 / (2 / 24));
+  m5 := CHR(c + Ord('A'));
+  L4 := Lat + 90;
+  c := Trunc(L4 / 10);
+  m2 := CHR(c + Ord('A'));
+  L4 := L4 - c * 10;
+  c := Trunc(L4);
+  m4 := CHR(c + Ord('0'));
+  L4 := L4 - c;
+  c := Trunc(L4 / (1 / 24));
+  m6 := CHR(c + Ord('A'));
+  ConvertLatLonToGrid := m1 + m2 + m3 + m4 + m5 + m6;
+end;
 
 procedure ctyAddNewPrefixRecord(pr: PrefixRecPtr; CheckDupe: boolean);
 var
@@ -452,17 +529,14 @@ begin
               begin
                 Windows.ZeroMemory(@b, SizeOf(b));
                 Windows.CopyMemory(@b, @p[s], l);
-                Lat := ValExt(b, code);
-                //Val(b, Lat, code);
-                //Lat := ValExt(b, code);
+                Val(StrPas(b), Lat, code);   // Issue #1033: was TF.ValExt (asm); RTL Val is equivalent for cty.dat's well-formed decimals
               end;
             cpLongitude:
               begin
 
                 Windows.ZeroMemory(@b, SizeOf(b));
                 Windows.CopyMemory(@b, @p[s], l);
-//                Val(b, Lon, code);
-                Lon := ValExt(b, code);
+                Val(StrPas(b), Lon, code);   // Issue #1033: was TF.ValExt (asm)
                 if code = 0 then r.DefaultGrid := ConvertLatLonToGrid(Lat, Lon);
               end;
 
@@ -630,7 +704,7 @@ begin
   begin
     TempPtr := PrefixRecPtr(DSA_GetItemPtr(CTY.CTYPrefixesTable, iI));
 {$IF tDebugMode}
-    sWriteFile(h, wsprintfBuffer, Format(wsprintfBuffer, '%04u %-15s %u'#13#10, iI, @TempPtr^.Prefix, TempPtr.Country));
+    sWriteFile(h, wsprintfBuffer, ctyDbgFmt(wsprintfBuffer, '%04u %-15s %u'#13#10, iI, @TempPtr^.Prefix, TempPtr.Country));
 {$IFEND}
     CTY.ctyIndexArray[TempPtr^.Prefix[0]] := iI;
 
@@ -1280,7 +1354,7 @@ begin
 
   cty.ctyR150SMode := True;
 
-  Format(TR4W_R150S_FILENAME, '%sr150s.dat', TR4W_PATH_NAME);
+  StrPCopy(TR4W_R150S_FILENAME, StrPas(TR4W_PATH_NAME) + 'r150s.dat');   // Issue #1033: was TF.Format(=wsprintfA)
   ctyLoadInCountryFile(TR4W_R150S_FILENAME, True, False);
 
 end;
@@ -1293,10 +1367,15 @@ begin
 
   cty.ctyRFOblMode := True;
 
-  Format(TR4W_rfobl_FILENAME, '%srfobl.dat', TR4W_PATH_NAME);
+  StrPCopy(TR4W_rfobl_FILENAME, StrPas(TR4W_PATH_NAME) + 'rfobl.dat');   // Issue #1033: was TF.Format(=wsprintfA)
   ctyLoadInCountryFile(TR4W_rfobl_FILENAME, True, False);
 
 end;
+
+initialization
+   // Own Log4D logger (see Issue #1033 note above) -- replaces the former
+   // MainUnit.logger borrow. GetLogger is safe before Log4D is configured.
+   logger := TLogLogger.GetLogger('uCTYDAT');
 
 end.
 

--- a/tr4w/src/uCallSignRoutines.pas
+++ b/tr4w/src/uCallSignRoutines.pas
@@ -18,7 +18,7 @@ unit uCallSignRoutines;
 {$IMPORTEDDATA OFF}
 interface
 uses
-  TF,
+  uStrSearch,   // Issue #1033: was TF (needed only for StrU, which #997 moved to the light uStrSearch) -- drops TF -> MainUnit -> LogStuff coupling
   uRussiaOblasts,
   // Tree,
   utils_text,
@@ -495,7 +495,7 @@ var
 begin
   GoodCallSyntax := False;
   if length(Call) < 3 then Exit;
-  strU(Call);
+  uStrSearch.StrU(Call);
   if not StringHasLetters(Call) then Exit;
   case length(Call) of
     8:

--- a/tr4w/src/uMults.pas
+++ b/tr4w/src/uMults.pas
@@ -32,8 +32,7 @@ uses
   uCTYDAT,
   //Country9,
   Windows,
-  uCallsigns,
-  Log4D;
+  Log4D;   // Issue #1034: dropped uCallsigns (unused here)
 
 
 const
@@ -73,8 +72,13 @@ var
   mo                                    : MultsObject;
   
 implementation
-uses
-  LogDupe, MainUnit;
+
+// Issue #1034: own Log4D logger (initialized below), replacing the former
+// MainUnit.logger borrow. MainUnit + LogDupe were otherwise unused here, so
+// dropping them removes uMults's direct MainUnit -> LogStuff coupling and lets
+// the multiplier logic be linked into the dependency-light unit-test EXE.
+var
+  logger: TLogLogger;
 
 procedure MultsObject.IncrementTotals(Band: BandType; Mode: ModeType; m: RemainingMultiplierType);
 begin
@@ -248,6 +252,7 @@ begin
 end;
 
 begin
+  logger := TLogLogger.GetLogger('uMults');   // Issue #1034: own logger (was MainUnit.logger)
   mo.PrfList.Init;
   mo.DomList.Init;
 //  mo.PrfList := TSSL.Create;

--- a/tr4w/src/uSSL.pas
+++ b/tr4w/src/uSSL.pas
@@ -24,7 +24,8 @@ interface
 
 uses
   VC,
-  TF,
+  // Issue #1034: dropped 'TF' (unused here) -- it pulled TF -> MainUnit -> LogStuff,
+  // which blocked uSSL (and its uMults consumer) from linking into the test EXE.
   //Country9,
   Windows,
   Messages;

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -52,7 +52,9 @@ uses
    uFreqTimeFormat      in '..\..\src\uFreqTimeFormat.pas',
    uTestFreqTimeFormat  in 'uTestFreqTimeFormat.pas',
    uStrSearch           in '..\..\src\uStrSearch.pas',
-   uTestStrSearch       in 'uTestStrSearch.pas';
+   uTestStrSearch       in 'uTestStrSearch.pas',
+   uCTYDAT              in '..\..\src\uCTYDAT.PAS',
+   uTestCTYDAT          in 'uTestCTYDAT.pas';
 
 begin
    IsMultiThread := True;  // Match main application setting
@@ -78,6 +80,7 @@ begin
    RegisterSuite(TADIFRegressionTests.Create('ADIFRegression'));
    RegisterSuite(TFreqTimeFormatTests.Create('FreqTimeFormat'));
    RegisterSuite(TStrSearchTests.Create('StrSearch'));
+   RegisterSuite(TCTYDATTests.Create('CTYDAT'));
 
    if RunAllSuites then
       begin

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -54,7 +54,9 @@ uses
    uStrSearch           in '..\..\src\uStrSearch.pas',
    uTestStrSearch       in 'uTestStrSearch.pas',
    uCTYDAT              in '..\..\src\uCTYDAT.PAS',
-   uTestCTYDAT          in 'uTestCTYDAT.pas';
+   uTestCTYDAT          in 'uTestCTYDAT.pas',
+   uMults               in '..\..\src\uMults.pas',
+   uTestMults           in 'uTestMults.pas';
 
 begin
    IsMultiThread := True;  // Match main application setting
@@ -81,6 +83,7 @@ begin
    RegisterSuite(TFreqTimeFormatTests.Create('FreqTimeFormat'));
    RegisterSuite(TStrSearchTests.Create('StrSearch'));
    RegisterSuite(TCTYDATTests.Create('CTYDAT'));
+   RegisterSuite(TMultsTests.Create('Mults'));
 
    if RunAllSuites then
       begin

--- a/tr4w/test/unit/uTestCTYDAT.pas
+++ b/tr4w/test/unit/uTestCTYDAT.pas
@@ -1,0 +1,228 @@
+unit uTestCTYDAT;
+
+{
+  Tests for uCTYDAT callsign -> DXCC entity lookup (Issue #1033,
+  pre-migration roadmap item 2).
+
+  These pin the country-database lookup that ~109k lines of contest code
+  rely on for country, continent and zone assignment, so it survives the
+  Delphi 12 Unicode / 64-bit phases unchanged.
+
+  Test data: the real, git-tracked cty.dat shipped in tr4w\target\.
+  It is resolved relative to the test EXE (test\unit\ -> ..\..\target\)
+  and loaded once via ctyLoadInCountryFile -- the same call the app makes
+  at startup (tr4w.dpr) -- so the tests exercise the actual
+  load -> shell-sort -> index -> binary-search pipeline, not a mock.
+
+  Asserted values were verified directly against the country header lines
+  in tr4w\target\cty.dat (name : CQ : ITU : Continent : ... : primaryPrefix):
+      United States      NA  K    CQ 05  ITU 08
+      England            EU  G    CQ 14  ITU 27
+      Japan              AS  JA   CQ 25
+      Fed. Rep. Germany  EU  DL
+      Argentina          SA  LU
+      Australia          OC  VK
+      South Africa       AF  ZS
+
+  Conventions (docs/tr4w-migration-strategy.md): cast enums/Bytes to
+  Integer before CheckEquals; keep each method focused on one entity.
+
+  Note: uCTYDAT was decoupled from MainUnit (own Log4D logger) as part of
+  this issue so it could be linked into the dependency-light test EXE.
+}
+
+interface
+
+uses
+   uTR4WTestFramework;
+
+type
+   TCTYDATTests = class(TTestCase)
+   public
+      procedure RunAllTests; override;
+
+   private
+      FLoaded: Boolean;
+
+      // Loads cty.dat once (idempotent). Asserts the load succeeded.
+      procedure EnsureCtyLoaded;
+      // Asserts a callsign resolves to the expected continent + DXCC id.
+      procedure CheckEntity(const Call: string; ExpectCont: Integer;
+                            const ExpectID, Ctx: string);
+
+      procedure Test_LoadCtyDat;
+      procedure Test_UnitedStates_W1AW;
+      procedure Test_England_G3;
+      procedure Test_Japan_JA1;
+      procedure Test_Germany_DL1;
+      procedure Test_Argentina_LU1;
+      procedure Test_Australia_VK2;
+      procedure Test_SouthAfrica_ZS6;
+      procedure Test_Zones_W1_England_Japan;
+      procedure Test_UnknownCountryIndex;
+   end;
+
+implementation
+
+uses
+   SysUtils, VC, uCTYDAT;
+
+// ---------------------------------------------------------------------------
+// Load helper -- loads the shipped cty.dat once, relative to the test EXE.
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.EnsureCtyLoaded;
+var
+   path: string;
+begin
+   if FLoaded then
+      begin
+      Exit;
+      end;
+
+   // test\unit\tr4w_unit_tests.exe -> ..\..\target\cty.dat
+   path := ExtractFilePath(ParamStr(0)) + '..\..\target\cty.dat';
+   CheckTrue(FileExists(path), 'cty.dat present at ' + path);
+   if not FileExists(path) then
+      begin
+      Exit;
+      end;
+
+   // (CheckDupe=False, LoadRemainingMults=False) -- the country/continent/
+   // zone tables come from the main parse; remaining-mults data is not
+   // needed for entity lookups and avoids extra file dependencies.
+   CheckTrue(ctyLoadInCountryFile(PChar(path), False, False),
+             'ctyLoadInCountryFile succeeded');
+   FLoaded := True;
+end;
+
+procedure TCTYDATTests.CheckEntity(const Call: string; ExpectCont: Integer;
+                                   const ExpectID, Ctx: string);
+begin
+   CheckEquals(ExpectCont, Integer(ctyGetContinent(Call)), Ctx + ' continent');
+   CheckEquals(ExpectID, Trim(ctyGetCountryID(Call)), Ctx + ' DXCC id');
+end;
+
+// ---------------------------------------------------------------------------
+// Load + sanity
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.Test_LoadCtyDat;
+begin
+   BeginTest('Test_LoadCtyDat');
+   EnsureCtyLoaded;
+   // The shipped cty.dat lists ~340 DXCC entities; a low bound proves the
+   // parse populated the country table without hard-coding the exact count.
+   CheckTrue(ctyGetTotalCountries > 300, 'country table populated (> 300)');
+end;
+
+// ---------------------------------------------------------------------------
+// Continent + DXCC-id spot checks, one representative call per continent
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.Test_UnitedStates_W1AW;
+begin
+   BeginTest('Test_UnitedStates_W1AW');
+   EnsureCtyLoaded;
+   CheckEntity('W1AW', Integer(NorthAmerica), 'K', 'W1AW (USA)');
+end;
+
+procedure TCTYDATTests.Test_England_G3;
+begin
+   BeginTest('Test_England_G3');
+   EnsureCtyLoaded;
+   CheckEntity('G3ABC', Integer(Europe), 'G', 'G3ABC (England)');
+end;
+
+procedure TCTYDATTests.Test_Japan_JA1;
+begin
+   BeginTest('Test_Japan_JA1');
+   EnsureCtyLoaded;
+   CheckEntity('JA1ABC', Integer(Asia), 'JA', 'JA1ABC (Japan)');
+end;
+
+procedure TCTYDATTests.Test_Germany_DL1;
+begin
+   BeginTest('Test_Germany_DL1');
+   EnsureCtyLoaded;
+   CheckEntity('DL1ABC', Integer(Europe), 'DL', 'DL1ABC (Germany)');
+end;
+
+procedure TCTYDATTests.Test_Argentina_LU1;
+begin
+   BeginTest('Test_Argentina_LU1');
+   EnsureCtyLoaded;
+   CheckEntity('LU1ABC', Integer(SouthAmerica), 'LU', 'LU1ABC (Argentina)');
+end;
+
+procedure TCTYDATTests.Test_Australia_VK2;
+begin
+   BeginTest('Test_Australia_VK2');
+   EnsureCtyLoaded;
+   CheckEntity('VK2ABC', Integer(Oceania), 'VK', 'VK2ABC (Australia)');
+end;
+
+procedure TCTYDATTests.Test_SouthAfrica_ZS6;
+begin
+   BeginTest('Test_SouthAfrica_ZS6');
+   EnsureCtyLoaded;
+   CheckEntity('ZS6ABC', Integer(Africa), 'ZS', 'ZS6ABC (South Africa)');
+end;
+
+// ---------------------------------------------------------------------------
+// CQ / ITU zone spot checks (uniform-zone entities only, to avoid
+// dependence on per-prefix zone overrides).
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.Test_Zones_W1_England_Japan;
+begin
+   BeginTest('Test_Zones_W1_England_Japan');
+   EnsureCtyLoaded;
+
+   // New England (W1): CQ 5 / ITU 8
+   CheckEquals(5, Integer(ctyGetCQZone('W1AW')),  'W1AW CQ zone');
+   CheckEquals(8, Integer(ctyGetITUZone('W1AW')), 'W1AW ITU zone');
+
+   // England: CQ 14 / ITU 27
+   CheckEquals(14, Integer(ctyGetCQZone('G3ABC')),  'G3ABC CQ zone');
+   CheckEquals(27, Integer(ctyGetITUZone('G3ABC')), 'G3ABC ITU zone');
+
+   // Japan CQ 25 (ITU zone varies across the country, so not asserted)
+   CheckEquals(25, Integer(ctyGetCQZone('JA1ABC')), 'JA1ABC CQ zone');
+end;
+
+// ---------------------------------------------------------------------------
+// Negative / edge: the UNKNOWN_COUNTRY sentinel maps to nothing.
+// Pure index getters -- deterministic, no lookup needed.
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.Test_UnknownCountryIndex;
+begin
+   BeginTest('Test_UnknownCountryIndex');
+   EnsureCtyLoaded;
+   CheckEquals(Integer(UnknownContinent),
+               Integer(ctyGetContinentByIndex(UNKNOWN_COUNTRY)),
+               'UNKNOWN_COUNTRY -> UnknownContinent');
+   CheckEquals('', Trim(ctyGetCountryIdByIndex(UNKNOWN_COUNTRY)),
+               'UNKNOWN_COUNTRY -> empty DXCC id');
+end;
+
+// ---------------------------------------------------------------------------
+// Suite entry point
+// ---------------------------------------------------------------------------
+
+procedure TCTYDATTests.RunAllTests;
+begin
+   Test_LoadCtyDat;
+   Test_UnitedStates_W1AW;
+   Test_England_G3;
+   Test_Japan_JA1;
+   Test_Germany_DL1;
+   Test_Argentina_LU1;
+   Test_Australia_VK2;
+   Test_SouthAfrica_ZS6;
+   Test_Zones_W1_England_Japan;
+   Test_UnknownCountryIndex;
+end;
+
+end.

--- a/tr4w/test/unit/uTestMults.pas
+++ b/tr4w/test/unit/uTestMults.pas
@@ -1,0 +1,172 @@
+unit uTestMults;
+
+{
+  Tests for uMults multiplier add / check / count (Issue #1034,
+  pre-migration roadmap item 3).
+
+  Scope: the zone-multiplier path of MultsObject, which is fully
+  self-contained (fixed-size arrays inside the object, no cty.dat and no
+  file backing). DX mults are deliberately NOT covered here because
+  SetDXMult gates on CTY.ctyNumberCountries, i.e. it needs a loaded
+  country database -- that belongs with the uCTYDAT lookup tests (#1033).
+
+  IMPORTANT semantics (verified against uMults.pas): IsZnMult returns
+  TRUE while the zone is still a NEEDED multiplier (its per-band bit is
+  clear) and FALSE once SetZnMult has marked it worked. Bits are tracked
+  per band and per mode, so working a zone on one band/mode leaves it
+  still needed on the others.
+
+  Counting: SetZnMult calls IncrementTotals, which bumps
+  MTotals[Band,Mode,rmZone] plus the Both-mode and AllBands roll-ups.
+  Tests read MTotals directly (a public field of the object).
+
+  Conventions (docs/tr4w-migration-strategy.md): cast Word/enum to
+  Integer before CheckEquals.
+
+  Note: uMults + uSSL were decoupled from MainUnit/TF as part of this
+  issue so the multiplier logic links into the dependency-light test EXE.
+  This suite also depends on the uCTYDAT/uCallSignRoutines decouple (#1033).
+}
+
+interface
+
+uses
+   uTR4WTestFramework;
+
+type
+   TMultsTests = class(TTestCase)
+   public
+      procedure RunAllTests; override;
+
+   private
+      procedure FreshMults;   // init once + ClearAllMults for a clean slate
+
+      procedure Test_FreshZoneIsNeeded;
+      procedure Test_SetMarksZoneWorked;
+      procedure Test_WorkedZoneStillNeededOnOtherBand;
+      procedure Test_WorkedZoneStillNeededOnOtherMode;
+      procedure Test_OtherZoneStillNeeded;
+      procedure Test_OutOfRangeZone;
+      procedure Test_ZoneCount;
+   end;
+
+implementation
+
+uses
+   VC, uMults;
+
+// Module-level instance: MultsObject embeds large fixed arrays, so keep it
+// off the test stack. Its TSSL sub-lists are Init'd once; ClearAllMults gives
+// each test a clean slate (and is itself under test).
+var
+   mo: MultsObject;
+   moInited: boolean;
+
+procedure TMultsTests.FreshMults;
+begin
+   if not moInited then
+      begin
+      mo.PrfList.Init;
+      mo.DomList.Init;
+      moInited := True;
+      end;
+   mo.ClearAllMults;
+end;
+
+// ---------------------------------------------------------------------------
+// A freshly-cleared zone reads as a NEEDED multiplier (True).
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_FreshZoneIsNeeded;
+begin
+   BeginTest('Test_FreshZoneIsNeeded');
+   FreshMults;
+   CheckTrue(mo.IsZnMult(5, Band20, CW), 'zone 5 needed on 20m CW after clear');
+end;
+
+// ---------------------------------------------------------------------------
+// SetZnMult marks the zone worked on that band/mode -> IsZnMult now False.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_SetMarksZoneWorked;
+begin
+   BeginTest('Test_SetMarksZoneWorked');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckFalse(mo.IsZnMult(5, Band20, CW), 'zone 5 no longer needed on 20m CW after SetZnMult');
+end;
+
+// ---------------------------------------------------------------------------
+// Per-band tracking: working a zone on 20m leaves it needed on 40m.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_WorkedZoneStillNeededOnOtherBand;
+begin
+   BeginTest('Test_WorkedZoneStillNeededOnOtherBand');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(5, Band40, CW), 'zone 5 still needed on 40m CW');
+end;
+
+// ---------------------------------------------------------------------------
+// Per-mode tracking: working a zone on CW leaves it needed on Phone.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_WorkedZoneStillNeededOnOtherMode;
+begin
+   BeginTest('Test_WorkedZoneStillNeededOnOtherMode');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(5, Band20, Phone), 'zone 5 still needed on 20m Phone');
+end;
+
+// ---------------------------------------------------------------------------
+// A different zone is unaffected by working zone 5.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_OtherZoneStillNeeded;
+begin
+   BeginTest('Test_OtherZoneStillNeeded');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(6, Band20, CW), 'zone 6 still needed on 20m CW');
+end;
+
+// ---------------------------------------------------------------------------
+// Out-of-range zone (> ZoneMultArraySize): IsZnMult False, SetZnMult a no-op.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_OutOfRangeZone;
+begin
+   BeginTest('Test_OutOfRangeZone');
+   FreshMults;
+   CheckFalse(mo.IsZnMult(9999, Band20, CW), 'out-of-range zone is not a mult');
+   mo.SetZnMult(9999, Band20, CW);   // must not touch state / raise
+   CheckTrue(mo.IsZnMult(5, Band20, CW), 'in-range zone unaffected by out-of-range set');
+end;
+
+// ---------------------------------------------------------------------------
+// Count: three distinct zones worked on 20m CW -> MTotals reflects 3, with
+// the Both-mode and AllBands roll-ups also at 3.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_ZoneCount;
+begin
+   BeginTest('Test_ZoneCount');
+   FreshMults;
+   mo.SetZnMult(3, Band20, CW);
+   mo.SetZnMult(5, Band20, CW);
+   mo.SetZnMult(7, Band20, CW);
+   CheckEquals(3, Integer(mo.MTotals[Band20, CW, rmZone]),   '20m CW zone count');
+   CheckEquals(3, Integer(mo.MTotals[Band20, Both, rmZone]), '20m Both-mode roll-up');
+   CheckEquals(3, Integer(mo.MTotals[AllBands, CW, rmZone]), 'AllBands CW roll-up');
+end;
+
+// ---------------------------------------------------------------------------
+// Suite entry point
+// ---------------------------------------------------------------------------
+procedure TMultsTests.RunAllTests;
+begin
+   Test_FreshZoneIsNeeded;
+   Test_SetMarksZoneWorked;
+   Test_WorkedZoneStillNeededOnOtherBand;
+   Test_WorkedZoneStillNeededOnOtherMode;
+   Test_OtherZoneStillNeeded;
+   Test_OutOfRangeZone;
+   Test_ZoneCount;
+end;
+
+end.


### PR DESCRIPTION
Pre-migration prep (roadmap item 2). Breaks `uCTYDAT`'s transitive `uCTYDAT -> TF -> MainUnit -> LogStuff` coupling so the callsign -> DXCC lookup can be unit-tested without pulling the TRDOS monolith into the test EXE:

- **uCTYDAT.pas**: own Log4D logger (was MainUnit.logger); drop `uses TF`/`LogGrid`; lift `PCharToInt` + `ConvertLatLonToGrid` verbatim; `ValExt`(asm) -> RTL `Val`; `Format`(=wsprintfA) -> `StrPCopy` + a local `wsprintfA` binding
- **uCallSignRoutines.pas**: `uses TF` -> `uses uStrSearch` (needed TF only for `StrU`, relocated in TR4W/TR4W-D12#24)
- **uTestCTYDAT** (10 tests): continent, DXCC id and CQ/ITU zone for calls across all six continents, loaded from the real git-tracked cty.dat

All pass; full app build unaffected; no lookup behavior change.

Closes TR4W/TR4W#1033.