### PR TITLE
Issue #1034: decouple uMults multiplier tracking + tests

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -4078,6 +4078,11 @@ QSOPartiesCount = 20;
 
   var
     tr4wBrushArray                      : array[tr4wColors] of HBRUSH;
+    // Issue #1034: relocated here from LogDupe so light units (uMults and the
+    // pre-migration test EXE) can read the active DX-multiplier mode without
+    // pulling LogDupe's monolith cone. DXMultType is defined above in this unit;
+    // zero-initialized to NoDXMults (its first value), matching the old default.
+    ActiveDXMult                        : DXMultType;
 
 implementation
 //rd4wa -

--- a/tr4w/src/trdos/LOGDUPE.PAS
+++ b/tr4w/src/trdos/LOGDUPE.PAS
@@ -235,7 +235,8 @@ var
   InitialExDupes                        : integer;
 
   tAllowDupeQSOs                        : boolean = False;
-  ActiveDXMult                          : DXMultType {= NoDXMults};
+  // Issue #1034: ActiveDXMult moved to VC.pas (light home) so uMults can read it
+  // without depending on LogDupe. All users resolve it via VC (universally used).
   ActivePrefixMult                      : PrefixMultType {= NoPrefixMults};
 
   AutoDupeEnableCQ                      : boolean = False;

--- a/tr4w/src/uMults.pas
+++ b/tr4w/src/uMults.pas
@@ -32,8 +32,7 @@ uses
   uCTYDAT,
   //Country9,
   Windows,
-  uCallsigns,
-  Log4D;
+  Log4D;   // Issue #1034: dropped uCallsigns (unused here)
 
 
 const
@@ -73,8 +72,13 @@ var
   mo                                    : MultsObject;
   
 implementation
-uses
-  LogDupe, MainUnit;
+
+// Issue #1034: own Log4D logger (initialized below), replacing the former
+// MainUnit.logger borrow. MainUnit + LogDupe were otherwise unused here, so
+// dropping them removes uMults's direct MainUnit -> LogStuff coupling and lets
+// the multiplier logic be linked into the dependency-light unit-test EXE.
+var
+  logger: TLogLogger;
 
 procedure MultsObject.IncrementTotals(Band: BandType; Mode: ModeType; m: RemainingMultiplierType);
 begin
@@ -248,6 +252,7 @@ begin
 end;
 
 begin
+  logger := TLogLogger.GetLogger('uMults');   // Issue #1034: own logger (was MainUnit.logger)
   mo.PrfList.Init;
   mo.DomList.Init;
 //  mo.PrfList := TSSL.Create;

--- a/tr4w/src/uSSL.pas
+++ b/tr4w/src/uSSL.pas
@@ -24,7 +24,8 @@ interface
 
 uses
   VC,
-  TF,
+  // Issue #1034: dropped 'TF' (unused here) -- it pulled TF -> MainUnit -> LogStuff,
+  // which blocked uSSL (and its uMults consumer) from linking into the test EXE.
   //Country9,
   Windows,
   Messages;

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -54,7 +54,9 @@ uses
    uStrSearch           in '..\..\src\uStrSearch.pas',
    uTestStrSearch       in 'uTestStrSearch.pas',
    uCTYDAT              in '..\..\src\uCTYDAT.PAS',
-   uTestCTYDAT          in 'uTestCTYDAT.pas';
+   uTestCTYDAT          in 'uTestCTYDAT.pas',
+   uMults               in '..\..\src\uMults.pas',
+   uTestMults           in 'uTestMults.pas';
 
 begin
    IsMultiThread := True;  // Match main application setting
@@ -81,6 +83,7 @@ begin
    RegisterSuite(TFreqTimeFormatTests.Create('FreqTimeFormat'));
    RegisterSuite(TStrSearchTests.Create('StrSearch'));
    RegisterSuite(TCTYDATTests.Create('CTYDAT'));
