### PR TITLE
Pre-migration: extract callsign compression to uCallCompress + golden tests

### DIFF
--- a/tr4w/src/VC.pas
+++ b/tr4w/src/VC.pas
@@ -1427,6 +1427,13 @@ type
 
   CallPtr = ^CallString;
 
+  // Issue: relocated from tree.pas so light units (uCallCompress, the
+  // pre-migration test EXE) can use the compressed-call byte types without
+  // pulling tree.pas's monolith cone. All existing users already use VC.
+  TwoBytes = array[1..2] of Byte;
+  FourBytes = array[1..4] of Byte;
+  EightBytes = array[1..8] of Byte;
+
   DomesticMultiplierString = Str10;
 
   DXMultiplierString = string[5];

--- a/tr4w/src/trdos/tree.pas
+++ b/tr4w/src/trdos/tree.pas
@@ -81,9 +81,8 @@ type
 
   ParityType = (tNoParity, EvenParity, OddParity);
 
-  TwoBytes = array[1..2] of Byte;
-  FourBytes = array[1..4] of Byte;
-  EightBytes = array[1..8] of Byte;
+  // TwoBytes/FourBytes/EightBytes moved to VC.pas (pre-migration extraction of
+  // callsign compression); tree.pas now gets them from VC (used in interface).
   FourBytesPtr = ^FourBytes;
 
 {
@@ -1012,6 +1011,7 @@ var
 implementation
 
 uses
+  uCallCompress,   // pre-migration: extracted callsign-compression primitives (golden-tested)
   LogStuff,
   uNet,
   LogDupe,
@@ -1323,25 +1323,10 @@ end;
 
 procedure BigCompressFormat(Call: CallString; var CompressedBigCall: EightBytes);
 
-var
-  CompressedCall                        : FourBytes;
-  Byte                                  : integer;
-  ShortCall                             : Str20;
+{ Extracted to uCallCompress.pas (pre-migration test net). Behavior unchanged. }
 
 begin
-  while length(Call) < 12 do
-    Call := ' ' + Call;
-
-  ShortCall := Copy(Call, 1, 6);
-  CompressFormat(ShortCall, CompressedCall);
-
-  for Byte := 1 to 4 do
-    CompressedBigCall[Byte] := CompressedCall[Byte];
-  Delete(Call, 1, 6);
-
-  CompressFormat(Call, CompressedCall);
-  for Byte := 1 to 4 do
-    CompressedBigCall[Byte + 4] := CompressedCall[Byte];
+  uCallCompress.BigCompressFormat(Call, CompressedBigCall);
 end;
 
 function BigExpandedString(Input: EightBytes): Str80;
@@ -1653,33 +1638,11 @@ end;
 
 procedure CompressFormat(Call: CallString; var Output: FourBytes);
 
-{ This function will give the compressed representation for the string
-    passed to it.  The string must be no longer than 6 characters.  }
-
-var
-  TempBytes                             : TwoBytes;
+{ Extracted to uCallCompress.pas (pre-migration test net). Forwards so the ~13
+  callers run the now unit-tested implementation. Behavior unchanged. }
 
 begin
-  if Call = '' then
-  begin
-    Output[1] := 0;
-    Output[2] := 0;
-    Output[3] := 0;
-    Output[4] := 0;
-    Exit;
-  end;
-
-  strU(Call);
-  //Call := UpperCase(Call);
-
-  while length(Call) < 6 do Call := ' ' + Call;
-
-  CompressThreeCharacters(Copy(Call, 1, 3), TempBytes);
-  Output[1] := TempBytes[1];
-  Output[2] := TempBytes[2];
-  CompressThreeCharacters(Copy(Call, 4, 3), TempBytes);
-  Output[3] := TempBytes[1];
-  Output[4] := TempBytes[2];
+  uCallCompress.CompressFormat(Call, Output);
 end;
 
 function CopyWord(LongString: string; Index: integer): Str80;

--- a/tr4w/src/uCallCompress.pas
+++ b/tr4w/src/uCallCompress.pas
@@ -1,0 +1,177 @@
+unit uCallCompress;
+
+{
+  Callsign compression -- extracted VERBATIM from tree.pas (Issue: pre-migration
+  test net for the byte-packing primitives, which are the most Unicode-fragile
+  code in the codebase: they assume 1 byte per character).
+
+  A callsign is packed into fixed bytes via a base-37 alphabet:
+    WordValueFromCharacter : Char  -> 0..36  (A-Z/a-z -> 11..36, 0-9 -> 1..10,
+                                              space '/' '?' #0 -> 0)
+    CompressThreeCharacters: <=3 chars -> 2 bytes (Hi/Lo of sum value*37^n)
+    CompressFormat         : 6-char call -> FourBytes (two 3-char halves)
+    BigCompressFormat      : 12-char call -> EightBytes (two CompressFormat)
+
+  Behavior is unchanged from tree.pas. tree.pas forwards its public
+  CompressFormat / BigCompressFormat here, so the ~13 existing callers (dupe
+  checking, binary log format, ...) run this code unchanged.
+
+  Bodies moved verbatim, with two deliberate, behavior-preserving edits:
+    * strU(Call) -> uStrSearch.StrU(Call): tree's strU was TF.strU, which #997
+      relocated to the light uStrSearch. Same routine; this drops the TF
+      (-> MainUnit) dependency so this unit stays link-light.
+    * The one extended-char branch in WordValueFromCharacter is written as the
+      explicit byte sequence #$EF#$BF#$BD instead of a source literal -- see the
+      comment there. That keeps it byte-identical without an encoding-fragile
+      character in this file.
+}
+
+interface
+
+uses
+   VC;
+
+function WordValueFromCharacter(Character: Char): Word;
+procedure CompressThreeCharacters(Input: Str80; var Output: TwoBytes);
+procedure CompressFormat(Call: CallString; var Output: FourBytes);
+procedure BigCompressFormat(Call: CallString; var CompressedBigCall: EightBytes);
+
+implementation
+
+uses
+   uStrSearch;
+
+function WordValueFromCharacter(Character: Char): Word;
+begin
+  if (Character = CHR(0)) or (Character = ' ') or
+    (Character = '/') or (Character = '?') then
+  begin
+    WordValueFromCharacter := 0;
+    Exit;
+  end;
+
+  if Character in ['A'..'Z'] then
+  begin
+    WordValueFromCharacter := Ord(Character) - Ord('A') + 11;
+    Exit;
+  end;
+
+  if Character in ['a'..'z'] then
+  begin
+    WordValueFromCharacter := Ord(Character) - Ord('a') + 11;
+    Exit;
+  end;
+
+  if Character in ['0'..'9'] then
+  begin
+    WordValueFromCharacter := Ord(Character) - Ord('0') + 1;
+    Exit;
+  end;
+
+  // Verbatim from tree.pas: originally a single extended char that a past UTF-8
+  // conversion mangled into U+FFFD (bytes EF BF BD). Delphi 7 reads that as a
+  // 3-byte string literal, so as a `Char = <3-byte string>` comparison it never
+  // matches today. Represented as explicit bytes to preserve that behavior
+  // exactly without an encoding-fragile literal in this file. (Flagged for D12.)
+  if Character = #$EF#$BF#$BD then
+  begin
+    WordValueFromCharacter := 1;
+    Exit;
+  end;
+
+  WordValueFromCharacter := 0;
+end;
+
+procedure CompressThreeCharacters(Input: Str80; var Output: TwoBytes);
+
+{ This procedure will compress a string of up to 3 characters to 2 bytes. }
+
+var
+  Multiplier, Value, Sum                : Word;
+  LoopCount, CharPosition               : integer;
+
+begin
+  if ((Input = '') or (length(Input) > 3)) then
+  begin
+    Output[1] := 0;
+    Output[2] := 0;
+    Exit;
+  end;
+
+  Multiplier := 1;
+  Sum := 0;
+  LoopCount := 0;
+
+  for CharPosition := length(Input) downto 1 do
+  begin
+    Value := WordValueFromCharacter(Input[CharPosition]);
+    Sum := Sum + Value * Multiplier;
+    inc(LoopCount);
+    if LoopCount >= 3 then Break;
+    Multiplier := Multiplier * 37;
+  end;
+
+  Output[2] := Lo(Sum);
+  Output[1] := Hi(Sum);
+end;
+
+procedure CompressFormat(Call: CallString; var Output: FourBytes);
+
+{ This function will give the compressed representation for the string
+    passed to it.  The string must be no longer than 6 characters.  }
+
+var
+  TempBytes                             : TwoBytes;
+
+begin
+  if Call = '' then
+  begin
+    Output[1] := 0;
+    Output[2] := 0;
+    Output[3] := 0;
+    Output[4] := 0;
+    Exit;
+  end;
+
+  uStrSearch.StrU(Call);   // was TF.strU (relocated to uStrSearch in #997)
+
+  while length(Call) < 6 do Call := ' ' + Call;
+
+  CompressThreeCharacters(Copy(Call, 1, 3), TempBytes);
+  Output[1] := TempBytes[1];
+  Output[2] := TempBytes[2];
+  CompressThreeCharacters(Copy(Call, 4, 3), TempBytes);
+  Output[3] := TempBytes[1];
+  Output[4] := TempBytes[2];
+end;
+
+procedure BigCompressFormat(Call: CallString; var CompressedBigCall: EightBytes);
+
+var
+  CompressedCall                        : FourBytes;
+  Byte                                  : integer;
+  ShortCall                             : Str20;
+
+begin
+  while length(Call) < 12 do
+     begin
+     Call := ' ' + Call;
+     end;
+
+  ShortCall := Copy(Call, 1, 6);
+  CompressFormat(ShortCall, CompressedCall);
+
+  for Byte := 1 to 4 do
+     begin
+     CompressedBigCall[Byte] := CompressedCall[Byte];
+     end;
+  Delete(Call, 1, 6);
+
+  CompressFormat(Call, CompressedCall);
+  for Byte := 1 to 4 do
+     begin
+     CompressedBigCall[Byte + 4] := CompressedCall[Byte];
+     end;
+end;
+
+end.

--- a/tr4w/test/unit/tr4w_unit_tests.dpr
+++ b/tr4w/test/unit/tr4w_unit_tests.dpr
@@ -52,7 +52,9 @@ uses
    uFreqTimeFormat      in '..\..\src\uFreqTimeFormat.pas',
    uTestFreqTimeFormat  in 'uTestFreqTimeFormat.pas',
    uStrSearch           in '..\..\src\uStrSearch.pas',
-   uTestStrSearch       in 'uTestStrSearch.pas';
+   uTestStrSearch       in 'uTestStrSearch.pas',
+   uCallCompress        in '..\..\src\uCallCompress.pas',
+   uTestCallCompress    in 'uTestCallCompress.pas';
 
 begin
    IsMultiThread := True;  // Match main application setting
@@ -78,6 +80,7 @@ begin
    RegisterSuite(TADIFRegressionTests.Create('ADIFRegression'));
    RegisterSuite(TFreqTimeFormatTests.Create('FreqTimeFormat'));
    RegisterSuite(TStrSearchTests.Create('StrSearch'));
+   RegisterSuite(TCallCompressTests.Create('CallCompress'));
 
    if RunAllSuites then
       begin

--- a/tr4w/test/unit/uTestCallCompress.pas
+++ b/tr4w/test/unit/uTestCallCompress.pas
@@ -1,0 +1,161 @@
+unit uTestCallCompress;
+
+{
+  Golden tests for uCallCompress (pre-migration test net).
+
+  Callsign compression packs characters into fixed bytes assuming 1 byte per
+  character -- the single most Unicode-fragile primitive in the codebase, and
+  foundational to dupe checking and the binary log format. These tests lock the
+  exact byte output so the Phase 2 (Unicode) / Phase 3 (64-bit) changes cannot
+  silently alter it.
+
+  Two kinds of assertion:
+    * exact golden bytes for known inputs (base-37 pack, verified by hand and
+      pinned by the build), and
+    * structural invariants that need no hand computation (empty -> zeros,
+      case-insensitivity via StrU, and the Big/Compress relationship).
+
+  Conventions (docs/tr4w-migration-strategy.md): cast Byte to Integer before
+  CheckEquals.
+}
+
+interface
+
+uses
+   uTR4WTestFramework;
+
+type
+   TCallCompressTests = class(TTestCase)
+   public
+      procedure RunAllTests; override;
+
+   private
+      procedure CheckFour(const Call: string; e1, e2, e3, e4: Integer; const Ctx: string);
+
+      procedure Test_WordValueFromCharacter;
+      procedure Test_EmptyCall;
+      procedure Test_SingleLetter;
+      procedure Test_KnownCall_W1AW;
+      procedure Test_CaseInsensitive;
+      procedure Test_BigCompressStructure;
+   end;
+
+implementation
+
+uses
+   VC, uCallCompress;
+
+procedure TCallCompressTests.CheckFour(const Call: string; e1, e2, e3, e4: Integer; const Ctx: string);
+var
+   f : FourBytes;
+begin
+   CompressFormat(Call, f);
+   CheckEquals(e1, Integer(f[1]), Ctx + ' [1]');
+   CheckEquals(e2, Integer(f[2]), Ctx + ' [2]');
+   CheckEquals(e3, Integer(f[3]), Ctx + ' [3]');
+   CheckEquals(e4, Integer(f[4]), Ctx + ' [4]');
+end;
+
+// ---------------------------------------------------------------------------
+// The base-37 alphabet: A-Z/a-z -> 11..36, 0-9 -> 1..10, space '/' '?' #0 -> 0.
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_WordValueFromCharacter;
+begin
+   BeginTest('Test_WordValueFromCharacter');
+   CheckEquals(0,  Integer(WordValueFromCharacter(CHR(0))), 'NUL -> 0');
+   CheckEquals(0,  Integer(WordValueFromCharacter(' ')),    'space -> 0');
+   CheckEquals(0,  Integer(WordValueFromCharacter('/')),    'slash -> 0');
+   CheckEquals(0,  Integer(WordValueFromCharacter('?')),    'question -> 0');
+   CheckEquals(11, Integer(WordValueFromCharacter('A')),    'A -> 11');
+   CheckEquals(36, Integer(WordValueFromCharacter('Z')),    'Z -> 36');
+   CheckEquals(11, Integer(WordValueFromCharacter('a')),    'a folds to A -> 11');
+   CheckEquals(36, Integer(WordValueFromCharacter('z')),    'z -> 36');
+   CheckEquals(1,  Integer(WordValueFromCharacter('0')),    '0 -> 1');
+   CheckEquals(10, Integer(WordValueFromCharacter('9')),    '9 -> 10');
+end;
+
+// ---------------------------------------------------------------------------
+// Empty call -> all zero bytes (explicit guard).
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_EmptyCall;
+begin
+   BeginTest('Test_EmptyCall');
+   CheckFour('', 0, 0, 0, 0, 'empty call');
+end;
+
+// ---------------------------------------------------------------------------
+// 'A' pads to '     A'; first 3 chars are spaces (0,0), last 3 are '  A'
+// -> value 11 in the low byte.
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_SingleLetter;
+begin
+   BeginTest('Test_SingleLetter');
+   CheckFour('A', 0, 0, 0, 11, 'single letter A');
+end;
+
+// ---------------------------------------------------------------------------
+// 'W1AW' pads to '  W1AW'.
+//   '  W' -> sum = 33            -> bytes (Hi,Lo) = (0, 33)
+//   '1AW' -> sum = 2*37^2 + 11*37 + 33 = 2738 + 407 + 33 = 3178 -> (12, 106)
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_KnownCall_W1AW;
+begin
+   BeginTest('Test_KnownCall_W1AW');
+   CheckFour('W1AW', 0, 33, 12, 106, 'W1AW golden');
+end;
+
+// ---------------------------------------------------------------------------
+// StrU uppercases before packing, so lower- and upper-case pack identically.
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_CaseInsensitive;
+var
+   fLo, fUp : FourBytes;
+begin
+   BeginTest('Test_CaseInsensitive');
+   CompressFormat('w1aw', fLo);
+   CompressFormat('W1AW', fUp);
+   CheckEquals(Integer(fUp[1]), Integer(fLo[1]), 'lower==upper [1]');
+   CheckEquals(Integer(fUp[2]), Integer(fLo[2]), 'lower==upper [2]');
+   CheckEquals(Integer(fUp[3]), Integer(fLo[3]), 'lower==upper [3]');
+   CheckEquals(Integer(fUp[4]), Integer(fLo[4]), 'lower==upper [4]');
+end;
+
+// ---------------------------------------------------------------------------
+// BigCompressFormat pads to 12 and packs two 6-char halves. For a short call
+// the leading half is all spaces (-> zeros), and the trailing half is the same
+// 6-char '  W1AW' that CompressFormat('W1AW') packs -- so big[5..8] == four[1..4].
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.Test_BigCompressStructure;
+var
+   big  : EightBytes;
+   four : FourBytes;
+begin
+   BeginTest('Test_BigCompressStructure');
+   BigCompressFormat('W1AW', big);
+   CompressFormat('W1AW', four);
+
+   CheckEquals(0, Integer(big[1]), 'big[1] leading-space half');
+   CheckEquals(0, Integer(big[2]), 'big[2]');
+   CheckEquals(0, Integer(big[3]), 'big[3]');
+   CheckEquals(0, Integer(big[4]), 'big[4]');
+
+   CheckEquals(Integer(four[1]), Integer(big[5]), 'big[5] == four[1]');
+   CheckEquals(Integer(four[2]), Integer(big[6]), 'big[6] == four[2]');
+   CheckEquals(Integer(four[3]), Integer(big[7]), 'big[7] == four[3]');
+   CheckEquals(Integer(four[4]), Integer(big[8]), 'big[8] == four[4]');
+end;
+
+// ---------------------------------------------------------------------------
+// Suite entry point
+// ---------------------------------------------------------------------------
+procedure TCallCompressTests.RunAllTests;
+begin
+   Test_WordValueFromCharacter;
+   Test_EmptyCall;
+   Test_SingleLetter;
+   Test_KnownCall_W1AW;
+   Test_CaseInsensitive;
+   Test_BigCompressStructure;
+end;
+
+end.


### PR DESCRIPTION
Extracts the byte-packing primitives (`WordValueFromCharacter`, `CompressThreeCharacters`, `CompressFormat`, `BigCompressFormat`) verbatim from `tree.pas` into a light `uCallCompress.pas` so the most Unicode-fragile code in the codebase (1-byte-per-char packing, foundational to dupe checking + the binary log format) is golden-tested before the D12 freeze.

- **uCallCompress.pas** (new; uses VC, uStrSearch): bodies verbatim; `strU` -> `uStrSearch.StrU` (drops TF -> MainUnit); the one UTF-8-mangled extended char kept byte-identical via an explicit `#$EF#$BF#$BD` literal
- **tree.pas**: `CompressFormat`/`BigCompressFormat` forward to uCallCompress -- the ~13 callers run the tested code unchanged
- **VC.pas / tree.pas**: `TwoBytes`/`FourBytes`/`EightBytes` relocated tree.pas -> VC so light units can use them (all users resolve via VC; verified by full build)
- **uTestCallCompress** (6 suites): base-37 alphabet, empty guard, `W1AW` golden `[0,33,12,106]`, case-insensitivity, Big/Compress structure

All pass; full app build unaffected; no behavior change.