### PR TITLE
IARU: set RxData.Zone from callsign when society exchange lacks a zone

### DIFF
--- a/tr4w/src/trdos/LOGDUPE.PAS
+++ b/tr4w/src/trdos/LOGDUPE.PAS
@@ -1410,16 +1410,21 @@ begin
 end;
 
 procedure LoadInitialExchangeFile;
-var
-  TempInteger                           : integer;
 begin
 
-  if not EnumerateLinesInFile(TR4W_INITIALEX_FILENAME, EnumInitialEx, True) then Exit;
-  TempInteger := Format(wsprintfBuffer, '%s:'#13#10 + TC_THEREWERECALLS, TR4W_INITIALEX_FILENAME, InitialExCallsigns, InitialExDupes);
-{$IF LANG = 'ENG'}
-  if InitialExDupes = 0 then wsprintfBuffer[TempInteger - 11] := #0;
-{$IFEND}
-  ShowMessage(wsprintfBuffer);
+  if not EnumerateLinesInFile(TR4W_INITIALEX_FILENAME, EnumInitialEx, True) then
+     begin
+     Exit;
+     end;
+
+     { Changed this from the MessageBox to a QuickDisplay - Much less intrusive - NY4I 2026JUL07 }
+  //TempInteger := Format(wsprintfBuffer, '%s:'#13#10 + TC_THEREWERECALLS, TR4W_INITIALEX_FILENAME, InitialExCallsigns, InitialExDupes);
+  if InitialExCallsigns > 0 then
+     begin
+     Format(wsprintfBuffer, '%s:' + TC_THEREWERECALLS, TR4W_INITIALEX_FILENAME, InitialExCallsigns, InitialExDupes);
+     QuickDisplay(wsprintfBuffer);
+     end;
+ // ShowMessage(wsprintfBuffer);
 end;
 
 procedure DupeAndMultSheet.MakePossibleCallList(Call: CallString; var PossCallList: PossibleCallRecord);

--- a/tr4w/src/trdos/LOGSTUFF.PAS
+++ b/tr4w/src/trdos/LOGSTUFF.PAS
@@ -3476,6 +3476,22 @@ begin
       logger.Error('[ProcessRSTAndDomesticQTHExchange] Improper DOmestic QTH');
       ExchangeErrorMessage := TC_IMPROPERDOMESITCQTH;
     end;
+    { The code below to handle IARU-HF was commented out but it is not quite right anyway.
+      The issue is that when the exchange is a member society like IARU, the RXData.Zone is
+      not being set from the callsign. This is only a factor for external processors like
+      UDP as the Society, not the zone goes in the exchange in Cabrillo for example.
+      So I am adding the following code to check if we the ActiveExchange is
+      RSTZoneOrSocietyExchange and RXData.Zone is 255 (initialized value apparently),
+      then I lookup the zone from the call and set that. - NY4I 2026JUL07
+     }
+     if ActiveExchange = RSTZoneOrSocietyExchange then
+        begin
+        if (CONTEST = IARU)     and
+            (RXData.Zone = 255) then
+            begin
+            RXData.Zone := ctyGetZone(RXData.Callsign);
+            end;
+        end;
     {WLI}
 //    if ActiveExchange = RSTZoneOrSocietyExchange then
 //      if CONTEST <> IARU then RXData.Zone := CountryTable.GetITUZone(RXData.Callsign);


### PR DESCRIPTION
## Summary

In an IARU HF contest the received exchange is frequently a member-society abbreviation rather than an ITU zone. In that case `RXData.Zone` was left at its initialized value (255), so external consumers that read the zone (e.g. the UDP feed) got a meaningless value — even though Cabrillo output carries the society text in the exchange field and is unaffected.

## Changes

**LOGSTUFF.PAS** — In `ProcessRSTAndDomesticQTHExchange`, when `ActiveExchange = RSTZoneOrSocietyExchange`, `CONTEST = IARU`, and `RXData.Zone` is still 255, look the zone up from the callsign via `ctyGetZone`. Replaces the old commented-out `CountryTable.GetITUZone` path.

**LOGDUPE.PAS** — Make `LoadInitialExchangeFile` less intrusive:
- Replace the `ShowMessage` MessageBox with a `QuickDisplay` status line.
- Show it only when at least one call was loaded (`InitialExCallsigns > 0`).
- Remove the now-dead `TempInteger` and the `LANG='ENG'` null-truncation trick.

## Testing

Manually tested by the author (NY4I).