### PR TITLE
Kenwood: fix RIT offset parse and per-VFO mode/frequency display

### DIFF
--- a/tr4w/src/TF.pas
+++ b/tr4w/src/TF.pas
@@ -297,11 +297,11 @@ begin  // This does not handle negative numbers very well.
    if i < 0 then
       begin
       absI := i * -1;
-      Format(FreqToPCharBuffer, '-%u.%2u', absI div 1000, (absI mod 1000) div 10); // Make 190 appear as 0.19
+      Format(FreqToPCharBuffer, '-%u.%02u', absI div 1000, (absI mod 1000) div 10); // %02u zero-pads hundredths: -1080 -> "-1.08", not "-1. 8"
       end
    else
       begin
-      Format(FreqToPCharBuffer, '%d.%2u', i div 1000, (abs(i) mod 1000) div 10); // Make 190 appear as 0.19
+      Format(FreqToPCharBuffer, '%d.%02u', i div 1000, (abs(i) mod 1000) div 10); // %02u zero-pads hundredths: 2060 -> "2.06", not "2. 6"
       end;
    Result := FreqToPCharBuffer;
 end;

--- a/tr4w/src/uRadioPolling.pas
+++ b/tr4w/src/uRadioPolling.pas
@@ -395,20 +395,39 @@ begin
                                                    begin
                                                       //            debugmsg('polling IF ' + inttostr(rig^.CurrentStatus.Freq));
                                                       rig^.CurrentStatus.VFO[VFOA].Frequency := rig^.CurrentStatus.Freq;
+                                                      // Mirror the mode into the active VFO so the per-VFO mode
+                                                      // label next to the frequency (Issue #566) updates -- the
+                                                      // IF parse above sets only the top-level Mode/ExtendedMode.
+                                                      rig^.CurrentStatus.VFO[VFOA].Mode := rig^.CurrentStatus.Mode;
+                                                      rig^.CurrentStatus.VFO[VFOA].ExtendedMode := rig^.CurrentStatus.ExtendedMode;
                                                       //        ActiveVFO_is_A := True;
                                                       rig^.CurrentStatus.VFOStatus := VFOA;
                                                    end
                                                 else
                                                    begin
                                                       rig^.CurrentStatus.VFO[VFOB].Frequency := rig^.CurrentStatus.Freq;
+                                                      rig^.CurrentStatus.VFO[VFOB].Mode := rig^.CurrentStatus.Mode;
+                                                      rig^.CurrentStatus.VFO[VFOB].ExtendedMode := rig^.CurrentStatus.ExtendedMode;
                                                       //        ActiveVFO_is_A := False;
                                                       rig^.CurrentStatus.VFOStatus := VFOB;
                                                    end;
 
                                                 //      rig^.CurrentStatus.Freq := rig^.CurrentStatus.Freq + rig^.FrequencyAdder;
+                                                // RIT/XIT offset: sign at position 19 (a SPACE for '+',
+                                                // '-' for negative), 4-digit magnitude at 20-23. BufferToInt
+                                                // returns 0 the moment it hits a non-digit, so reading the
+                                                // 5-char window from the sign position zeroed every POSITIVE
+                                                // offset (the space); negatives worked only because '-' is a
+                                                // valid leading char. Read the magnitude from 20 and apply
+                                                // the sign from 19 explicitly.
                                                 rig^.CurrentStatus.RITFreq :=
                                                    BufferToInt(@rig^.tBuf[i - 37],
-                                                   19, 5);
+                                                   20, 4);
+                                                if rig^.tBuf[i - 19] = '-' then
+                                                   begin
+                                                   rig^.CurrentStatus.RITFreq :=
+                                                      -rig^.CurrentStatus.RITFreq;
+                                                   end;
                                                 rig^.CurrentStatus.Split :=
                                                    rig^.tBuf[i - 5] <> '0';
                                                 rig^.CurrentStatus.RIT :=


### PR DESCRIPTION
Three display defects on the Kenwood polling path, all reproduced and verified on a TS-570.

### 1. RIT/XIT offset always read zero when positive

The Kenwood `IF` response carries the offset in P3 at positions 19–23: a sign character followed by four digits, where **the sign is a SPACE when the offset is positive**.

The parse asked `BufferToInt` for a 5-character window starting at the sign position:

```pascal
rig^.CurrentStatus.RITFreq := BufferToInt(@rig^.tBuf[i - 37], 19, 5);
```

`BufferToInt` (`uRadioPolling.pas:3739`) bails out with `Result := 0` on the first character that is not a digit, `'+'` or `'-'`. A positive offset therefore hit the space and returned `0` every time. Negative offsets happened to work only because `'-'` is in the accepted set.

Fixed by reading the 4-digit magnitude from position 20 and applying the sign from position 19 explicitly.

### 2. Per-VFO mode label never updated (Issue #566)

The `IF` parse set only the top-level `CurrentStatus.Mode` / `ExtendedMode`, but the label drawn next to each VFO frequency reads `CurrentStatus.VFO[n].Mode`. The mode is now mirrored into the VFO record at the same point the frequency is assigned, for both VFO A and VFO B.

### 3. Frequency offsets lost their leading zero

`FreqToPChar` formatted the hundredths with `'%2u'`, which space-pads rather than zero-pads, so `-1.08` rendered as `-1. 8` and `2.06` as `2. 6`. Both branches now use `'%02u'`.

### Verification

Field offsets were checked against the 38-character Kenwood `IF` response and are consistent with the surrounding reads already in the code (`i-7` VFO, `i-5` split, `i-14` RIT, `i-13` XIT, `i-9` TX). Tested on real TS-570 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)