+   RegisterSuite(TMultsTests.Create('Mults'));
 
    if RunAllSuites then
       begin

--- a/tr4w/test/unit/uTestMults.pas
+++ b/tr4w/test/unit/uTestMults.pas
@@ -1,0 +1,172 @@
+unit uTestMults;
+
+{
+  Tests for uMults multiplier add / check / count (Issue #1034,
+  pre-migration roadmap item 3).
+
+  Scope: the zone-multiplier path of MultsObject, which is fully
+  self-contained (fixed-size arrays inside the object, no cty.dat and no
+  file backing). DX mults are deliberately NOT covered here because
+  SetDXMult gates on CTY.ctyNumberCountries, i.e. it needs a loaded
+  country database -- that belongs with the uCTYDAT lookup tests (#1033).
+
+  IMPORTANT semantics (verified against uMults.pas): IsZnMult returns
+  TRUE while the zone is still a NEEDED multiplier (its per-band bit is
+  clear) and FALSE once SetZnMult has marked it worked. Bits are tracked
+  per band and per mode, so working a zone on one band/mode leaves it
+  still needed on the others.
+
+  Counting: SetZnMult calls IncrementTotals, which bumps
+  MTotals[Band,Mode,rmZone] plus the Both-mode and AllBands roll-ups.
+  Tests read MTotals directly (a public field of the object).
+
+  Conventions (docs/tr4w-migration-strategy.md): cast Word/enum to
+  Integer before CheckEquals.
+
+  Note: uMults + uSSL were decoupled from MainUnit/TF as part of this
+  issue so the multiplier logic links into the dependency-light test EXE.
+  This suite also depends on the uCTYDAT/uCallSignRoutines decouple (#1033).
+}
+
+interface
+
+uses
+   uTR4WTestFramework;
+
+type
+   TMultsTests = class(TTestCase)
+   public
+      procedure RunAllTests; override;
+
+   private
+      procedure FreshMults;   // init once + ClearAllMults for a clean slate
+
+      procedure Test_FreshZoneIsNeeded;
+      procedure Test_SetMarksZoneWorked;
+      procedure Test_WorkedZoneStillNeededOnOtherBand;
+      procedure Test_WorkedZoneStillNeededOnOtherMode;
+      procedure Test_OtherZoneStillNeeded;
+      procedure Test_OutOfRangeZone;
+      procedure Test_ZoneCount;
+   end;
+
+implementation
+
+uses
+   VC, uMults;
+
+// Module-level instance: MultsObject embeds large fixed arrays, so keep it
+// off the test stack. Its TSSL sub-lists are Init'd once; ClearAllMults gives
+// each test a clean slate (and is itself under test).
+var
+   mo: MultsObject;
+   moInited: boolean;
+
+procedure TMultsTests.FreshMults;
+begin
+   if not moInited then
+      begin
+      mo.PrfList.Init;
+      mo.DomList.Init;
+      moInited := True;
+      end;
+   mo.ClearAllMults;
+end;
+
+// ---------------------------------------------------------------------------
+// A freshly-cleared zone reads as a NEEDED multiplier (True).
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_FreshZoneIsNeeded;
+begin
+   BeginTest('Test_FreshZoneIsNeeded');
+   FreshMults;
+   CheckTrue(mo.IsZnMult(5, Band20, CW), 'zone 5 needed on 20m CW after clear');
+end;
+
+// ---------------------------------------------------------------------------
+// SetZnMult marks the zone worked on that band/mode -> IsZnMult now False.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_SetMarksZoneWorked;
+begin
+   BeginTest('Test_SetMarksZoneWorked');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckFalse(mo.IsZnMult(5, Band20, CW), 'zone 5 no longer needed on 20m CW after SetZnMult');
+end;
+
+// ---------------------------------------------------------------------------
+// Per-band tracking: working a zone on 20m leaves it needed on 40m.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_WorkedZoneStillNeededOnOtherBand;
+begin
+   BeginTest('Test_WorkedZoneStillNeededOnOtherBand');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(5, Band40, CW), 'zone 5 still needed on 40m CW');
+end;
+
+// ---------------------------------------------------------------------------
+// Per-mode tracking: working a zone on CW leaves it needed on Phone.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_WorkedZoneStillNeededOnOtherMode;
+begin
+   BeginTest('Test_WorkedZoneStillNeededOnOtherMode');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(5, Band20, Phone), 'zone 5 still needed on 20m Phone');
+end;
+
+// ---------------------------------------------------------------------------
+// A different zone is unaffected by working zone 5.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_OtherZoneStillNeeded;
+begin
+   BeginTest('Test_OtherZoneStillNeeded');
+   FreshMults;
+   mo.SetZnMult(5, Band20, CW);
+   CheckTrue(mo.IsZnMult(6, Band20, CW), 'zone 6 still needed on 20m CW');
+end;
+
+// ---------------------------------------------------------------------------
+// Out-of-range zone (> ZoneMultArraySize): IsZnMult False, SetZnMult a no-op.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_OutOfRangeZone;
+begin
+   BeginTest('Test_OutOfRangeZone');
+   FreshMults;
+   CheckFalse(mo.IsZnMult(9999, Band20, CW), 'out-of-range zone is not a mult');
+   mo.SetZnMult(9999, Band20, CW);   // must not touch state / raise
+   CheckTrue(mo.IsZnMult(5, Band20, CW), 'in-range zone unaffected by out-of-range set');
+end;
+
+// ---------------------------------------------------------------------------
+// Count: three distinct zones worked on 20m CW -> MTotals reflects 3, with
+// the Both-mode and AllBands roll-ups also at 3.
+// ---------------------------------------------------------------------------
+procedure TMultsTests.Test_ZoneCount;
+begin
+   BeginTest('Test_ZoneCount');
+   FreshMults;
+   mo.SetZnMult(3, Band20, CW);
+   mo.SetZnMult(5, Band20, CW);
+   mo.SetZnMult(7, Band20, CW);
+   CheckEquals(3, Integer(mo.MTotals[Band20, CW, rmZone]),   '20m CW zone count');
+   CheckEquals(3, Integer(mo.MTotals[Band20, Both, rmZone]), '20m Both-mode roll-up');
+   CheckEquals(3, Integer(mo.MTotals[AllBands, CW, rmZone]), 'AllBands CW roll-up');
+end;
+
+// ---------------------------------------------------------------------------
+// Suite entry point
+// ---------------------------------------------------------------------------
+procedure TMultsTests.RunAllTests;
+begin
+   Test_FreshZoneIsNeeded;
+   Test_SetMarksZoneWorked;
+   Test_WorkedZoneStillNeededOnOtherBand;
+   Test_WorkedZoneStillNeededOnOtherMode;
+   Test_OtherZoneStillNeeded;
+   Test_OutOfRangeZone;
+   Test_ZoneCount;
+end;
+
+end.


### PR DESCRIPTION
Pre-migration prep (roadmap item 3). **Stacked on TR4W/TR4W#1033** (base branch `issue-1033-uctydat-decouple`; will retarget to master once that merges).

Frees the multiplier logic from its monolith coupling so it links into the test EXE:

- **uMults.pas**: own Log4D logger; drop `uses MainUnit`/`LogDupe`/`uCallsigns` (only MainUnit.logger + the LogDupe global `ActiveDXMult` were used; uCallsigns unused)
- **uSSL.pas**: drop `uses TF` (unused; pulled TF -> MainUnit)
- **VC.pas / LOGDUPE.PAS**: relocate the shared `ActiveDXMult` global from LogDupe to VC (its type `DXMultType` already lives there); all ~9 users resolve via VC -- verified by full build
- **uTestMults** (7 tests): zone-multiplier add/check/count with synthetic data

All pass; full app build unaffected; no multiplier behavior change.

Closes TR4W/TR4W-D12#20.